### PR TITLE
feat: Add undo button in simulator page #9

### DIFF
--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -240,6 +240,11 @@
             <span class="glyphicon glyphicon-zoom-out" aria-hidden="true"></span>
           </button>
         </div>
+        <div style="position:absolute; right:30px; top:120px; z-index:100">
+          <button type="button" class="btn zoomButton btn-lg" onclick="undo()">
+            <span class="glyphicon glyphicon-repeat" aria-hidden="true"></span>
+          </button>
+        </div>
 
 		<div id="layoutDialog" style="display:none" class="" title="Layout Options">
 


### PR DESCRIPTION
I have added a new button below the right panel buttons (zoom in, center, zoom out) and used the same listener method 'undo' that's used inside the project when the user presses the key with code 122. Kindly inform me if you need anything to be improved/updated.