### PR TITLE
Fix zooming in/out in firefox. Fix Ctrl+T shortcut

### DIFF
--- a/public/js/embedListeners.js
+++ b/public/js/embedListeners.js
@@ -68,14 +68,14 @@ function startListeners() {
             simulationArea.controlDown = true;
         }
 
-        if (simulationArea.controlDown && e.keyCode == 187) {
+        if (simulationArea.controlDown && (e.keyCode == 187 || e.KeyCode == 171)) {
             e.preventDefault();
             if (globalScope.scale < 4 * DPR)
                 changeScale(.1 * DPR);
         }
 
         // zoom out (-)
-        if (simulationArea.controlDown && e.keyCode == 189) {
+        if (simulationArea.controlDown && (e.keyCode == 189 || e.Keycode == 173)) {
             e.preventDefault();
             if (globalScope.scale > 0.5 * DPR)
                 changeScale(-.1 * DPR);

--- a/public/js/listeners.js
+++ b/public/js/listeners.js
@@ -65,7 +65,7 @@ function startListeners() {
             simulationArea.controlDown = true;
         }
 
-        if (simulationArea.controlDown && (e.keyCode == 187 || e.keyCode == 61)) {
+        if (simulationArea.controlDown && (e.keyCode == 187 || e.keyCode == 171)) {
             e.preventDefault();
             if (globalScope.scale < 4 * DPR) {
                 changeScale(.1 * DPR);
@@ -170,6 +170,7 @@ function startListeners() {
                 simulationArea.lastSelected.newBitWidth(parseInt(prompt("Enter new bitWidth"), 10));
         }
         if (simulationArea.controlDown && (e.key == "T" || e.key == "t")) {
+            e.preventDefault(); //browsers normally open a new tab
             simulationArea.changeClockTime(prompt("Enter Time:"));
         }
         if ((e.keyCode == 108 || e.keyCode == 76) && simulationArea.lastSelected != undefined) {

--- a/public/js/listeners.js
+++ b/public/js/listeners.js
@@ -170,7 +170,7 @@ function startListeners() {
                 simulationArea.lastSelected.newBitWidth(parseInt(prompt("Enter new bitWidth"), 10));
         }
         if (simulationArea.controlDown && (e.key == "T" || e.key == "t")) {
-            e.preventDefault(); //browsers normally open a new tab
+            // e.preventDefault(); //browsers normally open a new tab
             simulationArea.changeClockTime(prompt("Enter Time:"));
         }
         if ((e.keyCode == 108 || e.keyCode == 76) && simulationArea.lastSelected != undefined) {


### PR DESCRIPTION
The correct keycode for + was 171 in firefox, not 61. (Sorry about that)

In addition, CTRL+T is used to open a new tab. I proposed preventing the default action, but another alternative is to change the shortcut to some other key combination that does not interfere with normal browser behavior.