### PR TITLE
Add SquareRGBLed component

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.formatOnSave": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "editor.formatOnSave": true
-}

--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -126,6 +126,7 @@
           <div class="icon logixModules" id="VariableLed" ></div>
           <div class="icon logixModules" id="HexDisplay" ></div>
           <div class="icon logixModules" id="SevenSegDisplay" ></div>
+          <div class="icon logixModules" id="SquareRGBLed" ></div>
         </div>
 
         <div class="panelHeader">Gates</div>

--- a/public/img/SquareRGBLed.svg
+++ b/public/img/SquareRGBLed.svg
@@ -1,0 +1,14 @@
+<svg version="1.1" 
+    xmlns="http://www.w3.org/2000/svg" 
+    xmlns:xlink="http://www.w3.org/1999/xlink" width="70" height="70">
+    <defs/>
+    <g>
+        <path stroke="green" d="M 35.2 40 L 35.2 50" stroke-width="2" />
+        <path stroke="red" d="M 25.2 40 L 25.2 50" stroke-width="2" />
+        <path stroke="blue" d="M 45.2 40 L 45.2 50" stroke-width="2" />
+        <rect fill="rgb(227, 228, 229)" stroke="#d3d4d5" height="30" width="30" x="20.5" y="12.5"/>
+        <ellipse fill="green" cx="25.2" cy="50" rx="3" ry="3"/>
+        <ellipse fill="green" cx="35.2" cy="50" rx="3" ry="3"/>
+        <ellipse fill="green" cx="45.2" cy="50" rx="3" ry="3"/>
+    </g>
+</svg>

--- a/public/js/UX.js
+++ b/public/js/UX.js
@@ -79,6 +79,7 @@ var help = {
     "Stepper": "Stepper ToolTip: Increase/Decrease value by selecting the stepper and using +/- keys.",
     "Output": "Output ToolTip: Simple output element showing output in binary.",
     "RGBLed": "RGB Led ToolTip: RGB Led inputs 8 bit values for the colors RED, GREEN and BLUE.",
+    "SquareRGBLed": "Square RGB Led ToolTip: RGB Led inputs 8 bit values for the colors RED, GREEN and BLUE.",
     "DigitalLed": "Digital Led ToolTip: Digital LED glows high when input is High(1).",
     "VariableLed": "Variable Led ToolTip: Variable LED inputs an 8 bit value and glows with a proportional intensity.",
     "HexDisplay": "Hex Display ToolTip: Inputs a 4 Bit Hex number and displays it.",

--- a/public/js/logix.js
+++ b/public/js/logix.js
@@ -39,7 +39,7 @@ forceResetNodes = true; // FLag to reset all Nodes
 circuitElementList = [
     "Input", "Output", "NotGate", "OrGate", "AndGate", "NorGate", "NandGate", "XorGate", "XnorGate", "SevenSegDisplay", "HexDisplay",
     "Multiplexer", "BitSelector", "Splitter", "Power", "Ground", "ConstantVal", "ControlledInverter", "TriState", "Adder", "Rom", "TflipFlop",
-    "JKflipFlop", "SRflipFlop", "DflipFlop", "TTY", "Keyboard", "Clock", "DigitalLed", "Stepper", "VariableLed", "RGBLed", "Button", "Demultiplexer",
+    "JKflipFlop", "SRflipFlop", "DflipFlop", "TTY", "Keyboard", "Clock", "DigitalLed", "Stepper", "VariableLed", "RGBLed", "SquareRGBLed", "Button", "Demultiplexer",
     "Buffer", "SubCircuit", "Flag", "MSB", "LSB", "PriorityEncoder", "Tunnel", "ALU", "Decoder", "Random", "Dlatch", "TB_Input", "TB_Output", "ForceGate"
 ];
 

--- a/public/js/miniMap.js
+++ b/public/js/miniMap.js
@@ -79,9 +79,11 @@ var miniMapArea = {
                 }
             } else if (lst[i] != 'nodes') {
 
+                // Don't include SquareRGBLed here; it has correct size.
                 var ledY = 0;
                 if (lst[i] == "DigitalLed" || lst[i] == "VariableLed" || lst[i] == "RGBLed")
                     ledY = 20;
+
                 for (var j = 0; j < globalScope[lst[i]].length; j++) {
                     var xx = (globalScope[lst[i]][j].x - simulationArea.minWidth);
                     var yy = (globalScope[lst[i]][j].y - simulationArea.minHeight);

--- a/public/js/modules.js
+++ b/public/js/modules.js
@@ -2543,7 +2543,7 @@ SquareRGBLed.prototype.customDraw = function () {
     var b = this.inp2.value;
     var c = this.inp3.value;
     ctx.strokeStyle = "#d3d4d5";
-    ctx.fillStyle = ["rgba(" + a + ", " + b + ", " + c + ", 0.8)", "rgba(227, 228, 229, 0.8)"][((a === undefined || b === undefined || c === undefined)) + 0]
+    ctx.fillStyle = ["rgb(" + a + ", " + b + ", " + c + ")", "rgba(227, 228, 229)"][((a === undefined || b === undefined || c === undefined)) + 0]
     ctx.lineWidth = correctWidth(1);
     ctx.beginPath();
     rect2(ctx, -15, -15, 30, 30, xx, yy, this.direction);
@@ -2552,7 +2552,7 @@ SquareRGBLed.prototype.customDraw = function () {
     if ((this.hover && !simulationArea.shiftDown) ||
         simulationArea.lastSelected == this ||
         simulationArea.multipleObjectSelections.contains(this)) {
-            ctx.fillStyle = "rgba(255, 255, 32,0.8)";
+            ctx.fillStyle = "rgba(255, 255, 32)";
     }
 
     ctx.fill();

--- a/public/js/modules.js
+++ b/public/js/modules.js
@@ -2468,14 +2468,15 @@ RGBLed.prototype.customDraw = function() {
     ctx.fill();
 }
 
-function SquareRGBLed(x, y, scope = globalScope, dir = "UP", pinLength = 5) {
+function SquareRGBLed(x, y, scope = globalScope, dir = "UP", pinLength = 1) {
     CircuitElement.call(this, x, y, scope, dir, 8);
     this.rectangleObject = false;
     this.setDimensions(15, 15);
-    this.pinLength = pinLength === undefined ? 5 : pinLength;
-    this.inp1 = new Node(-15 - this.pinLength, -10, 0, this, 8);
-    this.inp2 = new Node(-15 - this.pinLength, 0, 0, this, 8);
-    this.inp3 = new Node(-15 - this.pinLength, 10, 0, this, 8);
+    this.pinLength = pinLength === undefined ? 1 : pinLength;
+    var nodeX = -10 - 10 * pinLength;
+    this.inp1 = new Node(nodeX, -10, 0, this, 8, "R");
+    this.inp2 = new Node(nodeX, 0, 0, this, 8, "G");
+    this.inp3 = new Node(nodeX, 10, 0, this, 8, "B");
     this.inp = [this.inp1, this.inp2, this.inp3];
     this.labelDirection = "UP";
     this.fixedBitWidth = true;
@@ -2486,7 +2487,7 @@ function SquareRGBLed(x, y, scope = globalScope, dir = "UP", pinLength = 5) {
         if (pinLength < 0 || pinLength > 1000) return;
 
         // Calculate the new position of the LED, so the nodes will stay in the same place.
-        var diff = pinLength - this.pinLength;
+        var diff = 10 * (pinLength - this.pinLength);
         var diffX = this.direction == "LEFT" ? -diff : this.direction == "RIGHT" ? diff : 0;
         var diffY = this.direction == "UP" ? -diff : this.direction == "DOWN" ? diff : 0;
 
@@ -2527,23 +2528,35 @@ SquareRGBLed.prototype.customDraw = function () {
     var ctx = simulationArea.context;
     var xx = this.x;
     var yy = this.y;
+    var r = this.inp1.value;
+    var g = this.inp2.value;
+    var b = this.inp3.value;
 
-    var colors = ["red", "green", "blue"];
+    var colors = ["rgb(174,20,20)","rgb(40,174,40)","rgb(0,100,255)"];
     for (var i = 0; i < 3; i++) {
-        ctx.strokeStyle = colors[i];
+        var x = -10 - 10 * this.pinLength;
+        var y = i * 10 - 10;
         ctx.lineWidth = correctWidth(3);
+
+        // A gray line, which makes it easy on the eyes when the pin length is large
         ctx.beginPath();
         ctx.lineCap = "butt";
-        moveTo(ctx, -15, i * 10 - 10, xx, yy, this.direction);
-        lineTo(ctx, -15 - this.pinLength, i * 10 - 10, xx, yy, this.direction);
+        ctx.strokeStyle = "rgb(227, 228, 229)";
+        moveTo(ctx, -15, y, xx, yy, this.direction);
+        lineTo(ctx, x + 10, y, xx, yy, this.direction);
+        ctx.stroke();
+
+        // A colored line, so people know which pin does what.
+        ctx.lineCap = "round";
+        ctx.beginPath();
+        ctx.strokeStyle = colors[i];
+        moveTo(ctx, x + 10, y, xx, yy, this.direction);
+        lineTo(ctx, x, y, xx, yy, this.direction);
         ctx.stroke();
     }
 
-    var a = this.inp1.value;
-    var b = this.inp2.value;
-    var c = this.inp3.value;
     ctx.strokeStyle = "#d3d4d5";
-    ctx.fillStyle = ["rgb(" + a + ", " + b + ", " + c + ")", "rgba(227, 228, 229)"][((a === undefined || b === undefined || c === undefined)) + 0]
+    ctx.fillStyle = (r === undefined && g === undefined && b === undefined) ? "rgb(227, 228, 229)": "rgb(" + (r||0) + ", " + (g||0) + ", " + (b||0) + ")";
     ctx.lineWidth = correctWidth(1);
     ctx.beginPath();
     rect2(ctx, -15, -15, 30, 30, xx, yy, this.direction);

--- a/public/js/modules.js
+++ b/public/js/modules.js
@@ -2468,6 +2468,66 @@ RGBLed.prototype.customDraw = function() {
     ctx.fill();
 }
 
+function SquareRGBLed(x, y, scope = globalScope, dir = "UP") {
+    CircuitElement.call(this, x, y, scope, dir, 8);
+    this.rectangleObject = false;
+    this.setDimensions(15, 15);
+    this.inp1 = new Node(-20, -10, 0, this, 8);
+    this.inp2 = new Node(-20, 0, 0, this, 8);
+    this.inp3 = new Node(-20, 10, 0, this, 8);
+    this.inp = [this.inp1, this.inp2, this.inp3];
+    this.labelDirection = "UP";
+    this.fixedBitWidth = true;
+}
+SquareRGBLed.prototype = Object.create(CircuitElement.prototype);
+SquareRGBLed.prototype.constructor = SquareRGBLed;
+SquareRGBLed.prototype.customSave = function() {
+    var data = {
+        constructorParamaters: [this.direction],
+        nodes: {
+            inp1: findNode(this.inp1),
+            inp2: findNode(this.inp2),
+            inp3: findNode(this.inp3),
+        },
+    }
+    return data;
+}
+SquareRGBLed.prototype.customDraw = function() {
+    var ctx = simulationArea.context;
+    var xx = this.x;
+    var yy = this.y;
+
+    var colors = ["red", "green", "blue"];
+    for(var i=0; i<3; i++)
+    {
+        ctx.strokeStyle = colors[i];
+        ctx.lineWidth = correctWidth(3);
+        ctx.beginPath();
+        ctx.lineCap = "butt";
+        moveTo(ctx, -15, i*10-10, xx, yy, this.direction);
+        lineTo(ctx, -20, i*10-10, xx, yy, this.direction);
+        ctx.stroke();
+    }
+
+    var a = this.inp1.value;
+    var b = this.inp2.value;
+    var c = this.inp3.value;
+    ctx.strokeStyle = "#d3d4d5";
+    ctx.fillStyle = ["rgba(" + a + ", " + b + ", " + c + ", 0.8)", "rgba(227, 228, 229, 0.8)"][((a === undefined || b === undefined || c === undefined)) + 0]
+    ctx.lineWidth = correctWidth(1);
+    ctx.beginPath();
+    rect2(ctx, -15, -15, 30, 30, xx, yy, this.direction);
+    ctx.stroke();
+
+    if ((this.hover && !simulationArea.shiftDown) || 
+        simulationArea.lastSelected == this || 
+        simulationArea.multipleObjectSelections.contains(this)) {
+            ctx.fillStyle = "rgba(255, 255, 32,0.8)";
+    }
+
+    ctx.fill();
+}
+
 function Demultiplexer(x, y, scope = globalScope, dir = "LEFT", bitWidth = 1, controlSignalSize = 1) {
 
     CircuitElement.call(this, x, y, scope, dir, bitWidth);


### PR DESCRIPTION
This change adds a new SquareRGBLed component with the following features:

- The visual of the LED is square, which makes it possible to build a LED matrix with less visual interference.
- The square LED has the same inputs as the existing RGBLed.
- The square LED can be turned, allowing the inputs to be on any side.
- The LED is 3x3 in size, centered on a 4x4 grid:
![image](https://user-images.githubusercontent.com/4239171/52559937-ad337900-2dab-11e9-8b2e-3181a3d187b7.png)
- This design allows the following constructions:
  - LEDs can be stacked without gap in a 2xN matrix and the circuitry will be outside the matrix:
![image](https://user-images.githubusercontent.com/4239171/52560093-10bda680-2dac-11e9-93b1-38a1b6ef6d12.png)
  - A single LED can be placed on top of a 4x4 sub-circuit, which outputs the RGB values on the bottom of its layout:
![image](https://user-images.githubusercontent.com/4239171/52560183-5d08e680-2dac-11e9-86e3-459a25df870b.png)
  - A larger matrix can be created by stacking longer sub-circuits of size 4x(4*N). For example, three 4x12 drivers stacked create a uniform 3x3 LED matrix, where the pixels are spaced by one unit, both horizontally and vertically:
![image](https://user-images.githubusercontent.com/4239171/52560340-eae4d180-2dac-11e9-8e03-1f1edd7b5d5d.png)
  *That being said, the thick line of the sub-circuit ends up creating an illusion that the vertical space is larger than the horizontal space; I suppose we'll live with that for now and solve it with a full LED matrix component.*

NOTE: this is related to #47, but not the full solution.

As another example, one *could* create a multiplexing display matrix by stacking a bunch of drivers; each driver takes the horizontal enable input on the size and a combined RGB input for each pixel on top; it then output the combined RGB on the bottom, next to the individual RBG inputs for the LED; the pins should be placed so the combined input and output are vertically aligned. One can make an arbitrary long row like this, effectively using 4 units of space for each LED. Then it is simply a matter of stacking several rows, multiplexing them, like a real LED matrix.
Ex:
![image](https://user-images.githubusercontent.com/4239171/52563097-4c10a300-2db5-11e9-8f0c-ff18eb50f47b.png)




Attached is a file that exercises the new component.
[SquareRGBLedTest.txt](https://github.com/CircuitVerse/CircuitVerse/files/2851006/SquareRGBLedTest.txt)

