### PR TITLE
RAM component

### DIFF
--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -161,6 +161,7 @@
           <div class="icon logixModules" id="Keyboard" ></div>
           <div class="icon logixModules" id="Clock" ></div>
           <div class="icon logixModules" id="Rom" ></div>
+          <div class="icon logixModules" id="RAM" ></div>
         </div>
 
         <div class="panelHeader">Test Bench</div>
@@ -386,6 +387,7 @@
   <script src="/js/subcircuit.js"></script>
   <script src="/js/modules.js"></script>
   <script src="/js/sequential.js"></script>
+  <script src="/js/ram.js"></script>
   <script src="/js/canvasApi.js"></script>
   <script src="/js/data.js"></script>
   <script src="/js/listeners.js"></script>

--- a/app/views/simulator/embed.html.erb
+++ b/app/views/simulator/embed.html.erb
@@ -72,6 +72,7 @@
  <script src="/js/subcircuit.js"></script>
  <script src="/js/modules.js"></script>
  <script src="/js/sequential.js"></script>
+ <script src="/js/ram.js"></script>
  <script src="/js/canvasApi.js"></script>
  <script src="/js/data.js"></script>
  <script src="/js/embedListeners.js"></script>

--- a/public/img/RAM.svg
+++ b/public/img/RAM.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="70" height="70" version="1.1">
+    <defs/>
+    <rect width="60" height="40" x="5" y="15" fill="white" stroke="black"/>
+    <g fill="black" font-family="Georgia" font-size="6px" text-anchor="middle">
+        <text x="35" y="37">
+            RAM
+        </text>
+        <text x="11" y="27">
+            A
+        </text>
+        <text x="11" y="37">
+            DI
+        </text>
+        <text x="11" y="47">
+            W
+        </text>
+        <text x="58" y="37">
+            DO
+        </text>
+    </g>
+    <g fill="green">
+        <circle cx="5" cy="25" r="2"/>
+        <circle cx="5" cy="35" r="2"/>
+        <circle cx="5" cy="45" r="2"/>
+        <circle cx="65" cy="35" r="2"/>
+    </g>
+</svg>

--- a/public/js/UX.js
+++ b/public/js/UX.js
@@ -48,11 +48,13 @@ $(document).ready(function() {
 
     }
     $('.logixModules').hover(function() {
-        if (!help[this.id]) return;
+        // Tooltip can be statically defined in the prototype.
+        var tooltipText = window[this.id].prototype.tooltipText || help[this.id];
+        if (!tooltipText) return;
         $("#Help").addClass("show");
         $("#Help").empty();
         ////console.log("SHOWING")
-        $("#Help").append(help[this.id]);
+        $("#Help").append(tooltipText);
     }); // code goes in document ready fn only
     $('.logixModules').mouseleave(function() {
         $("#Help").removeClass("show");
@@ -89,7 +91,6 @@ var help = {
     "Flag": "FLag ToolTip: Use this for debugging and plotting.",
     "Splitter": "Splitter ToolTip: Split multiBit Input into smaller bitwidths or vice versa.",
     "ALU": "ALU ToolTip: 0: A&B, 1:A|B, 2:A+B, 4:A&~B, 5:A|~B, 6:A-B, 7:SLT ",
-
 }
 
 
@@ -164,22 +165,19 @@ function showProperties(obj) {
             }
         }
     }
-    // $('#moduleProperty-toolTip').empty();
-    // if(help[obj.objectType])$('#moduleProperty-toolTip').append(help[obj.objectType])
-    if (obj && help[obj.objectType]) {
-        $('#moduleProperty-inner').append('<p><button id="toolTipButton" class="btn btn-primary btn-xs" type="button" >Logix Tip</button></p>');
-        // $('#moduleProperty-toolTip').append('<div class="collapse" id="collapseExample"><div class="card card-body">'+help[obj.objectType]+'</div></div>')
 
+    // Tooltip can be defined in the prototype or the object itself, in addition to help map.
+    var tooltipText = obj && (obj.tooltipText || help[obj.objectType]);
+    if (tooltipText) {
+        $('#moduleProperty-inner').append('<p><button id="toolTipButton" class="btn btn-primary btn-xs" type="button" >CircuitVerse Tip</button></p>');
         $('#toolTipButton').hover(function() {
-            if (!help[obj.objectType]) return;
             $("#Help").addClass("show");
             $("#Help").empty();
             ////console.log("SHOWING")
-            $("#Help").append(help[obj.objectType]);
+            $("#Help").append(tooltipText);
         }); // code goes in document ready fn only
         $('#toolTipButton').mouseleave(function() {
             $("#Help").removeClass("show");
-
         });
     }
 

--- a/public/js/logix.js
+++ b/public/js/logix.js
@@ -38,7 +38,7 @@ forceResetNodes = true; // FLag to reset all Nodes
 
 circuitElementList = [
     "Input", "Output", "NotGate", "OrGate", "AndGate", "NorGate", "NandGate", "XorGate", "XnorGate", "SevenSegDisplay", "HexDisplay",
-    "Multiplexer", "BitSelector", "Splitter", "Power", "Ground", "ConstantVal", "ControlledInverter", "TriState", "Adder", "Rom", "TflipFlop",
+    "Multiplexer", "BitSelector", "Splitter", "Power", "Ground", "ConstantVal", "ControlledInverter", "TriState", "Adder", "Rom", "RAM", "TflipFlop",
     "JKflipFlop", "SRflipFlop", "DflipFlop", "TTY", "Keyboard", "Clock", "DigitalLed", "Stepper", "VariableLed", "RGBLed", "Button", "Demultiplexer",
     "Buffer", "SubCircuit", "Flag", "MSB", "LSB", "PriorityEncoder", "Tunnel", "ALU", "Decoder", "Random", "Dlatch", "TB_Input", "TB_Output", "ForceGate"
 ];

--- a/public/js/ram.js
+++ b/public/js/ram.js
@@ -1,0 +1,175 @@
+/** 
+ * RAM Component.
+ * 
+ * Two settings are available:
+ * - addressWidth: 1 to 20, default=10. Controls the width of the address input.
+ * - bitWidth: 1 to 32, default=8. Controls the width of data pins.
+ * 
+ * Amount of memory in the element is 2^addressWidth x bitWidth bits.
+ * Minimum RAM size is: 2^1  x  1 = 2 bits.
+ * Maximum RAM size is: 2^20 x 32 = 1M x 32 bits => 32 Mbits => 4MB.
+ * Maximum 8-bits size: 2^20 x  8 = 1M x 8 bits => 1MB.
+ * Default RAM size is: 2^10 x  8 = 1024 bytes => 1KB.
+ *
+ * RAMs are volatile therefore this component does not persist the memory contents.
+ * 
+ * Changes to addressWidth and bitWidth also cause data to be lost.
+ * Think of these operations as being equivalent to taking a piece of RAM out of a 
+ * circuit board and replacing it with another RAM of different size.
+ * 
+ * The contents of the RAM can be reset to zero by setting the RESET pin 1 or 
+ * or by selecting the component and pressing the "Reset" button in the properties window.
+ * 
+ * The contents of the RAM can be dumped to the console by transitioning CORE DUMP pin to 1
+ * or by selecting the component and pressing the "Core Dump" button in the properties window.
+ * Address spaces that have not been written will show up as `undefined` in the core dump. 
+ * 
+ * NOTE: The maximum address width of 20 is arbitrary.
+ * Larger values are possible, but in practice circuits won't need this much
+ * memory and keeping the value small helps avoid allocating too much memory on the browser.
+ * Internally we use a sparse array, so only the addresses that are written are actually
+ * allocated. Nevertheless, it is better to prevent large allocations from happening
+ * by keeping the max addressWidth small. If needed, we can increase the max.
+ */
+function RAM(x, y, scope = globalScope, dir = "RIGHT", bitWidth = 8, addressWidth = 10) {
+    CircuitElement.call(this, x, y, scope, dir, Math.min(Math.max(1, bitWidth), 32));
+    this.setDimensions(60, 40);
+
+    this.directionFixed = true;
+    this.labelDirection = "UP";
+
+    this.addressWidth = Math.min(Math.max(1, addressWidth), 20);
+    this.address = new Node(-this.leftDimensionX, -20, 0, this, this.addressWidth, "ADDRESS");
+    this.dataIn = new Node(-this.leftDimensionX, 0, 0, this, this.bitWidth, "DATA IN");
+    this.write = new Node(-this.leftDimensionX, 20, 0, this, 1, "WRITE");
+    this.reset = new Node(0, this.downDimensionY, 0, this, 1, "RESET");
+    this.coreDump = new Node(-20, this.downDimensionY, 0, this, 1, "CORE DUMP");
+    this.dataOut = new Node(this.rightDimensionX, 0, 1, this, this.bitWidth, "DATA OUT");
+    this.prevCoreDumpValue = undefined;
+
+    this.clearData()
+}
+RAM.prototype = Object.create(CircuitElement.prototype);
+RAM.prototype.tooltipText = "Random Access Memory";
+RAM.prototype.constructor = RAM;
+RAM.prototype.mutableProperties = {
+    "addressWidth": {
+        name: "Address Width",
+        type: "number",
+        max: "20",
+        min: "1",
+        func: "changeAddressWidth",
+    },
+    "dump": {
+        name: "Core Dump",
+        type: "button",
+        func: "dump",
+    },
+    "reset": {
+        name: "Reset",
+        type: "button",
+        func: "clearData",
+    },
+}
+RAM.prototype.customSave = function () {
+    return {
+        // NOTE: data is not persisted since RAMs are volatile.
+        constructorParamaters: [this.direction, this.bitWidth, this.addressWidth],
+        nodes: {
+            address: findNode(this.address),
+            dataIn: findNode(this.dataIn),
+            write: findNode(this.write),
+            reset: findNode(this.reset),
+            coreDump: findNode(this.coreDump),
+            dataOut: findNode(this.dataOut),
+        },
+    }
+}
+RAM.prototype.newBitWidth = function (value) {
+    value = parseInt(value);
+    if (!isNaN(value) && this.bitWidth != value && value >= 1 && value <= 32) {
+        this.bitWidth = value;
+        this.dataIn.bitWidth = value;
+        this.dataOut.bitWidth = value;
+        this.clearData();
+    }
+}
+RAM.prototype.changeAddressWidth = function (value) {
+    value = parseInt(value);
+    if (!isNaN(value) && this.addressWidth != value && value >= 1 && value <= 20) {
+        this.addressWidth = value;
+        this.address.bitWidth = value;
+        this.clearData();
+    }
+}
+RAM.prototype.clearData = function () {
+    this.data = new Array(Math.pow(2, this.addressWidth));
+    this.tooltipText = this.memSizeString() + " Random Access Memory";
+}
+RAM.prototype.isResolvable = function () {
+    return this.address.value !== undefined || this.reset.value !== undefined || this.coreDump.value !== undefined;
+}
+RAM.prototype.resolve = function () {
+    if (this.write.value == 1) {
+        this.data[this.address.value] = this.dataIn.value;
+    }
+
+    if (this.reset.value == 1) {
+        this.clearData();
+    }
+
+    if (this.coreDump.value && this.prevCoreDumpValue != this.coreDump.value) {
+        this.dump();
+    }
+    this.prevCoreDumpValue = this.coreDump.value;
+
+    this.dataOut.value = this.data[this.address.value] || 0;
+    simulationArea.simulationQueue.add(this.dataOut);
+}
+RAM.prototype.customDraw = function () {
+    var ctx = simulationArea.context;
+    var xx = this.x;
+    var yy = this.y;
+
+    ctx.beginPath();
+    ctx.strokeStyle = "gray";
+    ctx.fillStyle = this.write.value ? "red" : "lightgreen";
+    ctx.lineWidth = correctWidth(1);
+    drawCircle2(ctx, 50, -30, 3, xx, yy, this.direction);
+    ctx.fill();
+    ctx.stroke();
+
+    ctx.beginPath();
+    ctx.textAlign = "center";
+    ctx.fillStyle = "black";
+    fillText2(ctx, this.memSizeString(), 0, -10, xx, yy, this.direction);
+    fillText2(ctx, "RAM", 0, 10, xx, yy, this.direction);
+    fillText2(ctx, "A", this.address.x + 12, this.address.y, xx, yy, this.direction);
+    fillText2(ctx, "DI", this.dataIn.x + 12, this.dataIn.y, xx, yy, this.direction);
+    fillText2(ctx, "W", this.write.x + 12, this.write.y, xx, yy, this.direction);
+    fillText2(ctx, "DO", this.dataOut.x - 17, this.dataOut.y, xx, yy, this.direction);
+    ctx.fill();
+}
+RAM.prototype.memSizeString = function () {
+    var mag = ['', 'K', 'M'];
+    var unit = this.bitWidth == 8 ? "B" : this.bitWidth == 1 ? "b" : " x " + this.bitWidth + 'b';
+    var v = Math.pow(2, this.addressWidth);
+    var m = 0;
+    while (v >= 1024 && m < mag.length - 1) {
+        v /= 1024;
+        m++;
+    }
+    return v + mag[m] + unit;
+}
+RAM.prototype.dump = function () {
+    var logLabel = console.group && this.label;
+    if (logLabel) {
+        console.group(this.label);
+    }
+
+    console.log(this.data)
+
+    if (logLabel) {
+        console.groupEnd();
+    }
+}


### PR DESCRIPTION
This change implements a RAM component in CircuitVerse to address #81.

Two settings are available:
- addressWidth: 1 to 20, default=10. Controls the width of the address input.
- bitWidth: 1 to 32, default=8. Controls the width of data pins.

Amount of memory in the element is 2^addressWidth x bitWidth bits.
Minimum RAM size is: 2^1  x  1 = 2 bits.
Maximum RAM size is: 2^20 x 32 = 1M x 32 bits => 32 Mbits => 4MB.
Maximum 8-bits size: 2^20 x  8 = 1M x 8 bits => 1MB.
Default RAM size is: 2^10 x  8 = 1024 bytes => 1KB.
 
RAMs are volatile therefore this component does not persist the memory contents.

Changes to addressWidth and bitWidth cause data to be lost.
Think of these operations as being equivalent to taking a piece of RAM out of a 
circuit board and replacing it with another RAM of different size.

The contents of the RAM can be reset to zero by setting the RESET pin 1 or 
or by selecting the component and pressing the "Reset" button in the properties window.

The contents of the RAM can be dumped to the console by transitioning CORE DUMP pin to 1
or by selecting the component and pressing the "Core Dump" button in the properties window.
Address spaces that have not been written will show up as `undefined` in the core dump. 

NOTE: The maximum address width of 20 is arbitrary.
Larger values are possible, but in practice circuits won't need this much
memory and keeping the value small helps avoid allocating too much memory on the browser.
Internally we use a sparse array, so only the addresses that are written are actually
allocated. Nevertheless, it is better to prevent large allocations from happening
by keeping the max addressWidth small. If needed, we can increase the max.

An example of a circuit using the new component is shown below:
![image](https://user-images.githubusercontent.com/4239171/52936703-d60abf80-3311-11e9-9f9e-9a27450bc5c0.png)
