### PR TITLE
Fix component sizes

### DIFF
--- a/public/js/UX.js
+++ b/public/js/UX.js
@@ -75,7 +75,6 @@ $(document).ready(function() {
 var help = {
     "Input": "Input ToolTip: Toggle the individual bits by clicking on them.",
     "Button": "Button ToolTip: High(1) when pressed and Low(0) when released.",
-    "Power": "Power ToolTip: All bits are High(1).",
     "Ground": "Ground ToolTip: All bits are Low(0).",
     "ConstantVal": "Constant ToolTip: Bits are fixed. Double click element to change the bits.",
     "Stepper": "Stepper ToolTip: Increase/Decrease value by selecting the stepper and using +/- keys.",

--- a/public/js/UX.js
+++ b/public/js/UX.js
@@ -75,7 +75,6 @@ $(document).ready(function() {
 var help = {
     "Input": "Input ToolTip: Toggle the individual bits by clicking on them.",
     "Button": "Button ToolTip: High(1) when pressed and Low(0) when released.",
-    "Ground": "Ground ToolTip: All bits are Low(0).",
     "ConstantVal": "Constant ToolTip: Bits are fixed. Double click element to change the bits.",
     "Stepper": "Stepper ToolTip: Increase/Decrease value by selecting the stepper and using +/- keys.",
     "Output": "Output ToolTip: Simple output element showing output in binary.",

--- a/public/js/embedListeners.js
+++ b/public/js/embedListeners.js
@@ -39,8 +39,10 @@ function startListeners() {
         var rect = simulationArea.canvas.getBoundingClientRect();
         simulationArea.mouseRawX = (e.clientX - rect.left) * DPR;
         simulationArea.mouseRawY = (e.clientY - rect.top) * DPR;
-        simulationArea.mouseX = Math.round(((simulationArea.mouseRawX - globalScope.ox) / globalScope.scale) / unit) * unit;
-        simulationArea.mouseY = Math.round(((simulationArea.mouseRawY - globalScope.oy) / globalScope.scale) / unit) * unit;
+        simulationArea.mouseXf = (simulationArea.mouseRawX - globalScope.ox) / globalScope.scale;
+        simulationArea.mouseYf = (simulationArea.mouseRawY - globalScope.oy) / globalScope.scale;
+        simulationArea.mouseX = Math.round(simulationArea.mouseXf / unit) * unit;
+        simulationArea.mouseY = Math.round(simulationArea.mouseYf / unit) * unit;
 
         updateCanvas = true;
         if (simulationArea.lastSelected == globalScope.root) {

--- a/public/js/listeners.js
+++ b/public/js/listeners.js
@@ -301,9 +301,10 @@ function onMouseMove(e) {
     var rect = simulationArea.canvas.getBoundingClientRect();
     simulationArea.mouseRawX = (e.clientX - rect.left) * DPR;
     simulationArea.mouseRawY = (e.clientY - rect.top) * DPR;
-
-    simulationArea.mouseX = Math.round(((simulationArea.mouseRawX - globalScope.ox) / globalScope.scale) / unit) * unit;
-    simulationArea.mouseY = Math.round(((simulationArea.mouseRawY - globalScope.oy) / globalScope.scale) / unit) * unit;
+    simulationArea.mouseXf = (simulationArea.mouseRawX - globalScope.ox) / globalScope.scale;
+    simulationArea.mouseYf = (simulationArea.mouseRawY - globalScope.oy) / globalScope.scale;
+    simulationArea.mouseX = Math.round(simulationArea.mouseXf / unit) * unit;
+    simulationArea.mouseY = Math.round(simulationArea.mouseYf / unit) * unit;
 
     updateCanvas = true;
 

--- a/public/js/logix.js
+++ b/public/js/logix.js
@@ -1102,10 +1102,8 @@ CircuitElement.prototype.fixDirection = function() {
 // NOT OVERIDABLE
 CircuitElement.prototype.isHover = function() {
 
-    var mouseX = simulationArea.mouseX;
-    var mouseY = simulationArea.mouseY;
-
-    if (Math.abs(mouseX - this.x > Math.max(this.leftDimensionX, this.rightDimensionX)) || Math.abs(mouseY - this.y > Math.max(this.upDimensionY, this.downDimensionY))) return false;
+    var mX = simulationArea.mouseXf - this.x;
+    var mY = this.y - simulationArea.mouseYf;
 
     var rX = this.rightDimensionX;
     var lX = this.leftDimensionX;
@@ -1129,9 +1127,7 @@ CircuitElement.prototype.isHover = function() {
         }
     }
 
-    if (mouseX - this.x <= rX && this.x - mouseX <= lX && mouseY - this.y <= dY && this.y - mouseY <= uY) return true;
-
-    return false;
+    return -lX <= mX && mX <= rX && -dY <= mY && mY <= uY;
 };
 
 CircuitElement.prototype.setLabel = function(label) {

--- a/public/js/modules.js
+++ b/public/js/modules.js
@@ -217,7 +217,7 @@ function Multiplexer(x, y, scope = globalScope, dir = "RIGHT", bitWidth = 1, con
         this.yOff = 2;
     }
 
-    this.setDimensions(20, this.yOff * 5 * (this.inputSize));
+    this.setDimensions(20 - this.xOff, this.yOff * 5 * (this.inputSize));
     this.rectangleObject = false;
 
     this.inp = [];
@@ -2604,7 +2604,7 @@ function Demultiplexer(x, y, scope = globalScope, dir = "LEFT", bitWidth = 1, co
         this.input.bitWidth = bitWidth;
     }
 
-    this.setDimensions(20, this.yOff * 5 * (this.outputsize));
+    this.setDimensions(20 - this.xOff, this.yOff * 5 * (this.outputsize));
     this.rectangleObject = false;
     this.input = new Node(20 - this.xOff, 0, 0, this);
 
@@ -2730,7 +2730,7 @@ function Decoder(x, y, scope = globalScope, dir = "LEFT", bitWidth = 1) {
         return obj;
     }
 
-    this.setDimensions(20, this.yOff * 5 * (this.outputsize));
+    this.setDimensions(20 - this.xOff, this.yOff * 5 * (this.outputsize));
     this.rectangleObject = false;
     this.input = new Node(20 - this.xOff, 0, 0, this);
 

--- a/public/js/modules.js
+++ b/public/js/modules.js
@@ -1658,13 +1658,12 @@ function Power(x, y, scope = globalScope, bitWidth = 1) {
     CircuitElement.call(this, x, y, scope, "RIGHT", bitWidth);
     this.directionFixed = true;
     this.rectangleObject = false;
-    this.setDimensions(15, 15);
+    this.setDimensions(10, 10);
+    this.downDimensionY = 2;
     this.output1 = new Node(0, 10, 1, this);
-    this.output1.value = this.state;
-    this.wasClicked = false;
-
 }
 Power.prototype = Object.create(CircuitElement.prototype);
+Power.prototype.tooltipText = "Power: All bits are High(1).";
 Power.prototype.constructor = Power;
 Power.prototype.propagationDelay = 0;
 Power.prototype.resolve = function() {

--- a/public/js/modules.js
+++ b/public/js/modules.js
@@ -1593,16 +1593,12 @@ Splitter.prototype.customDraw = function() {
 function Ground(x, y, scope = globalScope, bitWidth = 1) {
     CircuitElement.call(this, x, y, scope, "RIGHT", bitWidth);
     this.rectangleObject = false;
-    this.setDimensions(20, 20);
+    this.setDimensions(10, 10);
     this.directionFixed = true;
     this.output1 = new Node(0, -10, 1, this);
-
-    this.output1.value = this.state;
-
-    this.wasClicked = false;
-
 }
 Ground.prototype = Object.create(CircuitElement.prototype);
+Ground.prototype.tooltipText = "Ground: All bits are Low(0).";
 Ground.prototype.constructor = Ground;
 Ground.prototype.propagationDelay = 0;
 Ground.prototype.customSave = function() {
@@ -1659,7 +1655,6 @@ function Power(x, y, scope = globalScope, bitWidth = 1) {
     this.directionFixed = true;
     this.rectangleObject = false;
     this.setDimensions(10, 10);
-    this.downDimensionY = 2;
     this.output1 = new Node(0, 10, 1, this);
 }
 Power.prototype = Object.create(CircuitElement.prototype);


### PR DESCRIPTION
Fix for #107 

The rounded values of mouseX and mouseY caused inHover to return true too soon, effectively making the hitbox half-a-square larger in each side of the component.

I've included non-rounded values in the simulationArea and use those to determine the hit.

Then I reduced the hitbox of Power & Ground to be just the 20x20 square.
I've also fixed the size of the 1-bit Decoder, Mux & Demux.