### PR TITLE
Add pry-rails dependency to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,7 @@ group :development, :test do
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '~> 2.13'
   gem 'selenium-webdriver'
+  gem 'pry-rails'
 end
 
 group :development do
@@ -79,7 +80,6 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
-  gem 'pry-rails'
 end
 
 group :production do

--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,7 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'pry-rails'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,7 @@ GEM
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     climate_control (0.2.0)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -171,6 +172,11 @@ GEM
       mimemagic (~> 0.3.0)
       terrapin (~> 0.6.0)
     pg (1.0.0)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (3.0.3)
     puma (3.12.0)
     rack (2.0.6)
@@ -312,6 +318,7 @@ DEPENDENCIES
   omniauth-microsoft-office365
   paperclip (>= 5.2.0)
   pg (~> 1.0.0)
+  pry-rails
   puma (~> 3.7)
   rails (~> 5.1.4)
   rails_admin (~> 1.2)
@@ -330,4 +337,4 @@ DEPENDENCIES
   will_paginate-bootstrap
 
 BUNDLED WITH
-   1.16.4
+   1.17.2

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Email: admin@circuitverse.org
 Password: password
 ```
 
+For debugging include `binding.pry` anywhere inside to code to open the `pry` console.
+
 ## Additional setup instructions for Ubuntu
 Additional instructions can be found [here](https://www.howtoforge.com/tutorial/ubuntu-ruby-on-rails/) and there are some extra notes for single user installations:
 - If setting up Postgres with these instructions, use your user name instead of 'rails_dev'.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Email: admin@circuitverse.org
 Password: password
 ```
 
-For debugging include `binding.pry` anywhere inside to code to open the `pry` console.
+For debugging include `binding.pry` anywhere inside the code to open the `pry` console.
 
 ## Additional setup instructions for Ubuntu
 Additional instructions can be found [here](https://www.howtoforge.com/tutorial/ubuntu-ruby-on-rails/) and there are some extra notes for single user installations:


### PR DESCRIPTION
Solves #127 
`pry-rails` dependency has been added to the Gemfile. More details have been included in the issue. 