### PR TITLE
Add more delimiters to email splitting for collaborators and groups

### DIFF
--- a/app/controllers/collaborations_controller.rb
+++ b/app/controllers/collaborations_controller.rb
@@ -35,7 +35,9 @@ class CollaborationsController < ApplicationController
       render plain: "Access Restricted " and return
     end
 
-    collaboration_params[:emails].split(',').each do |email|
+    collaboration_emails = collaboration_params[:emails].split(/[\s,\,]/).compact.reject(&:empty?)
+
+    collaboration_emails.each do |email|
       email = email.strip
       user = User.find_by(email: email)
       if user.nil?

--- a/app/controllers/group_members_controller.rb
+++ b/app/controllers/group_members_controller.rb
@@ -31,8 +31,9 @@ class GroupMembersController < ApplicationController
     end
 
     @group = Group.find(group_member_params[:group_id])
+    group_member_emails = group_member_params[:emails].split(/[\s,\,]/).compact.reject(&:empty?)
 
-    group_member_params[:emails].split(',').each do |email|
+    group_member_emails.each do |email|
       email = email.strip
       user = User.find_by(email: email)
       if user.nil?

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -62,7 +62,7 @@
 
             </div>
             <div class="modal-body">
-              <p>Enter Email IDs separated by commas. If users are not registered, an email ID will be sent requesting them to sign up.</p>
+              <p>Enter Email IDs separated by commas or spaces. If users are not registered, an email ID will be sent requesting them to sign up.</p>
               <%= form_with(model: @group_member, local: true) do |form| %>
                   <% if @group_member.errors.any? %>
                       <div id="error_explanation">

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -161,7 +161,7 @@
 
         </div>
         <div class="modal-body">
-          <p>Enter Email IDs separated by commas. Users need to be registered already on the platform.
+          <p>Enter Email IDs separated by commas or spaces. Users need to be registered already on the platform.
             Note that collaboration is not real time as of now. Every save overwites the previous data.</p>
           <%= form_with(model: @collaboration, local: true) do |form| %>
               <% if @collaboration.errors.any? %>


### PR DESCRIPTION
Fixes #92 