### PR TITLE
Improved email input for group members and collaborators

### DIFF
--- a/app/controllers/collaborations_controller.rb
+++ b/app/controllers/collaborations_controller.rb
@@ -35,9 +35,12 @@ class CollaborationsController < ApplicationController
       render plain: "Access Restricted " and return
     end
 
-    collaboration_emails = collaboration_params[:emails].split(/[\s,\,]/).compact.reject(&:empty?)
+    already_present = User.where(id: @project.collaborations.pluck(:user_id)).pluck(:email)
+    collaboration_emails = Utils.parse_mails(collaboration_params[:emails])
 
-    collaboration_emails.each do |email|
+    newly_added = collaboration_emails - already_present
+
+    newly_added.each do |email|
       email = email.strip
       user = User.find_by(email: email)
       if user.nil?
@@ -48,7 +51,7 @@ class CollaborationsController < ApplicationController
     end
 
     respond_to do |format|
-      format.html { redirect_to user_project_path(@project.author_id,@project.id), notice: 'Collaborators have been added'}
+      format.html { redirect_to user_project_path(@project.author_id,@project.id), notice: Utils.mail_notice(collaboration_params[:emails], collaboration_emails, newly_added)}
     end
 
   end

--- a/app/helpers/utils.rb
+++ b/app/helpers/utils.rb
@@ -1,0 +1,30 @@
+module Utils
+
+  # Filters out all the valid emails from the argument string
+  # @param mails string of emails entered
+  # @return array of valid emails
+  def self.parse_mails(mails)
+    mails.split(/[\s,\,]/).select do |email|
+      email.present? && URI::MailTo::EMAIL_REGEXP.match(email)
+    end.uniq
+  end
+
+  # Forms notice string for given email input
+  # @param input_mails string of emails entered
+  # @param parsed_mails array of valid emails
+  # @param newly_added array of emails that have been newly added
+  # @return notice string
+  def self.mail_notice(input_mails, parsed_mails, newly_added)
+    total = input_mails.split(/[\s,\,]/).select(&:present?).count
+    valid = parsed_mails.count
+    invalid = total - valid
+    already_present = (parsed_mails - newly_added).count
+
+    notice = if total != 0 && valid != 0
+             "Out of #{total} Email(s), #{valid} #{valid != 1 ? 'were' : 'was'} valid and #{invalid} #{invalid != 1 ? 'were' : 'was'} invalid. #{newly_added.count} user(s) will be invited. " + \
+               (already_present == 0 ? "No users were already present." : "#{already_present} user(s) #{already_present!= 1 ? 'were' : 'was'} already present.")
+             else
+               "No valid Email(s) entered."
+             end
+  end
+end


### PR DESCRIPTION
Fixes #131 

Now the message is of the format:
`Out of 3 Email(s), 2 were valid and 1 was invalid. 1 user(s) will be invited. 1 user(s) was already present.` 
 or `Out of 4 Email(s), 2 were valid and 2 were invalid. 2 user(s) will be invited. No users were already present.`  or `No valid Email(s) entered.`
