### PR TITLE
Fix: form responsiveness

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -22,3 +22,7 @@
   width:100%;
  }
 
+.col-centered{
+  float: none;
+  margin: 0 auto;
+}

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -9,12 +9,12 @@
     <% if @minimum_password_length %>
       <em>(<%= @minimum_password_length %> characters minimum)</em><br />
     <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "off" %>
+    <%= f.password_field :password, autofocus: true, autocomplete: "off", placeholder: 'New Password' %>
   </div>
 
   <div class="field">
     <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "off" %>
+    <%= f.password_field :password_confirmation, autocomplete: "off", placeholder: 'Confirm New Password' %>
   </div>
 
   <div class="actions">

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -1,25 +1,30 @@
-<h2>Change your password</h2>
+<div class="container">
+  <div class="row feature">
+    <div class="col-xs-10 col-lg-6 col-md-8 col-s-10 col-centered">
+      <h2>Change your password</h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= devise_error_messages! %>
-  <%= f.hidden_field :reset_password_token %>
+      <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+        <%= devise_error_messages! %>
+        <%= f.hidden_field :reset_password_token %>
 
-  <div class="field">
-    <%= f.label :password, "New password" %><br />
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
-    <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "off", placeholder: 'New Password' %>
+        <div class="field">
+          <%= f.label :password, "New password" %><br />
+          <% if @minimum_password_length %>
+            <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+          <% end %>
+          <%= f.password_field :password, autofocus: true, autocomplete: "off", placeholder: 'New Password' %>
+        </div>
+
+        <div class="field">
+          <%= f.label :password_confirmation, "Confirm new password" %><br />
+          <%= f.password_field :password_confirmation, autocomplete: "off", placeholder: 'Confirm New Password' %>
+        </div>
+
+        <div class="actions">
+          <%= f.submit "Change my password" %>
+        </div>
+      <% end %>
+      <%= render "users/shared/links" %>
+    </div>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "off", placeholder: 'Confirm New Password' %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Change my password" %>
-  </div>
-<% end %>
-
-<%= render "users/shared/links" %>
+</div>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -1,16 +1,23 @@
-<h2>Forgot your password?</h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= devise_error_messages! %>
+<div class="container">
+  <div class="row feature">
+    <div class="col-xs-10 col-lg-6 col-md-8 col-s-10 col-centered">
+      <h2>Forgot your password?</h2>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, placeholder: 'Email'%>
+      <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+      <%= devise_error_messages! %>
+
+        <div class="field form-group">
+          <%= f.label :email %><br />
+          <%= f.email_field :email, class: 'form-control', autofocus: true, placeholder: 'Email'%>
+        </div>
+
+        <div class="actions">
+          <%= f.submit "Send me reset password instructions", class: 'btn btn-primary' %>
+        </div>
+      <% end %>
+
+      <%= render "users/shared/links" %>
+    </div>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "users/shared/links" %>
+</div>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -5,7 +5,7 @@
 
   <div class="field">
     <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true %>
+    <%= f.email_field :email, autofocus: true, placeholder: 'Email'%>
   </div>
 
   <div class="actions">

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -10,7 +10,7 @@
 
           <div class="field">
             <%= f.label :email %><br />
-            <%= f.email_field :email, autofocus: true %>
+            <%= f.email_field :email, autofocus: true ,placeholder: 'Email'%>
           </div>
 
           <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
@@ -19,7 +19,7 @@
 
           <div class="field">
             <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-            <%= f.password_field :password, autocomplete: "off" %>
+            <%= f.password_field :password, autocomplete: "off", placeholder: 'New Password' %>
             <% if @minimum_password_length %>
                 <br />
                 <em><%= @minimum_password_length %> characters minimum</em>
@@ -28,12 +28,12 @@
 
           <div class="field">
             <%= f.label :password_confirmation %><br />
-            <%= f.password_field :password_confirmation, autocomplete: "off" %>
+            <%= f.password_field :password_confirmation, autocomplete: "off", placeholder: 'Confirm New Password' %>
           </div>
 
           <div class="field">
             <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-            <%= f.password_field :current_password, autocomplete: "off" %>
+            <%= f.password_field :current_password, autocomplete: "off", placeholder: 'Current Password' %>
           </div>
 
           <div class="actions">

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -3,7 +3,7 @@
 <div class="container">
   <div class="row feature">
 
-    <div class="col-5">
+    <div class="col-xs-10 col-lg-6 col-md-8 col-s-10 col-centered">
       <h2>Sign up</h2>
 
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -11,12 +11,12 @@
 
           <div class="field form-group">
             <%= f.label :name %><br />
-            <%= f.text_field :name, autofocus: true ,class:"form-control"%>
+            <%= f.text_field :name, autofocus: true ,class:"form-control", placeholder: 'Name'%>
           </div>
 
           <div class="field form-group">
             <%= f.label :email %><br />
-            <%= f.email_field :email, autofocus: true,class:"form-control" %>
+            <%= f.email_field :email, autofocus: true,class:"form-control", placeholder: 'Email'%>
           </div>
 
           <div class="field form-group">
@@ -24,12 +24,12 @@
             <% if @minimum_password_length %>
                 <em>(<%= @minimum_password_length %> characters minimum)</em>
             <% end %><br />
-            <%= f.password_field :password, autocomplete: "off",class:"form-control" %>
+            <%= f.password_field :password, autocomplete: "off",class:"form-control", placeholder: 'Password' %>
           </div>
 
           <div class="field form-group">
             <%= f.label :password_confirmation %><br />
-            <%= f.password_field :password_confirmation, autocomplete: "off" ,class:"form-control"%>
+            <%= f.password_field :password_confirmation, autocomplete: "off" ,class:"form-control", placeholder: 'Confirm Password'%>
           </div>
 
           <div class="actions">

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,9 +1,8 @@
 
 <div class="container">
   <div class="row feature">
-    <div class="col-5">
+    <div class="col-xs-10 col-lg-6 col-md-8 col-s-10 col-centered">
       <h2>Log in</h2>
-
       <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
            <% flash.each do |key, value| %>
              <div class="alert alert-danger"><%= value %></div>
@@ -32,7 +31,6 @@
 
       <%= render "users/shared/links" %>
     </div>
-
 
   </div>
   <br />

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,5 +1,4 @@
 
-
 <div class="container">
   <div class="row feature">
     <div class="col-5">
@@ -11,12 +10,12 @@
           <% end %>
           <div class="field form-group">
             <%= f.label :email %><br />
-            <%= f.email_field :email, autofocus: true ,class:"form-control"%>
+            <%= f.email_field :email, autofocus: true ,class:"form-control", placeholder: 'Email'%>
           </div>
 
           <div class="field form-group">
             <%= f.label :password %><br />
-            <%= f.password_field :password, autocomplete: "off" ,class:"form-control"%>
+            <%= f.password_field :password, autocomplete: "off" ,class:"form-control", placeholder: 'Password'%>
           </div>
 
           <% if devise_mapping.rememberable? -%>

--- a/app/views/users/unlocks/new.html.erb
+++ b/app/views/users/unlocks/new.html.erb
@@ -5,7 +5,7 @@
 
   <div class="field">
     <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true %>
+    <%= f.email_field :email, autofocus: true, placeholder: 'Email'%>
   </div>
 
   <div class="actions">


### PR DESCRIPTION
Closes #124 .
Added place holder in Login, Sign up and Password reset forms.
Added Password reset forms structure.
Added responsive bootstrap code for above mentioned forms.
Added a universal CSS class .col-centered that can find it's use on various pages across the project.
Screenshots:
Desktop View:
![image](https://user-images.githubusercontent.com/32102845/53611231-c897e400-3bf3-11e9-9c24-5a582006c8b8.png)
Mobile View:
![image](https://user-images.githubusercontent.com/32102845/53611255-e06f6800-3bf3-11e9-9789-62b0e782c8c9.png)
New Forgot Password page structure:
![image](https://user-images.githubusercontent.com/32102845/53611301-0dbc1600-3bf4-11e9-8fbb-2b1715a02aee.png)
Sign up page:(Desktop)
![image](https://user-images.githubusercontent.com/32102845/53611330-2d533e80-3bf4-11e9-9400-8026ee224f2e.png)
Sign up page(Mobile):
![image](https://user-images.githubusercontent.com/32102845/53611345-3f34e180-3bf4-11e9-9f9c-b2b8e6e7dfd2.png)

