### PR TITLE
Keep the connection point fixed when changing bitWidth of INPUT and OUTPUT elements

### DIFF
--- a/public/js/modules.js
+++ b/public/js/modules.js
@@ -1782,14 +1782,17 @@ Input.prototype.resolve = function() {
 // Check if override is necessary!!
 Input.prototype.newBitWidth = function(bitWidth) {
     if (bitWidth < 1) return;
+    var diffBitWidth = bitWidth - this.bitWidth;
     this.bitWidth = bitWidth; //||parseInt(prompt("Enter bitWidth"),10);
     this.setWidth(this.bitWidth * 10);
     this.state = 0;
     this.output1.bitWidth = bitWidth;
     if (this.direction == "RIGHT") {
+        this.x -= 10 * diffBitWidth;
         this.output1.x = 10 * this.bitWidth;
         this.output1.leftx = 10 * this.bitWidth;
     } else if (this.direction == "LEFT") {
+        this.x += 10 * diffBitWidth;
         this.output1.x = -10 * this.bitWidth;
         this.output1.leftx = 10 * this.bitWidth;
     }
@@ -1878,15 +1881,18 @@ Output.prototype.customSave = function() {
 }
 Output.prototype.newBitWidth = function(bitWidth) {
     if (bitWidth < 1) return;
+    var diffBitWidth = bitWidth - this.bitWidth;
     this.state = undefined;
     this.inp1.bitWidth = bitWidth;
     this.bitWidth = bitWidth;
     this.setWidth(10 * this.bitWidth);
 
     if (this.direction == "RIGHT") {
+        this.x -= 10 * diffBitWidth;
         this.inp1.x = 10 * this.bitWidth;
         this.inp1.leftx = 10 * this.bitWidth;
     } else if (this.direction == "LEFT") {
+        this.x += 10 * diffBitWidth;
         this.inp1.x = -10 * this.bitWidth;
         this.inp1.leftx = 10 * this.bitWidth;
     }


### PR DESCRIPTION
Fixes #97

This PR updates the INPUT and OUTPUT elements to move themselves left or right when bitWidth is changed, so that the connection point remains fixed. This prevents the layout of the circuit from being accidentally disrupted when one changes the bitWidth of these elements.

### Current Behavior
- Connect an INPUT and an OUTPUT element.
- Change the bitWidth of these elements.
- Their central point remains fixed and wires begin to appear in undesirable places.

### New Behavior
- Connect an INPUT and an OUTPUT element.
- Change the bitWidth of these elements.
- Their connection point remains fixed; no new wires appear.

### To Test:
- increase and decrease the bitWidth, sequentially (1,2,3,...) or in jumps (1, 5, 8, etc..)
- test with the connection point on the right and on the left of the element
- note there is no change in behavior when the connection point is up or down - in this case it will remain in the middle.