### PR TITLE
Support bitWidth inference in Output and Gates

### DIFF
--- a/public/js/Node.js
+++ b/public/js/Node.js
@@ -283,6 +283,16 @@ Node.prototype.resolve = function() {
 
         let node = this.connections[i];
 
+        // If we detect a bitWidth mismatch, give the parent element a chance to correct itself.
+        if (node.bitWidth != this.bitWidth) {
+            if (node.parent.onBitWidthError) {
+                node.parent.onBitWidthError(node, this.bitWidth);
+            }
+
+            // And then force recalculation of this particular node
+            node.value = undefined; 
+        }
+
         if (node.value != this.value) {
 
             if (node.type == 1 && node.value != undefined && node.parent.objectType != "TriState" && !(node.subcircuitOverride && node.scope != this.scope)) {
@@ -300,6 +310,8 @@ Node.prototype.resolve = function() {
 
                 node.bitWidth = this.bitWidth;
                 node.value = this.value;
+                this.highlighted = false;
+                node.highlighted = false;
                 simulationArea.simulationQueue.add(node);
             } else {
                 this.highlighted = true;
@@ -380,17 +392,14 @@ Node.prototype.draw = function() {
                 x: this.absX(),
                 y: this.absY() - 15
             }
-            if (this.type == 2) {
-                var v = "X";
-                if (this.value !== undefined)
-                    v = this.value.toString(16);
-                if (this.label.length) {
-                    canvasMessageData.string = this.label + " : " + v;
-                } else {
-                    canvasMessageData.string = v;
-                }
-            } else if (this.label.length) {
-                canvasMessageData.string = this.label;
+
+            // Show value, bitWidth and id on the tooltip of every node.
+            var v = (this.value !== undefined) ? this.value.toString(16) : "X";
+            var nodeTooltip = v + " (" + this.bitWidth + " bit" + (this.bitWidth == 1 ? "" : "s") + ", " + this.id + ")";
+            if (this.label.length) {
+                canvasMessageData.string = this.label + " : " + nodeTooltip;
+            } else {
+                canvasMessageData.string = nodeTooltip;
             }
         } else {
             setTimeout(function() {


### PR DESCRIPTION
Fixes #98 

# Automatic Inference of bitWidth in Output and Gate elements

This PR implements inference of bitWidth in CircuitVerse, making it easier to build circuits that use multi-bit signals.

## Example of current behavior

- Drop a couple of 4-bit Input elements and connect them to a default AND gate.
  - You are greeted with a message saying there is a bitWidth error.
- Fix the bitWidth of the AND gate.
- Connect an Output element to its output.
  - By default, Output comes as 1-bit and again you are greeted with another error message. 
- Now decide that you need the Input elements to be 8-bits.
  - You need to select each input, gate and output and fix their bitWidth to 8-bits.

## Example of new behavior

- Drop a couple of 4-bit Input elements and connect them to a default AND gate.
  - The AND gate automatically infers it should be 4-bits and fixes itself.
- Connect an Output element to the AND gate output.
  - In a similar manner, the Output realizes its input is a 4-bit signal and it fixes itself.
- Now decide that you need the Input elements to be 8-bits.
  - As you change both Inputs, all connected gates and outputs automatically change to 8-bits as well.
    > This might depend on the complexity of the circuit. See below.
- If a particular gate has a conflict, like one input asking for 4-bits and another asking for 5-bits, the circuit will report an error as usual and has to be manually fixed.

### Screen-capture of new behavior:
[![Screen-capture of new behavior](https://img.youtube.com/vi/fYoIJ0YPUeI/0.jpg)](https://www.youtube.com/watch?v=fYoIJ0YPUeI)
[CircuitVerse - Digital Circuit Simulator online - Google Chrome 2019-03-04 02-41-16.zip](https://github.com/CircuitVerse/CircuitVerse/files/2926025/CircuitVerse.-.Digital.Circuit.Simulator.online.-.Google.Chrome.2019-03-04.02-41-16.zip)


## Known issues

- At this point the fix targets Output and Gate elements.
  Other elements can be updated in future PRs to benefit from this mechanism using similar principles.

- Inference is currently limited to elements in a single circuit, ie, bitWidth does not flow into a sub-circuit.

- In complex circuits, not all gates might update in response to the change in bitWidth of an Input.
  - I've been trying to get the circuit to fix itself in most/all cases.
  - However, in some cases the bitWidth propagation in the wires does not seem to go all the way from one element to another. In those cases, changing an existing Input bitWidth might not cause all elements to fix themselves.
  - The error is still reported and can be fixed as usual.
  - In some cases, it is sufficient to change the value of an Input to cause its changes to propagate completely.
  - In other cases, it is a matter of fixing one offending wire and then all others fix themselves.
  - I'm looking for ways to eliminate this problem and have inference consider all nodes consistently.