### PR TITLE
Track users in Google Analytics

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,6 +33,9 @@
       gtag('js', new Date());
 
       gtag('config', 'UA-112678513-1');
+      <% if current_user %>
+      gtag('set', {'user_id': '<%= current_user.id %>'}); // Set the user ID using signed-in user_id.
+      <% end %>
   </script>
 
 </head>


### PR DESCRIPTION
Fixes #237

#### Describe the changes you have made in this pr -
This patch sends the `current_user` 's id to the google analytics engine to provide deeper analytic insights.

### Screenshots of the changes (If any) -
