### PR TITLE
Remove unnecessary links in the mentor and extended team section

### DIFF
--- a/app/views/logix/about.html.erb
+++ b/app/views/logix/about.html.erb
@@ -39,16 +39,16 @@
 
             <div class="col-6">
               <h3 class="card-title">Developer Team</h3>
-                 <h4>Core Team</h3>
+                 <h4>Core Team</h4>
                  <ul>
                      <li><a href="https://satu0king.github.io" target="_blank">Satvik Ramaprasad (Product Manager)</a> </li>
                      <li>Biswesh Mohapatra (Lead Developer) </li>
                      <li>Aditya Hegde (SEO and Infrastructure Manager) </li>
 
                  </ul>
-                 <h4>Extended Team</h3>
+                 <h4>Extended Team</h4>
                  <ul>
-                     <li><a href="https://www.linkedin.com/in/vibhavagarwal5/" target="_blank">Vibhav Agarwal (Module Developer) </li>
+                     <li><a href="https://www.linkedin.com/in/vibhavagarwal5/" target="_blank">Vibhav Agarwal (Module Developer) </a></li>
                      <li>Abhishek Krishna (UI Designer and consultant) </li>
                      <li>Aniruddha Mysore (UI Designer and consultant) </li>
                      <li>Shreyas Gupta (Logo Designer) </li>
@@ -56,13 +56,15 @@
             </div>
            <div class="col-6">
 
-             <h4>Mentors</h3>
+             <h4>Mentors</h4>
+
                <ul>
                  <li>Prof. Subhajit Sen (Domain Expert) </li>
                  <li>Ramesh Sundararaman (Brand Advisor)</li>
                  <li>Vikas Yadav (Technical Advisor) </li>
                  <li>Gaurav Koley (Technical Advisor)</li>
                </ul>
+               
                <!--<img src="img/logix.png" class="img-fluid img-thumbnail" alt="Responsive image">-->
            </div>
         </div>

--- a/app/views/logix/about.html.erb
+++ b/app/views/logix/about.html.erb
@@ -54,7 +54,7 @@
                      <li>Shreyas Gupta (Logo Designer) </li>
                  </ul>
             </div>
-           <div class="col-6">
+           <div class="col-10">
 
              <h4>Mentors</h4>
 


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this pr -
Unnecessary links present within the mentor and extended team section are removed.

### Screenshots of the changes (If any) -
![image](https://user-images.githubusercontent.com/40107298/54306250-f5ce9400-45ee-11e9-8a63-0ea2466acf06.png)

**Extra links present in INSPECT ELEMENT PAGE**

![image](https://user-images.githubusercontent.com/40107298/54306620-c53b2a00-45ef-11e9-81ec-99c46d958285.png)

**No extra links are present within the source code**

![image](https://user-images.githubusercontent.com/40107298/54306749-16e3b480-45f0-11e9-96b6-c23fc03e9867.png)


