### PR TITLE
Fix counter resetting to zero when adding elements to the circuit

### DIFF
--- a/public/js/Counter.js
+++ b/public/js/Counter.js
@@ -51,7 +51,7 @@ Counter.prototype.isResolvable = function () {
 Counter.prototype.resolve = function () {
     // Max value is either the value in the input pin or the max allowed by the bitWidth.
     var maxValue = this.maxValue.value != undefined ? this.maxValue.value : (1 << this.bitWidth) - 1;
-    var outputValue = this.output.value || 0;
+    var outputValue = this.value;
 
     // Increase value when clock is raised
     if (this.clock.value != this.prevClockState && this.clock.value == 1) {


### PR DESCRIPTION
Fixes #211 

#### Describe the changes you have made in this pr -
Update the Counter's resolve logic to look at its own "this.value" instead of "this.output.value".
The output node value gets reset to undefined when new elements are added/removed to the circuit.

