### PR TITLE
Use Eslint 5 in codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -4,6 +4,7 @@ plugins:
     enabled: true
   eslint:
     enabled: true
+    channel: "eslint-5"
 
 ratings:
   paths:


### PR DESCRIPTION
Codeclimate using eslint 3 by default and is causing inconsistency with local and code climate environment
