### PR TITLE
Add thumbnails for test-bench

### DIFF
--- a/public/img/TB_input.svg
+++ b/public/img/TB_input.svg
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="148mm"
+   height="148mm"
+   viewBox="0 0 148 148"
+   version="1.1"
+   id="svg8"
+   inkscape:export-filename="C:\Users\Monsij\Desktop\test2i.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="MAin_SVG.svg">
+  <defs
+     id="defs2">
+    <marker
+       inkscape:stockid="Arrow1Lstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lstart"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path817"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt"
+         transform="matrix(0.8,0,0,0.8,10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.0435424"
+     inkscape:cx="424.65877"
+     inkscape:cy="349.06647"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-149)">
+    <path
+       style="opacity:1;fill:#ff0000;fill-opacity:0.00995023;fill-rule:evenodd;stroke:#0a1507;stroke-width:2.6386025;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 7.6578869,184.10907 H 139.05479 v 78.65985 H 7.6578869 Z"
+       id="rect815"
+       inkscape:connector-curvature="0"
+       inkscape:export-xdpi="96"
+       inkscape:export-ydpi="96"
+       inkscape:export-filename="C:\Users\Monsij\Desktop\path3631.png" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="40.395481"
+       y="203.93687"
+       id="text847"><tspan
+         sodipodi:role="line"
+         x="40.395481"
+         y="203.93687"
+         id="tspan841"
+         style="stroke-width:0.26458332"><tspan
+           x="40.395481"
+           y="203.93687"
+           id="tspan837"
+           style="stroke-width:0.26458332">Test1 [INPUT]</tspan><tspan
+           dx="0"
+           x="114.93356"
+           y="203.93687"
+           id="tspan839"
+           style="stroke-width:0.26458332" /></tspan><tspan
+         sodipodi:role="line"
+         x="61.756191"
+         y="217.16603"
+         id="tspan845"
+         style="stroke-width:0.26458332"><tspan
+           x="61.756191"
+           y="217.16603"
+           style="text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           id="tspan843">      Case:0</tspan></tspan></text>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Triangle"
+     transform="translate(0,-149)">
+    <path
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#0a1507;stroke-width:1.74256849;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.01990051"
+       d="M 8.3555499,239.36122 8.6104869,207.6409 27.73047,223.39602 Z"
+       id="rect3639"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc"
+       inkscape:export-filename="C:\Users\Monsij\Desktop\path3631.png"
+       inkscape:export-xdpi="96"
+       inkscape:export-ydpi="96" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Circle"
+     transform="translate(0,-149)">
+    <ellipse
+       style="opacity:1;fill:#009200;fill-opacity:1;fill-rule:evenodd;stroke:#0a1507;stroke-width:2.16741109;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.01990051"
+       id="path3631"
+       cx="7.8153577"
+       cy="223.69244"
+       rx="6.9851956"
+       ry="7.3655105"
+       inkscape:export-filename="C:\Users\Monsij\Desktop\path3631.png"
+       inkscape:export-xdpi="96"
+       inkscape:export-ydpi="96" />
+  </g>
+</svg>

--- a/public/img/TB_output.svg
+++ b/public/img/TB_output.svg
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="148mm"
+   height="148mm"
+   viewBox="0 0 148 148"
+   version="1.1"
+   id="svg8"
+   inkscape:export-filename="C:\Users\Monsij\Desktop\test2i.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="MAin_SVG.svg">
+  <defs
+     id="defs2">
+    <marker
+       inkscape:stockid="Arrow1Lstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lstart"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path817"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt"
+         transform="matrix(0.8,0,0,0.8,10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.0435424"
+     inkscape:cx="424.65877"
+     inkscape:cy="349.06647"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-149)">
+    <path
+       style="opacity:1;fill:#ff0000;fill-opacity:0.00995023;fill-rule:evenodd;stroke:#0a1507;stroke-width:2.6386025;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 7.6578869,184.10907 H 139.05479 v 78.65985 H 7.6578869 Z"
+       id="rect815"
+       inkscape:connector-curvature="0"
+       inkscape:export-xdpi="96"
+       inkscape:export-ydpi="96"
+       inkscape:export-filename="C:\Users\Monsij\Desktop\path3631.png" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="130.71271"
+       y="203.93687"
+       id="text847"><tspan
+         sodipodi:role="line"
+         x="40.395485"
+         y="203.93687"
+         id="tspan841"
+         style="text-align:center;text-anchor:middle;stroke-width:0.26458332"><tspan
+           x="40.395481"
+           y="203.93687"
+           id="tspan837"
+           style="text-align:center;text-anchor:middle;stroke-width:0.26458332">                   Test1 [OUTPUT]</tspan></tspan><tspan
+         sodipodi:role="line"
+         x="61.756191"
+         y="217.16603"
+         id="tspan845"
+         style="text-align:center;text-anchor:middle;stroke-width:0.26458332"><tspan
+           x="61.756191"
+           y="217.16603"
+           style="text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           id="tspan843">      Paired</tspan></tspan></text>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Triangle"
+     transform="translate(0,-149)" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Circle"
+     transform="translate(0,-149)" />
+</svg>


### PR DESCRIPTION
Two images TB_input.svg and TB_output.svg has been added for testbench icon

Fixes #253 