### PR TITLE
removed the extra postgres gem from the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,6 @@ gem 'pundit'
 gem "pg", "~> 1.1.4"
 
 
-gem "pg", "~> 1.1.4"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this pr -
Removed the extra line 
gem "pg", "~> 1.1.4"

which was creating warnings when installing gems and could l cause errors if you change the version of one of them later.
### Screenshots of the changes (If any) -
