### PR TITLE
Fix `users/:id/groups` to display groups of the requested user

### DIFF
--- a/app/controllers/users/logix_controller.rb
+++ b/app/controllers/users/logix_controller.rb
@@ -35,7 +35,7 @@ class Users::LogixController < ApplicationController
   end
 
   def groups
-
+    @user = authorize @user
   end
 
   def profile_params

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class UserPolicy < Struct.new(:user, :requested_user)
+  attr_reader :user, :requested_user
+
+  def initialize(user, requested_user)
+    @user = user
+    @requested_user = requested_user
+  end
+
+  def groups?
+    requested_user.id == user.id || user.admin?
+  end
+end

--- a/app/views/users/logix/groups.html.erb
+++ b/app/views/users/logix/groups.html.erb
@@ -7,7 +7,7 @@
           <p id="notice" class="alert alert-danger"><%= notice %></p>
         <% end %>
 
-      <% if current_user.groups.count!=0 %>
+      <% if @user.groups.count!=0 %>
           <h1>Groups you belong to: </h1>
           <table class="table">
             <thead>
@@ -19,12 +19,12 @@
             </thead>
 
             <tbody>
-            <% current_user.groups.each do |group| %>
+            <% @user.groups.each do |group| %>
                 <tr>
                   <td><%= group.name %></td>
                   <td><%= group.mentor.name %></td>
                   <td><%= link_to 'Show', group %></td>
-                  <%if group.mentor.id == current_user.id %>
+                  <%if group.mentor.id == @user.id %>
                       <td><%= link_to 'Edit', edit_group_path(group) %></td>
                       <td><%= link_to 'Destroy', group, method: :delete, data: { confirm: 'Are you sure?' } %></td>
                   <%end%>
@@ -37,7 +37,7 @@
           <br>
       <% end %>
 
-      <% if current_user.groups_mentored.count!=0 %>
+      <% if @user.groups_mentored.count!=0 %>
           <h1>Groups you mentor: </h1>
           <table class="table">
             <thead>
@@ -49,7 +49,7 @@
             </thead>
 
             <tbody>
-            <% current_user.groups_mentored.each do |group| %>
+            <% @user.groups_mentored.each do |group| %>
                 <tr>
                   <td><%= group.name %></td>
                   <td><%= group.users.count %></td>

--- a/spec/controllers/users_logix_controller_spec.rb
+++ b/spec/controllers/users_logix_controller_spec.rb
@@ -19,9 +19,35 @@ describe Users::LogixController, type: :request do
     get user_favourites_path(:id => @user.id)
     expect(response.status).to eq(200)
   end
-  it  'should get user groups' do
-    get user_groups_path(:id => @user.id)
-    expect(response.status).to eq(200)
+
+  describe "#groups" do
+    before do
+      sign_out @user
+    end
+
+    context "user logged in is admin" do
+      it "should get user groups" do
+        sign_in FactoryBot.create(:user, admin: true)
+        get user_groups_path(id: @user.id)
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context "logged in user requests its own group" do
+      it "should get user groups" do
+        sign_in @user
+        get user_groups_path(id: @user.id)
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context "logged in user requests some other user's groups" do
+      it "should not get groups" do
+        sign_in FactoryBot.create(:user)
+        get user_groups_path(id: @user.id)
+        expect(response.body).to eq("You are not authorized to do the requested operation")
+      end
+    end
   end
   it 'should get edit profile' do
     get profile_edit_path(:id => @user.id)

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe UserPolicy do
+  subject { UserPolicy.new(user, requested_user) }
+
+  before do
+    @user = FactoryBot.create(:user)
+  end
+
+  describe "#groups" do
+    let(:user) { @user }
+
+    context "user is same as requested_user" do
+      let(:requested_user) { @user }
+      it { should permit(:groups) }
+    end
+
+    context "user is admin" do
+      let(:requested_user) { @user }
+      let(:user) { FactoryBot.create(:user, admin: true) }
+
+      it { should permit(:groups) }
+    end
+
+    context "user is not same as requested user" do
+      let(:requested_user) { FactoryBot.create(:user) }
+      it { should_not permit(:groups) }
+    end
+  end
+end


### PR DESCRIPTION
Fixes #256 

#### Describe the changes you have made in this pr -

- Add a user policy class to show the groups of the user whose `id` has been mentioned in the route. 
- Now the user will only be able to see their groups if the `id` in the route matches their own, admins will be able to see any group, a NotAuthorized error will be thrown otherwise. 

### Screenshots of the changes (If any) -
N.A.