### PR TITLE
Watermark and tooltip overlap issue

### DIFF
--- a/public/css/embed.css
+++ b/public/css/embed.css
@@ -117,7 +117,7 @@ button:focus {outline:0;}
 
 #elementName {
     position:absolute;
-    right: 6px; bottom: 6px;
+    left: 6px; bottom: 6px;
     background-color: white;
     z-index:101;
     color: black;


### PR DESCRIPTION
Fixes #300 

Changed the position of tooltip from bottom right to bottom left.

<img width="774" alt="Screenshot 2019-03-23 at 8 27 16 PM" src="https://user-images.githubusercontent.com/20012612/54867782-59548080-4daa-11e9-92f3-15316d41de46.png">

