### PR TITLE
Fix keyup and keydown listeners

### DIFF
--- a/public/js/embedListeners.js
+++ b/public/js/embedListeners.js
@@ -2,7 +2,7 @@
 // Refer listeners.js
 
 function startListeners() {
-    window.addEventListener('keyup', function(e) {
+    window.parent.addEventListener('keyup', function(e) {
         scheduleUpdate(1);
         if (e.keyCode == 16) {
             simulationArea.shiftDown = false;
@@ -85,7 +85,7 @@ function startListeners() {
 
 
     });
-    window.addEventListener('keydown', function(e) {
+    window.parent.addEventListener('keydown', function(e) {
 
         errorDetected = false;
         updateSimulation = true;


### PR DESCRIPTION
Fixes #307 

#### Describe the changes you have made in this pr -
A tricky but simple fix. The listeners were already present in `embedListeners.js` but, keyup and keydown events do not behave in the usual manner when they are embedded in the form of an iframe.  They need to be defined on the parent of the current window to capture the actual event.
References - 
- [simple fix](https://stackoverflow.com/a/10942878)
- [using jquery](https://stackoverflow.com/questions/1199075/keydown-event-on-a-iframe)

### Screenshots of the changes (If any) -
![fix-keyboard-compress](https://user-images.githubusercontent.com/22021150/55041644-fdad2000-5053-11e9-8393-9414b993072f.gif)
