### PR TITLE
Updated footer to be responsive to different screen sizes + typo fix

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -27,3 +27,21 @@
   float: none;
   margin: 0 auto;
 }
+
+/* CSS for the sponsor logos in the footer*/
+#footer-logo-iiitb{
+  width: 85%;
+}
+
+#footer-logo-DO{
+  width: 100%;
+  padding-top: 8%;
+}
+
+#footer-logo-istudio{
+  width: 75%;
+}
+
+#footer-logo-zense{
+  width: 75%;
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -28,7 +28,7 @@
   margin: 0 auto;
 }
 
-/* CSS for the sponsor logos in the footer*/
+/* CSS for the sponsor logos in the footer */
 #footer-logo-iiitb{
   width: 85%;
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -67,19 +67,22 @@
     <div class="row">
       <div class="col" style="text-align: center">
         <p style="text-align: center">Brought to you by</p>
-        <a href="https://www.iiitb.ac.in/"><img src="/img/iiitb.jpg" height="70px"></a>
+        <a href="https://www.iiitb.ac.in/"><img src="/img/iiitb.jpg" width="85%"></a>
       </div>
       <div class="col" style="text-align: center">
         <p style="text-align: center">Hosting Sponsor</p>
-        <a href="http://digitalocean.com/" ><img src="/img/DO.png" height="60px"></a>
+        <a href="http://digitalocean.com/" ><img src="/img/DO.png" width="100%" style="padding-top:8%;"></a>
       </div>
-      <div class="col" style="text-align: center">
+
+      <div class="d-block d-sm-none w-100"></div>
+
+      <div class="col align-bottom" style="text-align: center">
         <p style="text-align: center">Marketed by</p>
-        <a href="http://www.iiitb.org/"><img src="/img/istudio.png" height="70px"></a>
+        <a href="http://www.iiitb.org/"><img src="/img/istudio.png" width="75%"></a>
       </div>
       <div class="col" style="text-align: center">
         <p style="text-align: center">Developed by</p>
-        <a href="http://zense.co.in/"><img src="/img/zense.png" height="70px"></a>
+        <a href="http://zense.co.in/"><img src="/img/zense.png" width="75%"></a>
       </div>
 
       <!--<div class="col">-->

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -67,22 +67,23 @@
     <div class="row">
       <div class="col" style="text-align: center">
         <p style="text-align: center">Brought to you by</p>
-        <a href="https://www.iiitb.ac.in/"><img src="/img/iiitb.jpg" width="85%"></a>
+        <a href="https://www.iiitb.ac.in/"><img src="/img/iiitb.jpg" id="footer-logo-iiitb"></a>
       </div>
       <div class="col" style="text-align: center">
         <p style="text-align: center">Hosting Sponsor</p>
-        <a href="http://digitalocean.com/" ><img src="/img/DO.png" width="100%" style="padding-top:8%;"></a>
+        <a href="http://digitalocean.com/" ><img src="/img/DO.png" id="footer-logo-DO"></a>
       </div>
 
-      <div class="d-block d-sm-none w-100"></div>
+      <!-- For breaking the line into two lines when the screen size is not big enough -->
+      <div class="d-block d-sm-none w-100"><br/></div>
 
       <div class="col align-bottom" style="text-align: center">
         <p style="text-align: center">Marketed by</p>
-        <a href="http://www.iiitb.org/"><img src="/img/istudio.png" width="75%"></a>
+        <a href="http://www.iiitb.org/"><img src="/img/istudio.png" id="footer-logo-istudio"></a>
       </div>
       <div class="col" style="text-align: center">
         <p style="text-align: center">Developed by</p>
-        <a href="http://zense.co.in/"><img src="/img/zense.png" width="75%"></a>
+        <a href="http://zense.co.in/"><img src="/img/zense.png" id="footer-logo-zense"></a>
       </div>
 
       <!--<div class="col">-->

--- a/app/views/logix/contribute.html.erb
+++ b/app/views/logix/contribute.html.erb
@@ -59,7 +59,7 @@
                         <li class="list-group-item" >Add new features to the CircuitVerse project</li>
                         <li class="list-group-item" >Find and fix bugs to the CircuitVerse project</li>
 
-                        
+
                 </ul>
         </div>
     </div>
@@ -85,13 +85,13 @@
  <div class="col-10 offset-1 col-sm-6 offset-sm-0 col-md-6 offset-md-0 col-lg-4 offset-lg-0 offset-lg-2 col-xl-4" style="margin-top:20px;margin-bottom:20px;" >
  <div class="card " style="max-width: 19rem ;box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);">
         <div class="card-header" style="background-color:#C6CCCD; border-bottom-style:none">
-            <h5 class="card-title" ><center>If you are a company or organisation,you can</center></h5>
+            <h5 class="card-title" ><center>If you are a company or organisation, you can</center></h5>
         </div>
         <div class="card-body" style="background-color:#DCE3E3;">
                 <ul class="list-group" style="box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);" >
                         <li class="list-group-item" >Become a CircuitVerse Partner (see Patreon)</li>
                         <li class="list-group-item" >Contact support for more details</li>
-                        
+
                 </ul>
         </div>
     </div>
@@ -106,7 +106,7 @@
                 <ul class="list-group" style="box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);" >
                         <li class="list-group-item" >Become a patreon (recurring pledge)</li>
                         <li class="list-group-item" >Donate via PayPal <br>(one time)</li>
-                        
+
                 </ul>
         </div>
     </div>
@@ -114,7 +114,7 @@
 
 </div>
   </div>
-  
+
 
       <br />
         <div class="row center feature">

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -1,10 +1,19 @@
-<div class="container feature">
-  <h1>Editing Project</h1>
+<div class="container">
+  <div class="row feature">
 
-  <%= render 'form', project: @project %>
+    <div class="container">
 
-  <%= link_to 'Show', user_project_path(current_user,@project) %> |
-  <%= link_to 'Back', user_path(@author)%>
+      <h1>Editing Project</h1>
 
+      <%= render 'form', project: @project %>
+
+      <%= link_to 'Show', user_project_path(current_user,@project) %> |
+      <%= link_to 'Back', user_path(@author)%>
+
+    </div>
+    <br/>
+
+    <br/>
+
+  </div>
 </div>
-

--- a/public/css/logixRelease.css
+++ b/public/css/logixRelease.css
@@ -61,3 +61,21 @@ img{
         background-color: "transparent"
     }
 }
+
+/* CSS for the sponsor logos in the footer*/
+#footer-logo-iiitb{
+  width: 85%;
+}
+
+#footer-logo-DO{
+  width: 100%;
+  padding-top: 8%;
+}
+
+#footer-logo-istudio{
+  width: 75%;
+}
+
+#footer-logo-zense{
+  width: 75%;
+}

--- a/public/css/logixRelease.css
+++ b/public/css/logixRelease.css
@@ -61,21 +61,3 @@ img{
         background-color: "transparent"
     }
 }
-
-/* CSS for the sponsor logos in the footer*/
-#footer-logo-iiitb{
-  width: 85%;
-}
-
-#footer-logo-DO{
-  width: 100%;
-  padding-top: 8%;
-}
-
-#footer-logo-istudio{
-  width: 75%;
-}
-
-#footer-logo-zense{
-  width: 75%;
-}


### PR DESCRIPTION
Solves the footer issue mentioned in the comments of #192 and #195

Fixes #

- Old footer used to stretch the sponsor logos based on the screen size. So, sponsor logos were looking disproportional. Fixed the stretching issue.

- Code in the "Editing Projects" page was cleaned

- Fixed a small typo in the contribute page


#### Describe the changes you have made in this pr -

- _For the footer,_ Added responsive bootstrap columns to keep the proportions. Also added ability to break the long footer into two lines based on the screen size. Image widths were defined as percentages rather than hardcoded numbers

- _For the "Editing Projects" page_, Changed "container feature" class to "container" and added other lines for consistency in the code across different pages

- _For the typo_, the sentence was changed to "If you are a company or organisation, you can"

### Screenshots of the changes (If any) -
_Typo:_
<img width="350" alt="Screen Shot 2019-04-06 at 12 14 55 PM" src="https://user-images.githubusercontent.com/10498874/55666897-1bedf980-5866-11e9-802e-459a6e0914df.png">



_Old footer at different screen sizes:_
<img width="1623" alt="Screen Shot 2019-04-06 at 4 12 25 AM" src="https://user-images.githubusercontent.com/10498874/55662284-fd1a4380-5822-11e9-95b7-09939496c8f6.png">
<img width="772" alt="Screen Shot 2019-04-06 at 4 12 35 AM" src="https://user-images.githubusercontent.com/10498874/55662285-fdb2da00-5822-11e9-941f-0a8bfe65ebc3.png">
<img width="429" alt="Screen Shot 2019-04-06 at 4 12 45 AM" src="https://user-images.githubusercontent.com/10498874/55662287-00153400-5823-11e9-8d3f-0f709855403c.png">


_New footer at different screen sizes:_
<img width="1465" alt="Screen Shot 2019-04-06 at 4 14 54 AM" src="https://user-images.githubusercontent.com/10498874/55662297-0c998c80-5823-11e9-8c11-7ccd4bfa5ca2.png">
<img width="741" alt="Screen Shot 2019-04-06 at 4 15 08 AM" src="https://user-images.githubusercontent.com/10498874/55662301-128f6d80-5823-11e9-87c2-1e30edff3011.png">
<img width="427" alt="Screen Shot 2019-04-06 at 4 15 16 AM" src="https://user-images.githubusercontent.com/10498874/55662304-14593100-5823-11e9-9d4d-093d27d35af4.png">




