### PR TITLE
Make group related routes user specific

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -91,7 +91,8 @@ class AssignmentsController < ApplicationController
 
     respond_to do |format|
       if @assignment.save
-        format.html { redirect_to @group, notice: 'Assignment was successfully created.' }
+        format.html { redirect_to user_group_path(@group.mentor, @group), \
+          notice: "Assignment was successfully created." }
         format.json { render :show, status: :created, location: @assignment }
       else
         format.html { render :new }
@@ -103,7 +104,6 @@ class AssignmentsController < ApplicationController
   # PATCH/PUT /assignments/1
   # PATCH/PUT /assignments/1.json
   def update
-
     description = params["description"]
     params = assignment_params
     @assignment.description = description
@@ -111,7 +111,8 @@ class AssignmentsController < ApplicationController
 
     respond_to do |format|
       if @assignment.update(params)
-        format.html { redirect_to @group, notice: 'Assignment was successfully updated.' }
+        format.html { redirect_to user_group_path(@group.mentor, @group), \
+          notice: "Assignment was successfully updated." }
         format.json { render :show, status: :ok, location: @assignment }
       else
         format.html { render :edit }
@@ -125,7 +126,8 @@ class AssignmentsController < ApplicationController
   def destroy
     @assignment.destroy
     respond_to do |format|
-      format.html { redirect_to @group, notice: 'Assignment was successfully destroyed.' }
+      format.html { redirect_to user_group_path(@group.mentor, @group), \
+        notice: "Assignment was successfully destroyed." }
       format.json { head :no_content }
     end
   end

--- a/app/controllers/group_members_controller.rb
+++ b/app/controllers/group_members_controller.rb
@@ -56,7 +56,8 @@ class GroupMembersController < ApplicationController
     notice = Utils.mail_notice(group_member_params[:emails], group_member_emails, newly_added)
 
     respond_to do |format|
-      format.html { redirect_to group_path(@group), notice: Utils.mail_notice(group_member_params[:emails], group_member_emails, newly_added)
+      format.html { redirect_to user_group_path(@group.mentor, @group), \
+        notice: Utils.mail_notice(group_member_params[:emails], group_member_emails, newly_added)
 }
     end
     # redirect_to group_path(@group)
@@ -93,7 +94,8 @@ class GroupMembersController < ApplicationController
 
     @group_member.destroy
     respond_to do |format|
-      format.html { redirect_to group_path(@group_member.group), notice: 'Group member was successfully destroyed.' }
+      format.html { redirect_to user_group_path(@group_member.group.mentor, @group_member.group), \
+        notice: "Group member was successfully destroyed." }
       format.json { head :no_content }
     end
   end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -3,6 +3,7 @@ class GroupsController < ApplicationController
   before_action :authenticate_user!
   before_action :check_show_access, only: [:show, :edit, :update, :destroy]
   before_action :check_edit_access, only: [:edit,:update, :destroy]
+  before_action :set_and_verify_user, only: [:create, :new]
 
   # GET /groups
   # GET /groups.json
@@ -22,7 +23,7 @@ class GroupsController < ApplicationController
     end
   end
 
-  # GET /groups/new
+  # GET /users/:user_id/groups/new
   def new
     @group = Group.new
   end
@@ -31,10 +32,10 @@ class GroupsController < ApplicationController
   def edit
   end
 
-  # POST /groups
-  # POST /groups.json
+  # POST /users/:id/groups
+  # POST /users/:id/groups.json
   def create
-    @group = current_user.groups_mentored.new(group_params)
+    @group = @user.groups_mentored.new(group_params)
 
     respond_to do |format|
       if @group.save
@@ -72,6 +73,11 @@ class GroupsController < ApplicationController
   end
 
   private
+    def set_and_verify_user
+      @user = User.find(params[:user_id])
+      authorize @user, :groups?
+    end
+
     # Use callbacks to share common setup or constraints between actions.
     def set_group
       @group = Group.find(params[:id])

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -2,8 +2,8 @@ class GroupsController < ApplicationController
   before_action :set_group, only: [:show, :edit, :update, :destroy]
   before_action :authenticate_user!
   before_action :check_show_access, only: [:show, :edit, :update, :destroy]
-  before_action :check_edit_access, only: [:edit,:update, :destroy]
-  before_action :set_and_verify_user, only: [:create, :new, :edit]
+  before_action :check_edit_access, only: [:edit, :update, :destroy]
+  before_action :set_and_verify_user, only: [:create, :new, :edit, :show, :update, :destroy]
 
   # GET /groups
   # GET /groups.json
@@ -11,8 +11,8 @@ class GroupsController < ApplicationController
     @groups = Group.all
   end
 
-  # GET /groups/1
-  # GET /groups/1.json
+  # GET /users/:user_id/groups/1
+  # GET /users/:user_id/groups/1.json
   def show
     @group_member = @group.group_members.new
     @group.assignments.each do |assignment|
@@ -39,7 +39,8 @@ class GroupsController < ApplicationController
 
     respond_to do |format|
       if @group.save
-        format.html { redirect_to @group, notice: 'Group was successfully created.' }
+        format.html { redirect_to user_group_path(@user, @group), \
+          notice: "Group was successfully created." }
         format.json { render :show, status: :created, location: @group }
       else
         format.html { render :new }
@@ -48,12 +49,13 @@ class GroupsController < ApplicationController
     end
   end
 
-  # PATCH/PUT /groups/1
-  # PATCH/PUT /groups/1.json
+  # PATCH/PUT /users/:user_id/groups/1
+  # PATCH/PUT /users/:user_id/groups/1.json
   def update
     respond_to do |format|
       if @group.update(group_params)
-        format.html { redirect_to @group, notice: 'Group was successfully updated.' }
+        format.html { redirect_to user_group_path(@user, @group), \
+          notice: "Group was successfully updated." }
         format.json { render :show, status: :ok, location: @group }
       else
         format.html { render :edit }
@@ -62,12 +64,13 @@ class GroupsController < ApplicationController
     end
   end
 
-  # DELETE /groups/1
-  # DELETE /groups/1.json
+  # DELETE /users/user_id/groups/1
+  # DELETE /users/user_id/groups/1.json
   def destroy
     @group.destroy
     respond_to do |format|
-      format.html { redirect_to user_groups_path(current_user), notice: 'Group was successfully destroyed.' }
+      format.html { redirect_to user_groups_path(@user), \
+        notice: "Group was successfully destroyed." }
       format.json { head :no_content }
     end
   end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -3,7 +3,7 @@ class GroupsController < ApplicationController
   before_action :authenticate_user!
   before_action :check_show_access, only: [:show, :edit, :update, :destroy]
   before_action :check_edit_access, only: [:edit, :update, :destroy]
-  before_action :set_and_verify_user, only: [:create, :new, :edit, :show, :update, :destroy]
+  before_action :set_and_verify_user, only: [:show, :create, :new, :edit, :update, :destroy]
 
   # GET /groups
   # GET /groups.json

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -3,7 +3,7 @@ class GroupsController < ApplicationController
   before_action :authenticate_user!
   before_action :check_show_access, only: [:show, :edit, :update, :destroy]
   before_action :check_edit_access, only: [:edit,:update, :destroy]
-  before_action :set_and_verify_user, only: [:create, :new]
+  before_action :set_and_verify_user, only: [:create, :new, :edit]
 
   # GET /groups
   # GET /groups.json
@@ -28,7 +28,7 @@ class GroupsController < ApplicationController
     @group = Group.new
   end
 
-  # GET /groups/1/edit
+  # GET /users/:user_id/groups/1/edit
   def edit
   end
 

--- a/app/views/assignments/edit.html.erb
+++ b/app/views/assignments/edit.html.erb
@@ -8,7 +8,7 @@
 
       <%= render 'form', assignment: @assignment , group:@group%>
 
-      <%= link_to 'Back', group_path(@group) %>
+      <%= link_to 'Back', user_group_path(@group.mentor, @group) %>
 
     </div>
 

--- a/app/views/assignments/new.html.erb
+++ b/app/views/assignments/new.html.erb
@@ -6,7 +6,7 @@
 
       <%= render 'form', assignment: @assignment , group:@group%>
 
-      <%= link_to 'Back', group_path(@group) %>
+      <%= link_to 'Back', user_group_path(@group.mentor, @group) %>
 
     </div>
 

--- a/app/views/assignments/show.html.erb
+++ b/app/views/assignments/show.html.erb
@@ -30,7 +30,7 @@
         <p><%= @assignment.description.html_safe%></p><br>
       </p>
 
-      <%= link_to 'Back', group_path(@group) %>
+      <%= link_to 'Back', user_group_path(@group.mentor, @group) %>
 
       <%if policy(@assignment).admin_access? && @assignment.status!="closed"%>
 

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: group, local: true) do |form| %>
+<%= form_with(model: group, local: true, url: url) do |form| %>
   <% if group.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(group.errors.count, "error") %> prohibited this group from being saved:</h2>

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -4,9 +4,9 @@
     <div class="col">
       <h1>Editing Group</h1>
 
-      <%= render 'form', group: @group, url: group_path(@group) %>
+      <%= render 'form', group: @group, url: user_group_path(@user, @group) %>
 
-      <%= link_to 'Show', @group %> |
+      <%= link_to 'Show', user_group_path(@user, @group) %> |
       <%= link_to 'Back', user_groups_path(@user) %>
 
     </div>

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -4,10 +4,10 @@
     <div class="col">
       <h1>Editing Group</h1>
 
-      <%= render 'form', group: @group %>
+      <%= render 'form', group: @group, url: group_path(@group) %>
 
       <%= link_to 'Show', @group %> |
-      <%= link_to 'Back', user_groups_path(current_user) %>
+      <%= link_to 'Back', user_groups_path(@user) %>
 
     </div>
 

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -4,9 +4,9 @@
     <div class="col">
       <h1>New Group</h1>
 
-      <%= render 'form', group: @group %>
+      <%= render 'form', group: @group, url: user_groups_path(@user) %>
 
-      <%= link_to 'Back', user_groups_path(current_user) %>
+      <%= link_to 'Back', user_groups_path(@user) %>
 
     </div>
 

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -164,9 +164,9 @@
         </tbody>
       </table>
       <% if policy(@group).admin_access? %>
-      <%= link_to 'Edit', edit_group_path(@group) %> |
+      <%= link_to 'Edit', edit_user_group_path(@user, @group) %> |
       <% end %>
-      <%= link_to 'Back', user_groups_path(current_user) %>
+      <%= link_to 'Back', user_groups_path(@user) %>
 
     </div>
 

--- a/app/views/users/logix/groups.html.erb
+++ b/app/views/users/logix/groups.html.erb
@@ -2,7 +2,7 @@
   <div class="row feature">
 
     <div class="col">
-      <%= link_to 'New Group +', new_group_path, class: "btn btn-info" %>
+      <%= link_to 'New Group +', new_user_groups_path(@user), class: "btn btn-info" %>
       <% if notice %>
           <p id="notice" class="alert alert-danger"><%= notice %></p>
         <% end %>

--- a/app/views/users/logix/groups.html.erb
+++ b/app/views/users/logix/groups.html.erb
@@ -23,10 +23,10 @@
                 <tr>
                   <td><%= group.name %></td>
                   <td><%= group.mentor.name %></td>
-                  <td><%= link_to 'Show', group %></td>
+                  <td><%= link_to 'Show', user_group_path(@user, group) %></td>
                   <%if group.mentor.id == @user.id %>
                       <td><%= link_to 'Edit', edit_user_group_path(@user, group) %></td>
-                      <td><%= link_to 'Destroy', group, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+                      <td><%= link_to 'Destroy', user_group_path(@user, group), method: :delete, data: { confirm: 'Are you sure?' } %></td>
                   <%end%>
 
                 </tr>
@@ -53,9 +53,9 @@
                 <tr>
                   <td><%= group.name %></td>
                   <td><%= group.users.count %></td>
-                  <td><%= link_to 'Show', group %></td>
+                  <td><%= link_to 'Show', user_group_path(@user, group) %></td>
                   <td><%= link_to 'Edit', edit_user_group_path(@user, group) %></td>
-                  <td><%= link_to 'Destroy', group, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+                  <td><%= link_to 'Destroy', user_group_path(@user, group), method: :delete, data: { confirm: 'Are you sure?' } %></td>
                 </tr>
             <% end %>
             </tbody>

--- a/app/views/users/logix/groups.html.erb
+++ b/app/views/users/logix/groups.html.erb
@@ -2,7 +2,7 @@
   <div class="row feature">
 
     <div class="col">
-      <%= link_to 'New Group +', new_user_groups_path(@user), class: "btn btn-info" %>
+      <%= link_to 'New Group +', new_user_group_path(@user), class: "btn btn-info" %>
       <% if notice %>
           <p id="notice" class="alert alert-danger"><%= notice %></p>
         <% end %>
@@ -25,7 +25,7 @@
                   <td><%= group.mentor.name %></td>
                   <td><%= link_to 'Show', group %></td>
                   <%if group.mentor.id == @user.id %>
-                      <td><%= link_to 'Edit', edit_group_path(group) %></td>
+                      <td><%= link_to 'Edit', edit_user_group_path(@user, group) %></td>
                       <td><%= link_to 'Destroy', group, method: :delete, data: { confirm: 'Are you sure?' } %></td>
                   <%end%>
 
@@ -54,7 +54,7 @@
                   <td><%= group.name %></td>
                   <td><%= group.users.count %></td>
                   <td><%= link_to 'Show', group %></td>
-                  <td><%= link_to 'Edit', edit_group_path(group) %></td>
+                  <td><%= link_to 'Edit', edit_user_group_path(@user, group) %></td>
                   <td><%= link_to 'Destroy', group, method: :delete, data: { confirm: 'Are you sure?' } %></td>
                 </tr>
             <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
   # resources :assignment_submissions
   resources :group_members ,only: [:create,:destroy]
-  resources :groups, except: [:new, :create, :edit] do
+  resources :groups, except: [:new, :create, :edit, :show, :update, :destroy] do
     resources :assignments
   end
 
@@ -73,7 +73,7 @@ Rails.application.routes.draw do
 
   resources :users do
     resources :projects, only: [:show, :edit, :update, :new, :create, :destroy]
-    resources :groups, only: [:create, :new, :edit]
+    resources :groups, only: [:create, :new, :edit, :show, :update, :destroy]
   end
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
   # resources :assignment_submissions
   resources :group_members ,only: [:create,:destroy]
-  resources :groups, except: [:new, :create] do
+  resources :groups, except: [:new, :create, :edit] do
     resources :assignments
   end
 
@@ -73,7 +73,7 @@ Rails.application.routes.draw do
 
   resources :users do
     resources :projects, only: [:show, :edit, :update, :new, :create, :destroy]
-    resource :groups, only: [:create, :new]
+    resources :groups, only: [:create, :new, :edit]
   end
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
   # resources :assignment_submissions
   resources :group_members ,only: [:create,:destroy]
-  resources :groups do
+  resources :groups, except: [:new, :create] do
     resources :assignments
   end
 
@@ -53,7 +53,7 @@ Rails.application.routes.draw do
     get '/create_fork/:id', to: 'projects#create_fork',as: 'create_fork_project'
     get '/change_stars/:id', to: 'projects#change_stars', as: 'change_stars'
     get 'tags/:tag', to: 'projects#get_projects', as: 'tag'
-  end  
+  end
 
   mount Commontator::Engine => '/commontator'
 
@@ -73,6 +73,7 @@ Rails.application.routes.draw do
 
   resources :users do
     resources :projects, only: [:show, :edit, :update, :new, :create, :destroy]
+    resource :groups, only: [:create, :new]
   end
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
   # resources :assignment_submissions
   resources :group_members ,only: [:create,:destroy]
-  resources :groups, except: [:new, :create, :edit, :show, :update, :destroy] do
+  resources :groups, only: [:index] do
     resources :assignments
   end
 
@@ -73,7 +73,7 @@ Rails.application.routes.draw do
 
   resources :users do
     resources :projects, only: [:show, :edit, :update, :new, :create, :destroy]
-    resources :groups, only: [:create, :new, :edit, :show, :update, :destroy]
+    resources :groups, except: [:index]
   end
 
 

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe GroupsController, type: :request do
+  before do
+    @mentor = FactoryBot.create(:user)
+    @group = FactoryBot.create(:group, mentor: @mentor, name: "Test Group")
+  end
+
+  context "signed user requests group creation for another user" do
+    it "does not create group" do
+      sign_in FactoryBot.create(:user)
+      request_params = [
+        {
+          type: "post",
+          url: user_groups_path(@mentor),
+          params: { group: { name: "Test", mentor_id: @mentor.id } }
+        },
+        {
+          type: "put",
+          url: user_group_path(@mentor, @group),
+          params: { group: { name: "Test Change" } }
+        },
+        {
+          type: "delete",
+          url: user_group_path(@mentor, @group)
+        },
+        {
+          type: "get",
+          url: user_group_path(@mentor, @group)
+        }
+      ]
+
+      authorization_checks request_params
+    end
+  end
+
+  context "signed in user request group operations" do
+    before do
+      sign_in @mentor
+    end
+
+    describe "#create" do
+      it "creates group" do
+        expect do
+          post user_groups_path(@mentor), params: { group: { name: "Test", mentor_id: @mentor.id } }
+        end.to change { Group.count }.by(1)
+      end
+    end
+
+    describe "#update" do
+      it "updates group" do
+        expect do
+          expect do
+            put user_groups_path(@mentor), params: { group: { name: "Test Change" } }
+            @group.reload
+          end.to change { @group.name }.to "Test Change"
+        end
+      end
+    end
+
+    describe "#destory" do
+      it "deletes group" do
+        expect do
+          delete user_group_path(@mentor, @group)
+        end.to change { Group.count }.by(-1)
+      end
+    end
+
+    describe "#show" do
+      it "shows group" do
+        get user_group_path(@mentor, @group)
+        expect(response.status).to eq(200)
+        expect(response.body).to include(@group.name)
+      end
+    end
+
+    describe "#new" do
+      it "renders new group template" do
+        get new_user_group_path(@mentor, @group)
+        expect(response.status).to eq(200)
+        expect(response.body).to include("New Group")
+      end
+    end
+
+    describe "#edit" do
+      it "renders edit group template" do
+        get edit_user_group_path(@mentor, @group)
+        expect(response.status).to eq(200)
+        expect(response.body).to include("Editing Group")
+      end
+    end
+  end
+end

--- a/spec/support/spec_utils.rb
+++ b/spec/support/spec_utils.rb
@@ -7,4 +7,21 @@ module SpecUtils
       policy.public_send("#{action}?")
     end.to raise_error(ApplicationPolicy::CustomAuthException)
   end
+
+  def not_authorized_check
+    expect(response.body).to eq("You are not authorized to do the requested operation")
+  end
+
+  # A general function for authorization checks
+  # request_params = [{
+  #   url: "url",
+  #   type: "get",
+  #   params: {}
+  # }, ...]
+  def authorization_checks(request_params)
+    request_params.each do |req|
+      eval("#{req[:type]} '#{req[:url]}', params: #{req[:params] || {}}")
+      not_authorized_check
+    end
+  end
 end


### PR DESCRIPTION
Fixes #295 

#### Describe the changes you have made in this pr -

- All group routes `create, update, new, edit, destroy, show` are now user specific. 
- The use of `current_user` has been eliminated. This allowed admin to create, update and edit groups for individual users, refer #295 for details

Todo:
- [x] Code clean up and adding tests

**A minor note**
The show paths of the groups no longer unique. For eg for a mentor and a group member, the show path for the mentor will be `users/mentor_id/groups/group_id` and the group member will be `users/group_member_id/groups/group_id`. Either of the users will not be able to access each other's paths and admins will be able to access both. I had to do this to ensure proper navigation (the `Back` links at the edit and show pages) and also for proper navigation for the admins from the show page to the user group pages. 

#### Screenshots of the changes (If any) -
N.A