### PR TITLE
fixed n+1 query issue on tags page

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -13,7 +13,7 @@ class ProjectsController < ApplicationController
   end
   # GET /projects/tags/[tag]
   def get_projects
-    @projects = Project.tagged_with(params[:tag]).open
+    @projects = Project.tagged_with(params[:tag]).open.includes(:tags, :author)
   end
   # GET /projects/1
   # GET /projects/1.json


### PR DESCRIPTION
Fixes #365  
#### Describe the changes you have made in this pr -
Now the tags page always load in 3 queries instead of n+1 queries it was using earlier
### Screenshots of the changes (If any) -
![image](https://user-images.githubusercontent.com/32474302/56074424-dda98a80-5dcf-11e9-937a-822fde6c4cae.png)
