### PR TITLE
Fix n+1 group member count queries on group page

### DIFF
--- a/app/controllers/users/logix_controller.rb
+++ b/app/controllers/users/logix_controller.rb
@@ -39,6 +39,11 @@ class Users::LogixController < ApplicationController
 
   def groups
     @user = authorize @user
+    @groups_mentored = Group.where(id: Group.joins(:mentor).where(mentor: @user))
+                            .select("groups.*, COUNT(group_members.id) as group_member_count")
+                            .joins("left outer join group_members on \
+                              (group_members.group_id = groups.id)")
+                            .group("groups.id")
   end
 
   private

--- a/app/views/users/logix/groups.html.erb
+++ b/app/views/users/logix/groups.html.erb
@@ -37,7 +37,7 @@
           <br>
       <% end %>
 
-      <% if @user.groups_mentored.count!=0 %>
+      <% if @groups_mentored.present? %>
           <h1>Groups you mentor: </h1>
           <table class="table">
             <thead>
@@ -49,10 +49,10 @@
             </thead>
 
             <tbody>
-            <% @user.groups_mentored.each do |group| %>
+            <% @groups_mentored.each do |group| %>
                 <tr>
                   <td><%= group.name %></td>
-                  <td><%= group.users.count %></td>
+                  <td><%= group.group_member_count %></td>
                   <td><%= link_to 'Show', group %></td>
                   <td><%= link_to 'Edit', edit_group_path(group) %></td>
                   <td><%= link_to 'Destroy', group, method: :delete, data: { confirm: 'Are you sure?' } %></td>


### PR DESCRIPTION
Fixes #364 

#### Describe the changes you have made in this pr -
The earlier n+1 group member count queries have been reduced to 1 single query as follows - 

```sql
SELECT groups.*, COUNT(group_members.id) as group_member_count FROM "groups" 
LEFT OUTER JOIN group_members on  (group_members.group_id = groups.id) 
WHERE "groups"."id" IN (SELECT "groups"."id" FROM "groups" INNER JOIN "users" ON "users"."id" = "groups"."mentor_id" WHERE "groups"."mentor_id" = 2) 
GROUP BY groups.id
```


### Screenshots of the changes (If any) -
![puma logs](https://user-images.githubusercontent.com/22021150/57390742-a8c80200-71da-11e9-9176-f6ce4be77bfc.png)
