### PR TITLE
Add coveralls config to circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs: # a collection of steps
       - run:
           name: Run rspec in parallel
           command: |
-            bundle exec rspec --profile 10 \
+            COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN bundle exec rspec --profile 10 \
                               --format RspecJunitFormatter \
                               --out test_results/rspec.xml \
                               --format progress \

--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+service_name: circle-ci


### PR DESCRIPTION
Adds coveralls config to circle-ci. 

#### Describe the changes you have made in this pr -
To see code coverages on pull requests we'll have to register our repo on https://coveralls.io/. 
And from here add the coveralls repo token as an environment variable in circle-ci like so - 
`COVERALLS_REPO_TOKEN=<repo-token-from-coveralls>`

### Screenshots of the changes (If any) -
![image](https://user-images.githubusercontent.com/22021150/59026230-81189800-8873-11e9-82eb-733ac94eaf77.png)

