### PR TITLE
Add subscription of mails for users

### DIFF
--- a/app/controllers/custom_mails_controller.rb
+++ b/app/controllers/custom_mails_controller.rb
@@ -46,6 +46,9 @@ class CustomMailsController < ApplicationController
   end
 
   def send_mail
+    @mail.sent = true
+    @mail.save
+
     send_mail_in_batches(@mail)
 
     render html: "The mails were queued for sending!"

--- a/app/controllers/custom_mails_controller.rb
+++ b/app/controllers/custom_mails_controller.rb
@@ -8,6 +8,7 @@ class CustomMailsController < ApplicationController
   before_action :set_mail, only: [:edit, :update, :show, :send_mail]
 
   def show
+    @user = current_user
   end
 
   def new

--- a/app/controllers/custom_mails_controller.rb
+++ b/app/controllers/custom_mails_controller.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 class CustomMailsController < ApplicationController
+  include CustomMailsHelper
+
   before_action :authenticate_user!
   before_action :authorize_admin
-  before_action :set_mail, only: [:edit, :update, :show]
+  before_action :set_mail, only: [:edit, :update, :show, :send_mail]
 
   def show
   end
@@ -40,6 +42,12 @@ class CustomMailsController < ApplicationController
         format.json { render json: @mail.errors, status: :unprocessable_entity }
       end
     end
+  end
+
+  def send_mail
+    send_mail_in_batches(@mail)
+
+    render html: "The mails were queued for sending!"
   end
 
   private

--- a/app/controllers/custom_mails_controller.rb
+++ b/app/controllers/custom_mails_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CustomMailsController < ApplicationController
+  before_action :authenticate_user!
+
+  def new
+    authorize CustomMail
+  end
+
+  def create
+  end
+
+  private
+    def custom_mails_params
+      params.require(:custom_mails).permit(:subject, :content)
+    end
+end

--- a/app/controllers/custom_mails_controller.rb
+++ b/app/controllers/custom_mails_controller.rb
@@ -2,16 +2,56 @@
 
 class CustomMailsController < ApplicationController
   before_action :authenticate_user!
+  before_action :authorize_admin
+  before_action :set_mail, only: [:edit, :update, :show]
+
+  def show
+  end
 
   def new
-    authorize CustomMail
+  end
+
+  def edit
   end
 
   def create
+    @mail = CustomMail.new(subject: custom_mails_params[:subject],
+     content: custom_mails_params[:content],
+     sender: current_user)
+
+    respond_to do |format|
+      if @mail.save
+        format.html { redirect_to custom_mail_path(@mail) }
+        format.json { render json: { message: "Mail created" }, status: 200 }
+      else
+        format.html { render :new }
+        format.json { render json: @mail.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def update
+    respond_to do |format|
+      if @mail.update(custom_mails_params)
+        format.html { redirect_to custom_mail_path(@mail) }
+        format.json { render json: { message: "Mail updated" }, status: 200 }
+      else
+        format.html { render :edit }
+        format.json { render json: @mail.errors, status: :unprocessable_entity }
+      end
+    end
   end
 
   private
+    def authorize_admin
+      authorize CustomMail.new, :admin?
+    end
+
+    def set_mail
+      @mail = CustomMail.find(params[:id])
+    end
+
     def custom_mails_params
-      params.require(:custom_mails).permit(:subject, :content)
+      params.require(:custom_mail).permit(:subject, :content)
     end
 end

--- a/app/controllers/users/logix_controller.rb
+++ b/app/controllers/users/logix_controller.rb
@@ -49,7 +49,8 @@ class Users::LogixController < ApplicationController
   private
 
     def profile_params
-      params.require(:user).permit(:name, :profile_picture, :country, :educational_institute)
+      params.require(:user).permit(:name, :profile_picture, :country, :educational_institute,
+       :subscribed)
     end
 
     def set_user

--- a/app/decorators/profile_decorator.rb
+++ b/app/decorators/profile_decorator.rb
@@ -17,4 +17,8 @@ class ProfileDecorator < SimpleDelegator
     country = ISO3166::Country[profile.country]
     country ? country.translations[I18n.locale.to_s] || country.name : "Not Entered"
   end
+
+  def mail_subscription
+    profile.subscribed? ? "Subscribed" : "Not Susbcribed"
+  end
 end

--- a/app/helpers/custom_mails_helper.rb
+++ b/app/helpers/custom_mails_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module CustomMailsHelper
+  BATCH_SIZE = 1000
+
+  def send_mail_in_batches(mail)
+    User.subscribed.find_each(batch_size: BATCH_SIZE) do |user|
+      UserMailer.custom_email(user, mail).deliver_later
+    end
+  end
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 class UserMailer < ApplicationMailer
+  def custom_email(user, mail)
+    @user = user
+    @mail = mail
+    mail(to: user.email, subject: mail.subject)
+  end
+
   def welcome_email(user)
     @user = user
     @url = "CircuitVerse.org"

--- a/app/models/custom_mail.rb
+++ b/app/models/custom_mail.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class CustomMail < ApplicationRecord
+  belongs_to :sender, class_name: "User", foreign_key: :user_id
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,8 @@ class User < ApplicationRecord
   has_attached_file :profile_picture, styles: { medium: "205X240#", thumb: "100x100>" }, default_url: ":style/Default.jpg"
   validates_attachment_content_type :profile_picture, content_type: /\Aimage\/.*\z/
 
+  scope :subscribed, -> { where(subscribed: true) }
+
   def create_members_from_invitations
     pending_invitations.reload.each do |invitation|
       GroupMember.where(group_id: invitation.group.id, user_id: self.id).first_or_create

--- a/app/policies/custom_mail_policy.rb
+++ b/app/policies/custom_mail_policy.rb
@@ -7,8 +7,4 @@ class CustomMailPolicy < ApplicationPolicy
     @user = user
     @custom_mail = custom_mail
   end
-
-  def new?
-    admin?
-  end
 end

--- a/app/policies/custom_mail_policy.rb
+++ b/app/policies/custom_mail_policy.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CustomMailPolicy < ApplicationPolicy
+  attr_reader :user, :custom_mail
+
+  def initialize(user, custom_mail)
+    @user = user
+    @custom_mail = custom_mail
+  end
+
+  def new?
+    admin?
+  end
+end

--- a/app/views/custom_mails/_form.html.erb
+++ b/app/views/custom_mails/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: CustomMail.new, local: true, multipart: true, id:"mailsForm") do |form| %>
+<%= form_with(model: custom_mail, local: true, multipart: true, id:"mailsForm") do |form| %>
 
   <div class="field">
     <%= form.label :subject %>
@@ -10,7 +10,16 @@
     <%= render "wysiwyg/index" %>
   </div>
 
-  <div class="actions">
+  <div class="actions" onclick="before_submit()">
     <%= form.submit() %>
   </div>
 <% end %>
+
+<script>
+  function before_submit() {
+  $('<input />').attr('type', 'hidden')
+    .attr('name', 'custom_mail[content]')
+    .attr('value', $("#editor").cleanHtml())
+    .appendTo('#mailsForm');
+  }
+</script>

--- a/app/views/custom_mails/_form.html.erb
+++ b/app/views/custom_mails/_form.html.erb
@@ -1,0 +1,16 @@
+<%= form_with(model: CustomMail.new, local: true, multipart: true, id:"mailsForm") do |form| %>
+
+  <div class="field">
+    <%= form.label :subject %>
+    <%= form.text_field :subject %>
+  </div>
+
+  <div class="field" id="wysiwyg">
+    <%= form.label :content %><br>
+    <%= render "wysiwyg/index" %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit() %>
+  </div>
+<% end %>

--- a/app/views/custom_mails/edit.html.erb
+++ b/app/views/custom_mails/edit.html.erb
@@ -1,8 +1,8 @@
 <div class="container">
   <div class="row feature">
     <div class="container">
-      <h1>New Custom Mail</h1>
-      <%= render 'form', custom_mail: CustomMail.new %>
+      <h1>Edit Custom Mail</h1>
+      <%= render 'form', custom_mail: @mail %>
     </div>
   </div>
 </div>

--- a/app/views/custom_mails/new.html.erb
+++ b/app/views/custom_mails/new.html.erb
@@ -1,0 +1,8 @@
+<div class="container">
+  <div class="row feature">
+    <div class="container">
+      <h1>Send Mails</h1>
+      <%= render 'form' %>
+    </div>
+  </div>
+</div>

--- a/app/views/custom_mails/show.html.erb
+++ b/app/views/custom_mails/show.html.erb
@@ -5,4 +5,4 @@
   <%= link_to 'Send', send_custom_mail_path(@mail), class: "send-link" %>
 </div>
 
-<%= render file: "user_mailer/custom_email", layout: "layouts/mailer", mail: @mail %>
+<%= render file: "user_mailer/custom_email", layout: "layouts/mailer", mail: @mail, user: @user %>

--- a/app/views/custom_mails/show.html.erb
+++ b/app/views/custom_mails/show.html.erb
@@ -1,0 +1,7 @@
+<link rel="stylesheet" type="text/css" href="/css/custom_mail.css">
+
+<div class="mail-preview-header">
+  <%= link_to 'Edit', edit_custom_mail_path(@mail) %>
+</div>
+
+<%= render file: "user_mailer/custom_email", layout: "layouts/mailer", mail: @mail %>

--- a/app/views/custom_mails/show.html.erb
+++ b/app/views/custom_mails/show.html.erb
@@ -3,6 +3,7 @@
 <div class="mail-preview-header">
   <%= link_to 'Edit', edit_custom_mail_path(@mail) %>
   <%= link_to 'Send', send_custom_mail_path(@mail), class: "send-link" %>
+  <span class="mail-status"> <%= @mail.sent? ? "Mail has been sent out" : "Mail has not been sent" %> </span>
 </div>
 
 <%= render file: "user_mailer/custom_email", layout: "layouts/mailer", mail: @mail, user: @user %>

--- a/app/views/custom_mails/show.html.erb
+++ b/app/views/custom_mails/show.html.erb
@@ -2,6 +2,7 @@
 
 <div class="mail-preview-header">
   <%= link_to 'Edit', edit_custom_mail_path(@mail) %>
+  <%= link_to 'Send', send_custom_mail_path(@mail), class: "send-link" %>
 </div>
 
 <%= render file: "user_mailer/custom_email", layout: "layouts/mailer", mail: @mail %>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -837,7 +837,7 @@
                 <!--[if mso]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px;"><![endif]-->
                 <div style="color:#8F8F8F;font-family:'Open Sans', Helvetica, Arial, sans-serif;line-height:120%; padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px;">
                   <div style="font-size:12px;line-height:14px;color:#8F8F8F;font-family:'Open Sans', Helvetica, Arial, sans-serif;text-align:left;"><p style="margin: 0;font-size: 11px;line-height: 14px"><span style="font-size: 11px; line-height: 13px;">Copyright © 2018 CircuitVerse, All rights reserved. For any issues, reach out to us <a style="color:#8F8F8F;text-decoration: underline;" title="support@circuitverse.org" href="mailto:support@circuitverse.org" data-mce-selected="1">support@circuitverse.org</a></span><br><span style="font-size: 11px; line-height: 13px;"></span><br>
-                  <% if @mail.present? %> <a style="color:#8F8F8F;text-decoration: underline;" title="support@circuitverse.org" href="<%= "/users/#{@user.id}/profile/edit" %>" data-mce-selected="1">Unsubscribe</a> <% end %> </p></div>
+                  <% if @mail.present? %> <a style="color:#8F8F8F;text-decoration: underline;" title="support@circuitverse.org" href="<%= "#{Rails.configuration.site_url}users/#{@user.id}/profile/edit" %>" data-mce-selected="1">Unsubscribe</a> <% end %> </p></div>
                 </div>
                 <!--[if mso]></td></tr></table><![endif]-->
               </div>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -836,7 +836,8 @@
               <div class="">
                 <!--[if mso]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px;"><![endif]-->
                 <div style="color:#8F8F8F;font-family:'Open Sans', Helvetica, Arial, sans-serif;line-height:120%; padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px;">
-                  <div style="font-size:12px;line-height:14px;color:#8F8F8F;font-family:'Open Sans', Helvetica, Arial, sans-serif;text-align:left;"><p style="margin: 0;font-size: 11px;line-height: 14px"><span style="font-size: 11px; line-height: 13px;">Copyright © 2018 CircuitVerse, All rights reserved. For any issues, reach out to us <a style="color:#8F8F8F;text-decoration: underline;" title="support@circuitverse.org" href="mailto:support@circuitverse.org" data-mce-selected="1">support@circuitverse.org</a></span><br><span style="font-size: 11px; line-height: 13px;"></span><br></p></div>
+                  <div style="font-size:12px;line-height:14px;color:#8F8F8F;font-family:'Open Sans', Helvetica, Arial, sans-serif;text-align:left;"><p style="margin: 0;font-size: 11px;line-height: 14px"><span style="font-size: 11px; line-height: 13px;">Copyright © 2018 CircuitVerse, All rights reserved. For any issues, reach out to us <a style="color:#8F8F8F;text-decoration: underline;" title="support@circuitverse.org" href="mailto:support@circuitverse.org" data-mce-selected="1">support@circuitverse.org</a></span><br><span style="font-size: 11px; line-height: 13px;"></span><br>
+                  <% if @mail.present? %> <a style="color:#8F8F8F;text-decoration: underline;" title="support@circuitverse.org" href="<%= "/users/#{@user.id}/profile/edit" %>" data-mce-selected="1">Unsubscribe</a> <% end %> </p></div>
                 </div>
                 <!--[if mso]></td></tr></table><![endif]-->
               </div>

--- a/app/views/user_mailer/custom_email.html.erb
+++ b/app/views/user_mailer/custom_email.html.erb
@@ -15,8 +15,8 @@
           </div>
 
 
-          <div align="center" class="button-container center " style="padding-right: 10px; padding-left: 10px; padding-top:10px; padding-bottom:10px;">
-            <div style="font-family: Bitter, Georgia, Times, 'Times New Roman', serif; background: white; padding: 20px 10px; color: #7E7E7E">
+          <div class="button-container" style="padding-right: 25px; padding-top:10px; padding-bottom:10px;">
+            <div style="font-family: Bitter, Georgia, Times, 'Times New Roman', serif; background: white; padding: 20px 20px; color: #7E7E7E">
             <%= raw @mail.content %>
           </div>
           </div>

--- a/app/views/user_mailer/custom_email.html.erb
+++ b/app/views/user_mailer/custom_email.html.erb
@@ -1,0 +1,28 @@
+
+<% content_for :title, @mail.subject %>
+
+<div style="background-color:transparent;">
+  <div style="margin: 0 auto;min-width: 320px;max-width: 605px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;" class="block-grid ">
+    <div style="border-collapse: collapse;display: table;width: 100%;background-color:transparent;">
+      <div class="col num12" style="min-width: 320px;max-width: 605px;display: table-cell;vertical-align: top;">
+        <div style="background-color: transparent; width: 100% !important;">
+          <!--[if (!mso)&(!IE)]><!--><div style="border-top: 0px solid transparent; border-left: 0px solid transparent; border-bottom: 0px solid transparent; border-right: 0px solid transparent; padding-top:5px; padding-bottom:5px; padding-right: 0px; padding-left: 0px;"><!--<![endif]-->
+
+
+          <div class="">
+            <!--[if mso]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding-right: 15px; padding-left: 15px; padding-top: 15px; padding-bottom: 15px;"><![endif]-->
+            <!--[if mso]></td></tr></table><![endif]-->
+          </div>
+
+
+          <div align="center" class="button-container center " style="padding-right: 10px; padding-left: 10px; padding-top:10px; padding-bottom:10px;">
+            <div style="font-family: Bitter, Georgia, Times, 'Times New Roman', serif; background: white; padding: 20px 10px; color: #7E7E7E">
+            <%= raw @mail.content %>
+          </div>
+          </div>
+          </div>
+          </div>
+          </div>
+          </div>
+          </div>
+          </div>

--- a/app/views/users/logix/edit.html.erb
+++ b/app/views/users/logix/edit.html.erb
@@ -27,6 +27,11 @@
           <p> <%= image_tag @profile.profile_picture.url(:thumb) %></p>
           <input type="file" class="form-control" id="profile_picture" name="user[profile_picture]" value="<%= @profile.profile_picture %>">
         </div>
+
+        <div class="field form-group">
+          <label for="profile_subscribed">Subscribed to mails: </label>
+          <%= f.check_box :subscribed, {checked: @profile.subscribed?, style: 'margin-top: 0', id: "profile_subscribed"} %>
+        </div>
         <button type="submit" class="btn btn-secondary">Save</button>
       <% end %>
 

--- a/app/views/users/logix/profile.html.erb
+++ b/app/views/users/logix/profile.html.erb
@@ -11,6 +11,7 @@
           <p><strong>Member since: </strong><%= @profile.member_since %> days</p>
           <p><strong>Educational Institution: </strong><%= @profile.educational_institute %></p>
           <p><strong>Country: </strong><%= @profile.country_name %></p>
+          <p><strong>Subscribed to mails: </strong><%= @profile.mail_subscription %></p>
           <% if policy(@user).edit? %>
             <p><a class="btn btn-secondary" href=<%= profile_edit_path(current_user) %> role="button">Edit </a></p>
           <% end %>

--- a/app/views/wysiwyg/_index.html.erb
+++ b/app/views/wysiwyg/_index.html.erb
@@ -91,10 +91,12 @@
     </div>
 
     <div id="editor">
-      <% if @project != nil%>
+      <% if @project.present? %>
         <%=raw @project.description%>
-      <% else %>
+      <% elsif @assignment.present? %>
           <%= raw @assignment.description%>
+      <% elsif @mail.present? %>
+          <%= raw @mail.content %>
       <% end %>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   resources :collaborations
   mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
+  # require 'sidekiq/web'
+  # mount Sidekiq::Web => '/sidekiq'
   # resources :assignment_submissions
   resources :group_members ,only: [:create,:destroy]
   resources :groups do
@@ -8,6 +10,7 @@ Rails.application.routes.draw do
   end
 
   resources :custom_mails, only: [:new, :create, :edit, :show, :update]
+  get '/custom_mails/send_mail/:id', to: 'custom_mails#send_mail', as: 'send_custom_mail'
 
   # grades
   scope '/grades' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,9 @@ Rails.application.routes.draw do
     resources :assignments
   end
 
+  resource :custom_mails, only: [:new, :create] do
+  end
+
   # grades
   scope '/grades' do
     post '/', to: 'grades#create', as: 'grades'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,8 +7,7 @@ Rails.application.routes.draw do
     resources :assignments
   end
 
-  resource :custom_mails, only: [:new, :create] do
-  end
+  resources :custom_mails, only: [:new, :create, :edit, :show, :update]
 
   # grades
   scope '/grades' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,13 @@
 Rails.application.routes.draw do
   resources :collaborations
   mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
-  # require 'sidekiq/web'
-  # mount Sidekiq::Web => '/sidekiq'
+
+  require 'sidekiq/web'
+
+  authenticate :user, lambda { |u| u.admin? } do
+    mount Sidekiq::Web => '/sidekiq'
+  end
+
   # resources :assignment_submissions
   resources :group_members ,only: [:create,:destroy]
   resources :groups do

--- a/db/migrate/20190723154732_add_subscribed_to_users.rb
+++ b/db/migrate/20190723154732_add_subscribed_to_users.rb
@@ -1,0 +1,5 @@
+class AddSubscribedToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :subscribed, :boolean, default: true
+  end
+end

--- a/db/migrate/20190728103204_add_mails_model.rb
+++ b/db/migrate/20190728103204_add_mails_model.rb
@@ -1,0 +1,11 @@
+class AddMailsModel < ActiveRecord::Migration[5.1]
+  def change
+    create_table :custom_mails do |t|
+      t.text :subject
+      t.text :content
+      t.timestamps
+    end
+
+    add_reference :custom_mails, :user, foreign_key: true
+  end
+end

--- a/db/migrate/20190728103204_add_mails_model.rb
+++ b/db/migrate/20190728103204_add_mails_model.rb
@@ -3,6 +3,7 @@ class AddMailsModel < ActiveRecord::Migration[5.1]
     create_table :custom_mails do |t|
       t.text :subject
       t.text :content
+      t.boolean :sent, default: false
       t.timestamps
     end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,49 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190628090620) do
+ActiveRecord::Schema.define(version: 20190723154732) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "ahoy_events", force: :cascade do |t|
+    t.bigint "visit_id"
+    t.bigint "user_id"
+    t.string "name"
+    t.json "properties"
+    t.datetime "time"
+    t.index ["name", "time"], name: "index_ahoy_events_on_name_and_time"
+    t.index ["user_id"], name: "index_ahoy_events_on_user_id"
+    t.index ["visit_id"], name: "index_ahoy_events_on_visit_id"
+  end
+
+  create_table "ahoy_visits", force: :cascade do |t|
+    t.string "visit_token"
+    t.string "visitor_token"
+    t.bigint "user_id"
+    t.string "ip"
+    t.text "user_agent"
+    t.text "referrer"
+    t.string "referring_domain"
+    t.text "landing_page"
+    t.string "browser"
+    t.string "os"
+    t.string "device_type"
+    t.string "country"
+    t.string "region"
+    t.string "city"
+    t.string "utm_source"
+    t.string "utm_medium"
+    t.string "utm_term"
+    t.string "utm_content"
+    t.string "utm_campaign"
+    t.string "app_version"
+    t.string "os_version"
+    t.string "platform"
+    t.datetime "started_at"
+    t.index ["user_id"], name: "index_ahoy_visits_on_user_id"
+    t.index ["visit_token"], name: "index_ahoy_visits_on_visit_token", unique: true
+  end
 
   create_table "assignments", force: :cascade do |t|
     t.string "name"
@@ -185,11 +224,12 @@ ActiveRecord::Schema.define(version: 20190628090620) do
     t.string "uid"
     t.string "profile_picture_file_name"
     t.string "profile_picture_content_type"
-    t.bigint "profile_picture_file_size"
+    t.integer "profile_picture_file_size"
     t.datetime "profile_picture_updated_at"
     t.boolean "admin", default: false
     t.string "country"
     t.string "educational_institute"
+    t.boolean "subscribed", default: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,45 +15,6 @@ ActiveRecord::Schema.define(version: 20190728103204) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "ahoy_events", force: :cascade do |t|
-    t.bigint "visit_id"
-    t.bigint "user_id"
-    t.string "name"
-    t.json "properties"
-    t.datetime "time"
-    t.index ["name", "time"], name: "index_ahoy_events_on_name_and_time"
-    t.index ["user_id"], name: "index_ahoy_events_on_user_id"
-    t.index ["visit_id"], name: "index_ahoy_events_on_visit_id"
-  end
-
-  create_table "ahoy_visits", force: :cascade do |t|
-    t.string "visit_token"
-    t.string "visitor_token"
-    t.bigint "user_id"
-    t.string "ip"
-    t.text "user_agent"
-    t.text "referrer"
-    t.string "referring_domain"
-    t.text "landing_page"
-    t.string "browser"
-    t.string "os"
-    t.string "device_type"
-    t.string "country"
-    t.string "region"
-    t.string "city"
-    t.string "utm_source"
-    t.string "utm_medium"
-    t.string "utm_term"
-    t.string "utm_content"
-    t.string "utm_campaign"
-    t.string "app_version"
-    t.string "os_version"
-    t.string "platform"
-    t.datetime "started_at"
-    t.index ["user_id"], name: "index_ahoy_visits_on_user_id"
-    t.index ["visit_token"], name: "index_ahoy_visits_on_visit_token", unique: true
-  end
-
   create_table "assignments", force: :cascade do |t|
     t.string "name"
     t.datetime "deadline", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -80,6 +80,7 @@ ActiveRecord::Schema.define(version: 20190728103204) do
   create_table "custom_mails", force: :cascade do |t|
     t.text "subject"
     t.text "content"
+    t.boolean "sent", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190723154732) do
+ActiveRecord::Schema.define(version: 20190728103204) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -114,6 +114,15 @@ ActiveRecord::Schema.define(version: 20190723154732) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["commontable_id", "commontable_type"], name: "index_commontator_threads_on_c_id_and_c_type", unique: true
+  end
+
+  create_table "custom_mails", force: :cascade do |t|
+    t.text "subject"
+    t.text "content"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_custom_mails_on_user_id"
   end
 
   create_table "featured_circuits", force: :cascade do |t|
@@ -251,6 +260,7 @@ ActiveRecord::Schema.define(version: 20190723154732) do
   add_foreign_key "assignments", "groups"
   add_foreign_key "collaborations", "projects"
   add_foreign_key "collaborations", "users"
+  add_foreign_key "custom_mails", "users"
   add_foreign_key "featured_circuits", "projects"
   add_foreign_key "grades", "assignments"
   add_foreign_key "grades", "projects"

--- a/lib/mailer_previews/user_mailer_preview.rb
+++ b/lib/mailer_previews/user_mailer_preview.rb
@@ -8,4 +8,10 @@ class UserMailerPreview < ActionMailer::Preview
   def featured_circuit_email
     UserMailer.featured_circuit_email(User.first, Project.first)
   end
+
+  def custom_email
+    mail = CustomMail.new(subject: "Launching Graded Assignments!",
+      content: "<i> Now grade your assignments with CircuitVerse! </i>")
+    UserMailer.custom_email(User.first, mail)
+  end
 end

--- a/public/css/custom_mail.css
+++ b/public/css/custom_mail.css
@@ -6,3 +6,7 @@
     padding: 10px 20px;
     background: #F3F3F3
 }
+
+.send-link {
+    margin-left: 15px;
+}

--- a/public/css/custom_mail.css
+++ b/public/css/custom_mail.css
@@ -1,4 +1,4 @@
-.navbar {
+.navbar, .foot {
     display: none;
 }
 

--- a/public/css/custom_mail.css
+++ b/public/css/custom_mail.css
@@ -10,3 +10,8 @@
 .send-link {
     margin-left: 15px;
 }
+
+.mail-status {
+    color: #7E7E7E;
+    margin-left: 10px;
+}

--- a/public/css/custom_mail.css
+++ b/public/css/custom_mail.css
@@ -1,0 +1,8 @@
+.navbar {
+    display: none;
+}
+
+.mail-preview-header {
+    padding: 10px 20px;
+    background: #F3F3F3
+}

--- a/spec/controllers/custom_mail_controller_spec.rb
+++ b/spec/controllers/custom_mail_controller_spec.rb
@@ -31,6 +31,14 @@ describe CustomMailsController, type: :request do
       end
     end
 
+    describe "#show" do
+      it "should show the mail" do
+        get custom_mail_path(@mail)
+        expect(response.body).to include(@mail.subject)
+        expect(response.body).to include(@mail.content)
+      end
+    end
+
     describe "#update" do
       let(:update_params) do
         {

--- a/spec/controllers/custom_mail_controller_spec.rb
+++ b/spec/controllers/custom_mail_controller_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe CustomMailsController, type: :request do
+  before do
+    @mail = FactoryBot.create(:custom_mail, subject: "Test subject",
+      content: "Test content",
+      sender: FactoryBot.create(:user, subscribed: false))
+  end
+
+  context "admin is signed in" do
+    before do
+      sign_in FactoryBot.create(:user, admin: true, subscribed: false)
+    end
+
+    describe "#create" do
+      let(:create_params) do
+        {
+          custom_mail: {
+            content: "Test content",
+            subject: "Test subject"
+           }
+         }
+      end
+
+      it "should create a new custom mail" do
+        expect {
+          post custom_mails_path, params: create_params
+        }.to change { CustomMail.count }.by(1)
+      end
+    end
+
+    describe "#update" do
+      let(:update_params) do
+        {
+          custom_mail: {
+            subject: "Updated subject"
+          }
+        }
+      end
+
+      it "udpates mails" do
+        expect {
+          put custom_mail_path(@mail), params: update_params
+          @mail.reload
+        }.to change { @mail.subject }.to("Updated subject")
+      end
+    end
+
+    describe "#send_mail" do
+      before do
+        FactoryBot.create(:user, subscribed: true)
+      end
+
+      it "should send all mails" do
+        expect {
+          get send_custom_mail_path(@mail)
+        }.to have_enqueued_job.on_queue("mailers")
+        expect(response.body).to eq("The mails were queued for sending!")
+      end
+    end
+  end
+
+  context "user is not admin" do
+    it "should return not authorized for all routes" do
+      sign_in FactoryBot.create(:user)
+      get send_custom_mail_path(@mail)
+      check_not_authorized(response)
+      put custom_mail_path(@mail), params: { custom_mail: {} }
+      check_not_authorized(response)
+      post custom_mails_path, params: { custom_mail: {} }
+      check_not_authorized(response)
+    end
+  end
+end

--- a/spec/factories/custom_mail.rb
+++ b/spec/factories/custom_mail.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :custom_mail do
+  end
+end

--- a/spec/helpers/custom_mail_helper_spec.rb
+++ b/spec/helpers/custom_mail_helper_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe CustomMailsHelper do
+  SUBSCRIBED_USERS_COUNT = 2
+  UNSUBSCRIBED_USERS_COUNT = 3
+
+  include CustomMailsHelper
+
+  describe "#send_mail_in_batches" do
+    before do
+      (1..SUBSCRIBED_USERS_COUNT).each { FactoryBot.create(:user, subscribed: true) }
+      (1..UNSUBSCRIBED_USERS_COUNT).each { FactoryBot.create(:user, subscribed: false) }
+
+      @mail = FactoryBot.create(:custom_mail, subject: "Test subject",
+        content: "Test content",
+        sender: FactoryBot.create(:user, subscribed: false))
+    end
+
+    it "should send mails to all subscribed users" do
+      expect {
+        send_mail_in_batches(@mail)
+      }.to have_enqueued_job.on_queue("mailers").exactly(SUBSCRIBED_USERS_COUNT).times
+    end
+  end
+end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -6,6 +6,17 @@ RSpec.describe UserMailer, type: :mailer do
   before do
     @user = FactoryBot.create(:user)
     @project = FactoryBot.create(:project, author: @user)
+    @mail = FactoryBot.create(:custom_mail, subject: "Test subject",
+      content: "Test content", sender: FactoryBot.create(:user))
+  end
+
+  describe "#custom_email" do
+    let(:mail) { UserMailer.custom_email(@user, @mail) }
+
+    it "sends custom mail" do
+      expect(mail.to).to eq([@user.email])
+      expect(mail.subject).to eq(@mail.subject)
+    end
   end
 
   describe "#welcome_email" do

--- a/spec/models/custom_mail_spec.rb
+++ b/spec/models/custom_mail_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CustomMail, type: :model do
+  describe "associations" do
+    it { should belong_to(:sender) }
+  end
+end


### PR DESCRIPTION
### Feature description

- `/custom_mails/new` - this route is only available to admins and can be used to send custom emails to subscribed users
![image](https://user-images.githubusercontent.com/22021150/62013810-a069dc80-b1b5-11e9-96a7-f06c4090ad10.png)

- Upon creation a preview of the email is shown with options to edit or send it right away
![image](https://user-images.githubusercontent.com/22021150/62408292-4d908a80-b5e4-11e9-8a0a-ebfdbbc29062.png)


- Users can unsubscribe to e-mails from the profile settings page
![image](https://user-images.githubusercontent.com/22021150/62013841-3dc51080-b1b6-11e9-8f21-6a278eaf3252.png)

#### Notes -

- Users are processed in batch sizes of 1000, currently, there are 7k users.
- User table export is only 2MB in size hence there is no significant load on memory while loading the user data to send mails.

#### TODO - 

- [x] Add tests to increase test coverage
- [x] Provide a way to unsubscribe from mails from with the sent mail


