### PR TITLE
Fix email from proc in commontator config

### DIFF
--- a/config/initializers/commontator.rb
+++ b/config/initializers/commontator.rb
@@ -225,7 +225,8 @@ Commontator.configure do |config|
   #   "no-reply@#{Rails.application.class.parent.to_s.downcase}.com"
   # }
   config.email_from_proc = ->(thread) {
-    "no-reply@#{Rails.application.class.parent.to_s.downcase}.com"
+    # "no-reply@#{Rails.application.class.parent.to_s.downcase}.com"
+    return "#{ENV["CIRCUITVERSE_EMAIL_ID"]}"
   }
 
   # commontable_name_proc


### PR DESCRIPTION
Fixes commontator error. `Net::SMTPFatalError: 553 5.7.1 Sender address rejected: not owned by auth user.`

#### Describe the changes you have made in this pr -

Fixed email_from_proc in `config/initializers/commontator.rb`

### Screenshots of the changes (If any) -

![image](https://user-images.githubusercontent.com/22021150/63109722-797a1b80-bfa7-11e9-91c7-0f0fe30dc7b3.png)



