### PR TITLE
Add separate database config for docker setups

### DIFF
--- a/bin/docker_run
+++ b/bin/docker_run
@@ -1,18 +1,5 @@
 #!/bin/bash
 
-cat << EOF > config/database.yml
-development:
-  adapter: postgresql
-  username: postgres
-  password: postgres
-  database: circuitverse_development
-  encoding: unicode
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  host: db
-  port: 5432
-
-EOF
-
 echo "Waiting for db to be available"
 for i in $(seq 1 30) ; do timeout 1 bash -c "echo > /dev/tcp/db/5432" > /dev/null 2>&1 && status=0 && break || status=$? && sleep 1 ; done
 
@@ -30,5 +17,6 @@ echo "Running db:seed"
 bundle exec rails db:seed
 
 rm -f /circuitverse/tmp/pids/server.pid
+
 echo "Starting on 127.0.0.1:3000"
 bundle exec rails s -p 3000 -b '0.0.0.0'

--- a/config/database.docker.yml
+++ b/config/database.docker.yml
@@ -1,0 +1,9 @@
+development:
+  adapter: postgresql
+  username: postgres
+  password: postgres
+  database: circuitverse_development
+  encoding: unicode
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  host: db
+  port: 5432

--- a/config/sunspot.yml
+++ b/config/sunspot.yml
@@ -8,6 +8,7 @@ production:
     # open_timeout: 0.5
 
 development:
+  disabled: <%= !(ENV["CIRCUITVERSE_USE_SOLR"] == "true") %>
   solr:
     hostname: localhost
     port: 8982

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 20190804064213) do
 
   # These are extensions that must be enabled in order to support this database

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     command: bundle exec sidekiq -q default -q mailers -d
     volumes:
       - .:/circuitverse
+      - ./config/database.docker.yml:/circuitverse/config/database.yml
     environment:
       REDIS_URL: "redis://redis:6379/0"
   web:
@@ -20,6 +21,7 @@ services:
     entrypoint: /circuitverse/bin/docker_run
     volumes:
       - .:/circuitverse
+      - ./config/database.docker.yml:/circuitverse/config/database.yml
     ports:
       - "3000:3000"
     depends_on:
@@ -28,6 +30,7 @@ services:
       - sidekiq
     environment:
       REDIS_URL: "redis://redis:6379/0"
+      CIRCUITVERSE_USE_SOLR: "false"
   redis:
     image: redis
 # volumes:


### PR DESCRIPTION
Fixes #400 

This patch also allows the docker build to run without solr installed in the container and should also fix #451. Setting `disabled: <%= !(ENV["CIRCUITVERSE_USE_SOLR"] == "true") %>` in `sunspot.yml` will disable all requests made to the solr service and the application works smoothly on Postgres. 

While local setups support both Solr and Postgres, the docker setups currently only support Postgres.
After this fix, work on extending local docker setups to use Solr will be required. 
