### PR TITLE
Fixes #479 - Changed line under "Teachers" and "Create Group"

### DIFF
--- a/app/views/logix/teachers.html.erb
+++ b/app/views/logix/teachers.html.erb
@@ -20,7 +20,7 @@
     <div class="col-12 col-md-5">
       <h3 class="card-title">Create Groups</h4>
         <p class="card-text">
-          Teachers can create groups and their students to them! To create a group, simply click on your username and navigate to the groups page. Click on new groups to create a group.
+          Teachers can create groups and add their students to them! To create a group, simply click on your username and navigate to the groups page. Click on new groups to create a group.
         </p>
     </div>
     <div class="col">


### PR DESCRIPTION
added the word "add"

Fixes #479 

![groups-text-missing](https://user-images.githubusercontent.com/24937677/68025419-abf80280-fcd2-11e9-9e98-a63d6e00983f.png)

