### PR TITLE
Changed navbar collapse size from lg to xl

### DIFF
--- a/app/views/logix_assets/_nav.html.erb
+++ b/app/views/logix_assets/_nav.html.erb
@@ -1,5 +1,5 @@
 <link href="/css/search.css" rel="stylesheet">
-<nav class="navbar navbar-expand-lg navbar-dark fixed-top bg-dark" style="padding-right:4.5em;padding-left:4.5em;">
+<nav class="navbar navbar-expand-xl navbar-dark fixed-top bg-dark" style="padding-right:4.5em;padding-left:4.5em;">
   <a class="navbar-brand" href="/"><img src="/img/circuitverse2.svg" alt="Logo" height="25px"></a>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
Fixes #533
The logo doesn't shrink on bigger devices now.
- Changed from "navbar-expand-lg" to "navbar-expand-xl" in nav class
