### PR TITLE
Reject duplicate names for circuits

### DIFF
--- a/public/js/data.js
+++ b/public/js/data.js
@@ -359,6 +359,7 @@ function deleteCurrentCircuit() {
     if (confirmation) {
         $('#' + globalScope.id).remove()
         delete scopeList[globalScope.id]
+        delete circuitNames[circuitNames.indexOf(globalScope.name)]
         switchCircuit(Object.keys(scopeList)[0])
         showMessage("Circuit was successfuly deleted")
     } else

--- a/public/js/data.js
+++ b/public/js/data.js
@@ -1,9 +1,17 @@
 // Function to create new circuit
 // Function creates button in tab, creates scope and switches to this circuit
+
+var circuitNames=[];
+
 function newCircuit(name, id) {
     name = name || prompt("Enter circuit name:");
     name = stripTags(name);
     if (!name) return;
+    if (circuitNames.includes(name)) {
+      alert("The circuit name \""+name+"\" is used.");
+      return;
+    }
+    circuitNames.push(name);
     var scope = new Scope(name);
     if (id) scope.id = id;
     scopeList[scope.id] = scope;

--- a/public/js/data.js
+++ b/public/js/data.js
@@ -2,16 +2,19 @@
 // Function creates button in tab, creates scope and switches to this circuit
 
 var circuitNames=[];
+var projectLoading=false;
 
 function newCircuit(name, id) {
     name = name || prompt("Enter circuit name:");
     name = stripTags(name);
     if (!name) return;
-    if (circuitNames.includes(name)) {
+    if (circuitNames.includes(name) && !projectLoading) {
       alert("The circuit name \"" + name + "\" is used.");
       return;
     }
-    circuitNames.push(name);
+    if (!circuitNames.includes(name)) {
+      circuitNames.push(name);
+    }
     var scope = new Scope(name);
     if (id) scope.id = id;
     scopeList[scope.id] = scope;
@@ -531,6 +534,7 @@ function load(data) {
         return;
     }
 
+    projectLoading=true;
     projectId = data.projectId;
     projectName = data.name;
 
@@ -588,6 +592,7 @@ function load(data) {
     gridUpdate = true
     scheduleUpdate();
 
+    projectLoading=false;
 
 }
 

--- a/public/js/data.js
+++ b/public/js/data.js
@@ -8,7 +8,7 @@ function newCircuit(name, id) {
     name = stripTags(name);
     if (!name) return;
     if (circuitNames.includes(name)) {
-      alert("The circuit name \""+name+"\" is used.");
+      alert("The circuit name \"" + name + "\" is used.");
       return;
     }
     circuitNames.push(name);

--- a/public/js/data.js
+++ b/public/js/data.js
@@ -4,16 +4,24 @@
 var circuitNames=[];
 var projectLoading=false;
 
+function checkExistingCircuit(name) {
+  if (circuitNames.includes(name) && !projectLoading) {
+    return true;
+  }
+  if (!circuitNames.includes(name)) {
+    circuitNames.push(name);
+  }
+  return false;
+}
+
 function newCircuit(name, id) {
     name = name || prompt("Enter circuit name:");
     name = stripTags(name);
     if (!name) return;
-    if (circuitNames.includes(name) && !projectLoading) {
+    existing=checkExistingCircuit(name);
+    if (existing) {
       alert("The circuit name \"" + name + "\" is used.");
       return;
-    }
-    if (!circuitNames.includes(name)) {
-      circuitNames.push(name);
     }
     var scope = new Scope(name);
     if (id) scope.id = id;


### PR DESCRIPTION
Fixes #481, for GCI 2019

#### Describe the changes you have made in this pr -

When a duplicate circuit name is used, an alert of the form `The circuit name "(name here)" is used.` is shown and the circuit is not created.

### Screenshots of the changes (If any) -
![Screen Shot 2019-12-02 at 2 59 20 PM](https://user-images.githubusercontent.com/4466438/69994832-5fdbf000-1514-11ea-89f3-c61c308e2e69.png)