### PR TITLE
[GCI] Fix search category hidden issue

### DIFF
--- a/public/css/search.css
+++ b/public/css/search.css
@@ -51,7 +51,14 @@
     display: flex;
 }
 
+@media (max-width: 350px) {
+    .navbar {
+        padding-left: 1.5em !important;
+    }
+}
+
 .nav-bar-search-select {
+    width: fit-content;
     cursor: pointer;
     -webkit-appearance: none;
     -moz-appearance: none;


### PR DESCRIPTION
Fixes #551 

Use CSS fit-content to ensure that dropdown has enough space.
Before:
![68310783-96ba1400-00d6-11ea-9bfc-43d99c815dc6](https://user-images.githubusercontent.com/26194273/70043119-ed920b00-15fa-11ea-9baa-c8bc6be7fee6.png)

After:
![image](https://user-images.githubusercontent.com/26194273/70129457-b8002700-16b9-11ea-9702-8da8cf163ecc.png)

[GCI task](https://codein.withgoogle.com/dashboard/task-instances/5754230170714112/)
