### PR TITLE
[GCI] Make profile country select responsive and match bootstraps style

### DIFF
--- a/app/views/users/logix/edit.html.erb
+++ b/app/views/users/logix/edit.html.erb
@@ -14,7 +14,7 @@
 
         <div class="field form-group">
           <%= f.label :country %><br/>
-          <%= f.country_select :country,priority_countries: ["IN"], class: "form-control" %>
+          <%= f.country_select :country, { priority_countries: ["IN"] }, { class: "form-control" } %>
         </div>
 
         <div class="field form-group ">


### PR DESCRIPTION
Fixes #577 

#### Describe the changes you have made in this pr -

Make sure the class of the `country_select` is correctly associated with the bootstraps class so it matches the general style and is responsive.

### Screenshots of the changes (If any) -
![screenshot_mobile](https://user-images.githubusercontent.com/31157644/70077065-6051b500-1600-11ea-905b-c50dfe8696dd.png)
![screenshot_desktop](https://user-images.githubusercontent.com/31157644/70077069-62b40f00-1600-11ea-8513-4d118d9650c4.png)
