### PR TITLE
Fix pagination overflowing on smaller screens

### DIFF
--- a/app/views/logix/index.html.erb
+++ b/app/views/logix/index.html.erb
@@ -140,7 +140,7 @@
       <% end %>
     </div>
     <br>
-    <div class"container">
+    <div class="container">
 <%= will_paginate @projects, renderer: PaginateRenderer %>
 
     </div>

--- a/config/initializers/paginate_renderer.rb
+++ b/config/initializers/paginate_renderer.rb
@@ -1,6 +1,6 @@
 class PaginateRenderer < WillPaginate::ActionView::LinkRenderer
   def container_attributes
-    {class: "pagination justify-content-center container"}
+    {class: "pagination justify-content-center"}
   end
 
   def page_number(page)

--- a/public/css/logixRelease.css
+++ b/public/css/logixRelease.css
@@ -110,3 +110,52 @@ a.btn.btn-outline-danger {
 }
 
 
+.pagination .page-link {
+    white-space: nowrap;
+}
+
+@media (max-width: 992px) {
+    .pagination {
+        display: grid;
+        grid-template-columns: 100px repeat(8, 1fr) 100px;
+        grid-template-rows: repeat(2, 1fr);
+    }
+
+    .pagination > :first-child {
+        grid-row: 1 / -1;
+        grid-column: 1;
+    }
+
+    .pagination > :last-child {
+        grid-row: 1 / -1;
+        grid-column: -2;
+    }
+
+    .pagination .page-link, .pagination .page-item, .pagination .mr2 {
+        display: flex;
+        width: 100%;
+        height: 100%;
+        justify-content: center;
+        align-items: center;
+    }
+
+    .pagination .mr2 {
+        border: 1px solid #dee2e6;
+    }
+}
+
+@media (max-width: 700px) {
+    .pagination {
+        display: grid;
+        grid-template-columns: 100px repeat(5, 1fr) 100px;
+        grid-template-rows: repeat(3, 1fr);
+    }
+}
+
+@media (max-width: 500px) {
+    .pagination {
+        display: grid;
+        grid-template-columns: 100px repeat(3, 1fr) 100px;
+        grid-template-rows: repeat(5, 1fr);
+    }
+}

--- a/public/css/search.css
+++ b/public/css/search.css
@@ -1,9 +1,3 @@
-.pagination{
-    display: flex;
-    justify-content: center;
-    margin: 30px;
-}
-
 .results-head {
     margin: 2rem 1rem 0 1.60rem;
 }


### PR DESCRIPTION
Fixes #494

#### Describe the changes you have made in this pr -
Added a media query that will put the pagination into a grid on smaller screens. Also did necessary changes in PaginateRenderer to consistently render the next/previous links so they can be styled accordingly.

**I couldn't check the render script** because I couldn't get to create mock up data in the local database but as far as I understand it, my changes shouldn't break anything.

### Screenshots of the changes (If any) -
![screenshot](https://user-images.githubusercontent.com/19410489/70076141-72325880-15fe-11ea-9105-09163309350c.png)