### PR TITLE
[GCI] Add send to self feature for custom emails

### DIFF
--- a/app/controllers/custom_mails_controller.rb
+++ b/app/controllers/custom_mails_controller.rb
@@ -5,7 +5,7 @@ class CustomMailsController < ApplicationController
 
   before_action :authenticate_user!
   before_action :authorize_admin
-  before_action :set_mail, only: [:edit, :update, :show, :send_mail]
+  before_action :set_mail, only: [:edit, :update, :show, :send_mail, :send_mail_self]
 
   def show
     @user = current_user
@@ -19,8 +19,8 @@ class CustomMailsController < ApplicationController
 
   def create
     @mail = CustomMail.new(subject: custom_mails_params[:subject],
-     content: custom_mails_params[:content],
-     sender: current_user)
+                           content: custom_mails_params[:content],
+                           sender: current_user)
 
     respond_to do |format|
       if @mail.save
@@ -54,7 +54,14 @@ class CustomMailsController < ApplicationController
     render html: "The mails were queued for sending!"
   end
 
+  def send_mail_self
+    send_mail_to_self(current_user, @mail)
+
+    render html: "A mail has been sent to your email!"
+  end
+
   private
+
     def authorize_admin
       authorize CustomMail.new, :admin?
     end

--- a/app/helpers/custom_mails_helper.rb
+++ b/app/helpers/custom_mails_helper.rb
@@ -8,4 +8,8 @@ module CustomMailsHelper
       UserMailer.custom_email(user, mail).deliver_later
     end
   end
+
+  def send_mail_to_self(user, mail)
+    UserMailer.custom_email(user, mail).deliver_later
+  end
 end

--- a/app/views/custom_mails/show.html.erb
+++ b/app/views/custom_mails/show.html.erb
@@ -3,6 +3,7 @@
 <div class="mail-preview-header">
   <%= link_to 'Edit', edit_custom_mail_path(@mail) %>
   <%= link_to 'Send', send_custom_mail_path(@mail), class: "send-link" %>
+  <%= link_to 'Send to self', send_custom_mail_self_path(@mail), class: "send-link" %>
   <span class="mail-status"> <%= @mail.sent? ? "Mail has been sent out" : "Mail has not been sent" %> </span>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
 
   resources :custom_mails, only: [:new, :create, :edit, :show, :update]
   get '/custom_mails/send_mail/:id', to: 'custom_mails#send_mail', as: 'send_custom_mail'
+  get '/custom_mails/send_mail_to_self/:id', to: 'custom_mails#send_mail_self', as: 'send_custom_mail_self'
 
   # grades
   scope '/grades' do

--- a/spec/controllers/custom_mail_controller_spec.rb
+++ b/spec/controllers/custom_mail_controller_spec.rb
@@ -68,6 +68,19 @@ describe CustomMailsController, type: :request do
         expect(response.body).to eq("The mails were queued for sending!")
       end
     end
+
+    describe "#send_mail_self" do
+      before do
+        FactoryBot.create(:user, subscribed: true)
+      end
+
+      it "should send mail to send only" do
+        expect {
+          get send_custom_mail_self_path(@mail)
+        }.to have_enqueued_job.on_queue("mailers")
+        expect(response.body).to eq("A mail has been sent to your email!")
+      end
+    end
   end
 
   context "user is not admin" do


### PR DESCRIPTION
Fixes #425 

#### Describe the changes you have made in this pr -
Added link to send email to self.
[MailCatcher](https://mailcatcher.me/) was used to view mails in development.

### Demonstration video:
![demo](https://user-images.githubusercontent.com/26194273/70201401-8044be00-1751-11ea-917e-fc8ed8a2eb3b.gif)

[GCI task](https://codein.withgoogle.com/dashboard/task-instances/6384327542177792/)

