### PR TITLE
Rectified padding in the heading

### DIFF
--- a/public/css/logixRelease.css
+++ b/public/css/logixRelease.css
@@ -1,3 +1,10 @@
+@media only screen and (max-width: 480px) {
+  /* For mobile phones: */
+  [class*="display-4"] {
+    padding-top:10px;
+  }
+}
+
 p{
     text-align: justify;
 }


### PR DESCRIPTION


#### Fixes 
Added media query for mobile view.

#### Describe the changes you have made in this pr -
Added media query for mobile view to rectify the padding of heading with respect to other elements

solved the issue:
https://github.com/CircuitVerse/CircuitVerse/issues/583
 
### Screenshots of the changes (If any) -
Before the changes the different views are as follows:

![Screenshot (33)](https://user-images.githubusercontent.com/53391296/70262569-99358980-17ba-11ea-9726-1ca435028a8a.png)

![Screenshot (34)](https://user-images.githubusercontent.com/53391296/70262580-9f2b6a80-17ba-11ea-94b1-6775d7589d4e.png)

![Screenshot (35)](https://user-images.githubusercontent.com/53391296/70262587-a3578800-17ba-11ea-9ffb-254ed32e9bf1.png)

After the changes the different views are as follows:

![Screenshot (22)](https://user-images.githubusercontent.com/53391296/70262653-bec29300-17ba-11ea-935d-71d4d211766d.png)

![Screenshot (23)](https://user-images.githubusercontent.com/53391296/70262661-c2eeb080-17ba-11ea-9204-633886fafed8.png)

![Screenshot (32)](https://user-images.githubusercontent.com/53391296/70262670-c7b36480-17ba-11ea-9b9e-7f079cedef1e.png)

