### PR TITLE
New assignment field sizes

### DIFF
--- a/public/WYSIWYG/index.css
+++ b/public/WYSIWYG/index.css
@@ -5,7 +5,7 @@
 #editor {
 	max-height: 250px;
 	height: 250px;
-	width: 815px;
+	/*width: 815px;*/
 	background-color: white;
 	border-collapse: separate;
 	border: 1px solid rgb(204, 204, 204);


### PR DESCRIPTION
#### Describe the changes you have made in this pr - I have removed the element of the CSS which fixes the width of the text input box on the new assignment form. It now will fit to the size of the parent div. Meaning on narrower screens, it won't go beyond the edge of the screen

### Screenshots of the changes (If any) -
Before:
![image](https://user-images.githubusercontent.com/7693055/70277397-376d2380-17aa-11ea-91ae-2ed27fbf933b.png)

After:
![image](https://user-images.githubusercontent.com/7693055/70277480-64213b00-17aa-11ea-9321-6001c6cd1e77.png)

