### PR TITLE
Moved the warning on the grading type to below the form label

### DIFF
--- a/app/views/assignments/_form.html.erb
+++ b/app/views/assignments/_form.html.erb
@@ -1,6 +1,22 @@
+<head>
 <link rel="stylesheet" type="text/css" href="/css/restrictedElements.css">
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js"></script>
 <script src="/js/metadata.json"></script>
+
+<style>
+#label {
+  color:black;
+}
+
+#label em {
+  color:red;
+}
+
+
+</style>
+
+</head>
+
 <%= form_with(model: [group,@assignment], local: true, html: {onsubmit:"before_submit()"}, multipart: true ,id:"assignmentForm") do |form| %>
   <% if @assignment.errors.any? %>
     <div id="error_explanation">
@@ -16,14 +32,13 @@
 
   <div class="field">
     <%= form.label :name %>
-    <%= form.text_field :name, id: :assignment_name %>
+    <%= form.text_field :name, id: :assignment_name, placeholder:"Enter assignment name" %>
   </div>
 
   <% if @assignment.new_record? %>
     <div class="field">
-      <%= form.label :grading_scale %>
-      <p style="color: red"> * Cannot be changed once set </p>
-      <%= form.select :grading_scale, [:no_scale, :letter, :percent, :custom] %>
+      <p id='label'>Grading Scale <em>* Cannot be changed once set<em> </p>
+      <%= form.select :grading_scale, [:no_scale, :letter, :percent, :custom]%>
       <span style="margin-bottom: 2px">
         <div class="tooltip-help assignment-tooltip"> Help
           <div class="right-help">
@@ -44,8 +59,9 @@
 
   <div class="field">
     <%= form.label :deadline %>
-    <input class ="date" id="party" type="datetime-local" name="assignment[deadline]" min="<%= Time.now.strftime("%Y-%m-%dT%H:%M")%>" value="<%= assignment.deadline.strftime("%Y-%m-%dT%H:%M")%>">
+    <input type="datetime-local" name="assignment[deadline]" min="<%= Time.now.strftime("%Y-%m-%dT%H:%M")%>" value="<%= assignment.deadline.strftime("%Y-%m-%dT%H:%M")%>">
   </div>
+
 
   <div class="field" id="wysiwyg">
     <%= form.label :description %><br>
@@ -63,7 +79,7 @@
   <div class="actions">
     <%= form.submit %>
   </div>
-<% end %>
+  <% end %>
 
 <script src="/js/time.js"></script>
 <script type="text/javascript" src="/js/restrict_elements.js"></script>

--- a/app/views/assignments/_form.html.erb
+++ b/app/views/assignments/_form.html.erb
@@ -21,16 +21,16 @@
 
   <% if @assignment.new_record? %>
     <div class="field">
-      <span style="color: red"> * Cannot be changed once set </span>
       <%= form.label :grading_scale %>
+      <p style="color: red"> * Cannot be changed once set </p>
       <%= form.select :grading_scale, [:no_scale, :letter, :percent, :custom] %>
       <span style="margin-bottom: 2px">
         <div class="tooltip-help assignment-tooltip"> Help
           <div class="right-help">
-            <div> <span style="font-style: italic"> percent </span>: Assignment can be graded on a scale of 1-100 </div>
-            <div> <span style="font-style: italic"> letter </span>: Assignment can be graded with letters A-F </div>
-            <div> <span style="font-style: italic"> no_scale </span>: Assignment won't be graded </div>
-            <div> <span style="font-style: italic"> custom </span>: Assignment can be graded as required </div>
+            <div> <span style="font-style: italic; font-weight:bold;"> Percent </span>: Assignment can be graded on a scale of 1-100 </div>
+            <div> <span style="font-style: italic; font-weight:bold;"> Letter </span>: Assignment can be graded with letters A-F </div>
+            <div> <span style="font-style: italic; font-weight:bold;"> No_scale </span>: Assignment will not be graded </div>
+            <div> <span style="font-style: italic; font-weight:bold;"> Custom </span>: Assignment can be graded as required </div>
             <i> </i>
           </div>
         </div>


### PR DESCRIPTION
Part of GCI

@sal2701

#### Describe the changes you have made in this pr - I have moved the grading warning to be below the form label

### Screenshots of the changes (If any) -
![image](https://user-images.githubusercontent.com/7693055/70379900-37486180-192b-11ea-80f4-6ef72717acba.png)

