### PR TITLE
Error message made red colour GCI task issue #548

### DIFF
--- a/public/css/logixRelease.css
+++ b/public/css/logixRelease.css
@@ -109,4 +109,10 @@ a.btn.btn-outline-danger {
     margin-top: 10px;
 }
 
+#error_explanation{
+    color: crimson;
+    background: #cea0a5;
+    border: 1px solid #86181d;
+    padding: 4px;
+    }
 

--- a/public/css/logixRelease.css
+++ b/public/css/logixRelease.css
@@ -110,9 +110,12 @@ a.btn.btn-outline-danger {
 }
 
 #error_explanation{
-    color: crimson;
-    background: #cea0a5;
+    color: red;
+    background: #f0f0f0;
     border: 1px solid #86181d;
     padding: 4px;
-    }
+}
 
+#error_explanation h2{
+    font-size: 1.25rem;
+}


### PR DESCRIPTION
Fixes #
Fixed The color of the text. Made it Red to be notisable.
#### Describe the changes you have made in this pr -
Changed the styles of "#error_messages"
### Screenshots of the changes (If any) -
![aaaa](https://user-images.githubusercontent.com/58560983/70547930-c22d9400-1b97-11ea-83b2-3df2f1d91193.png)


