### PR TITLE
[GCI] New group page styling

### DIFF
--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -11,13 +11,13 @@
     </div>
   <% end %>
 
-  <div class="field">
+  <div class="field form-group">
     <%= form.label :name %>
-    <%= form.text_field :name, id: :group_name %>
+    <%= form.text_field :name, id: :group_name, class: 'form-control' %>
   </div>
 
 
-  <div class="actions">
-    <%= form.submit %>
+  <div class="actions form-group">
+    <%= form.submit "Create Group", class: 'btn btn-primary' %>
   </div>
 <% end %>

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -11,13 +11,13 @@
     </div>
   <% end %>
 
-  <div class="field form-group">
+  <div class="field">
     <%= form.label :name %>
-    <%= form.text_field :name, id: :group_name, class: 'form-control' %>
+    <%= form.text_field :name, id: :group_name %>
   </div>
 
 
-  <div class="actions form-group">
-    <%= form.submit "Create Group", class: 'btn btn-primary' %>
+  <div class="actions">
+    <%= form.submit %>
   </div>
 <% end %>

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row feature">
 
-    <div class="col">
+    <div class="col col-xs-10 col-lg-6 col-md-8 col-s-10 col-centered">
       <h1>Editing Group</h1>
 
       <%= render 'form', group: @group %>

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -6,7 +6,7 @@
     <h1>New Group</h1>
 
     <p>Groups are useful for mentors and teachers, allowing them to create assignments with deadlines to evaluate the progress of group members.
-      More information can be found <a href="https://circuitverse.org/features">here</a>, and the documentation <a href="https://github.com/CircuitVerse/CircuitVerseDocs/blob/master/docs/groups.md">here</a>.
+      More information can be found <a href="https://circuitverse.org/features">here</a>, and the documentation <a href="https://docs.circuitverse.org/#/groups">here</a>.
     </p>
 
       <%= render 'form', group: @group %>

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -1,8 +1,13 @@
 <div class="container">
   <div class="row feature">
 
-    <div class="col">
-      <h1>New Group</h1>
+    <div class="col col-xs-10 col-lg-6 col-md-8 col-s-10 col-centered">
+      
+    <h1>New Group</h1>
+
+    <p>Groups are useful for mentors and teachers, allowing them to create assignments with deadlines to evaluate the progress of group members.
+      More information can be found <a href="https://circuitverse.org/features">here</a>, and the documentation <a href="https://github.com/CircuitVerse/CircuitVerseDocs/blob/master/docs/groups.md">here</a>.
+    </p>
 
       <%= render 'form', group: @group %>
 

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -5,7 +5,7 @@
       
     <h1>New Group</h1>
 
-    <p>Groups are useful for mentors and teachers, allowing them to create assignments with deadlines to evaluate the progress of group members.
+    <p>Groups can be used by mentors to set projects for and give grades to students.
       More information can be found <a href="https://circuitverse.org/features">here</a>, and the documentation <a href="https://docs.circuitverse.org/#/groups">here</a>.
     </p>
 

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -1,13 +1,8 @@
 <div class="container">
   <div class="row feature">
 
-    <div class="col col-xs-10 col-lg-6 col-md-8 col-s-10 col-centered">
-      
-    <h1>New Group</h1>
-
-    <p>Groups are useful for mentors and teachers, allowing them to create assignments with deadlines to evaluate the progress of group members.
-      More information can be found <a href="https://circuitverse.org/features">here</a>, and the documentation <a href="https://github.com/CircuitVerse/CircuitVerseDocs/blob/master/docs/groups.md">here</a>.
-    </p>
+    <div class="col">
+      <h1>New Group</h1>
 
       <%= render 'form', group: @group %>
 


### PR DESCRIPTION
#### Describe the changes you have made in this pr:
Added styling to the page for creating groups so it looks in line with the rest of the site, plus a brief description of what the groups are used for and links to where users can get further informations.

### Screenshots of the changes (If any):
![image](https://user-images.githubusercontent.com/51863168/70829599-07470580-1de6-11ea-80e7-be63afd3592c.png)

For issue #527 
