### PR TITLE
Moved authorisation methods from User model

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -46,30 +46,6 @@ class Project < ApplicationRecord
   # after_commit :send_mail, on: :create
 
   scope :open, -> { where(project_access_type: "Public") }
-  def check_edit_access(user)
-    @user_access =
-        ((!user.nil? and self.author_id == user.id and self.project_submission != true) \
-        or (!user.nil? and Collaboration.find_by(project_id:self.id,user_id:user.id)))
-
-  end
-
-  def check_view_access(user)
-    @user_access =
-        (self.project_access_type != "Private" \
-        or (!user.nil? and self.author_id==user.id) \
-        or (!user.nil? and !self.assignment_id.nil? and self.assignment.group.mentor_id==user.id) \
-        or (!user.nil? and Collaboration.find_by(project_id:self.id,user_id:user.id)) \
-        or (!user.nil? and user.admin))
-  end
-
-
-  def check_direct_view_access(user)
-    @user_access =
-        (self.project_access_type == "Public" or \
-        (self.project_submission == false and  !user.nil? and self.author_id==user.id) or \
-        (!user.nil? and Collaboration.find_by(project_id:self.id,user_id:user.id)) or \
-        (!user.nil? and user.admin))
-  end
 
   def increase_views(user)
 

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -12,24 +12,24 @@ class ProjectPolicy < ApplicationPolicy
   end
 
   def check_edit_access?
-        ((!user.nil? && project.author_id == user.id && project.project_submission != true) \
-        || (!user.nil? && Collaboration.find_by(project_id:project.id,user_id:user.id)))
+    ((!user.nil? && project.author_id == user.id && project.project_submission != true) \
+    || (!user.nil? && Collaboration.find_by(project_id: project.id, user_id: user.id)))
   end
 
   def check_view_access?
-        (project.project_access_type != "Private" \
-        || (!user.nil? && project.author_id==user.id) \
-        || (!user.nil? && !project.assignment_id.nil? && project.assignment.group.mentor_id==user.id) \
-        || (!user.nil? && Collaboration.find_by(project_id:project.id,user_id:user.id)) \
-        || (!user.nil? && user.admin))
+    (project.project_access_type != "Private" \
+    || (!user.nil? && project.author_id == user.id) \
+    || (!user.nil? && !project.assignment_id.nil? && project.assignment.group.mentor_id == user.id) \
+    || (!user.nil? && Collaboration.find_by(project_id: project.id, user_id: user.id)) \
+    || (!user.nil? && user.admin))
   end
 
 
   def check_direct_view_access?
-        (project.project_access_type == "Public"  \
-        || (project.project_submission == false &&  !user.nil? && project.author_id==user.id) \
-        || (!user.nil? && Collaboration.find_by(project_id:project.id,user_id:user.id)) \
-        || (!user.nil? && user.admin))
+    (project.project_access_type == "Public"  \
+    || (project.project_submission == false &&  !user.nil? && project.author_id == user.id) \
+    || (!user.nil? && Collaboration.find_by(project_id: project.id, user_id: user.id)) \
+    || (!user.nil? && user.admin))
   end
 
   def can_feature?

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -53,6 +53,7 @@ class ProjectPolicy < ApplicationPolicy
   def direct_view_access?
     raise @simulator_exception unless check_direct_view_access?
     true
+  end
 
   def embed?
     raise @simulator_exception unless project.project_access_type != "Private"

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -24,10 +24,9 @@ class ProjectPolicy < ApplicationPolicy
     || (!user.nil? && user.admin))
   end
 
-
   def check_direct_view_access?
     (project.project_access_type == "Public"  \
-    || (project.project_submission == false &&  !user.nil? && project.author_id == user.id) \
+    || (project.project_submission == false && !user.nil? && project.author_id == user.id) \
     || (!user.nil? && Collaboration.find_by(project_id: project.id, user_id: user.id)) \
     || (!user.nil? && user.admin))
   end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -92,5 +92,5 @@ RSpec.describe Project, type: :model do
         }.to change { FeaturedCircuit.count }.by(-1)
       end
     end
-  end
+
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -48,31 +48,6 @@ RSpec.describe Project, type: :model do
         end
       end
 
-      describe "#check_edit_access #check_view_access #check_direct_view_access" do
-        it "returns true for author" do
-          expect(@project.check_edit_access(@user)).to be_truthy
-          expect(@project.check_view_access(@user)).to be_truthy
-          expect(@project.check_direct_view_access(@user)).to be_truthy
-        end
-
-        it "returns true for collaborator" do
-          collaborator = FactoryBot.create(:user)
-          FactoryBot.create(:collaboration, project: @project, user: collaborator)
-
-          expect(@project.check_edit_access(collaborator)).to be_truthy
-          expect(@project.check_view_access(collaborator)).to be_truthy
-          expect(@project.check_direct_view_access(collaborator)).to be_truthy
-        end
-
-        it "returns false otherwise" do
-          user = FactoryBot.create(:user)
-          expect(@project.check_edit_access(user)).to be_falsey
-          expect(@project.check_view_access(user)).to be_falsey
-          expect(@project.check_direct_view_access(user)).to be_falsey
-        end
-      end
-    end
-
     context "project submission is true" do
       before do
         @project = FactoryBot.create(
@@ -90,14 +65,6 @@ RSpec.describe Project, type: :model do
           }.to_not have_enqueued_job.on_queue("mailers")
         end
       end
-
-      describe "#check_edit_access #check_direct_view_access" do
-        it "returns false for edit and direct_view access" do
-          expect(@project.check_edit_access(@user)).to be_falsey
-          expect(@project.check_direct_view_access(@user)).to be_falsey
-        end
-      end
-    end
 
     describe "#increase_views" do
       before do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe Project, type: :model do
           }.to have_enqueued_job.on_queue("mailers")
         end
       end
+    end
 
     context "project submission is true" do
       before do
@@ -65,6 +66,7 @@ RSpec.describe Project, type: :model do
           }.to_not have_enqueued_job.on_queue("mailers")
         end
       end
+    end
 
     describe "#increase_views" do
       before do
@@ -92,5 +94,5 @@ RSpec.describe Project, type: :model do
         }.to change { FeaturedCircuit.count }.by(-1)
       end
     end
-
+  end
 end


### PR DESCRIPTION
Moved check edit_access, check_view_access, and check_direct view access to pundit authorization layer
[GCI Task](https://codein.withgoogle.com/dashboard/task-instances/5302389335130112/)
Fixes #663 

#### Describe the changes you have made in this pr -
Moved Authorisation methods to pundit policy
Removed Old Tests
[WIP] Add new tests
