### PR TITLE
Add tooltip for fork and embed buttons

### DIFF
--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -116,10 +116,10 @@
                   <%= link_to 'Delete',user_project_path(@author,@project), method: :delete, data: { confirm: 'Are you sure?' }, class: "card-link" %>
                 <% end %>
             <% end %>
-          <%= link_to 'Fork', create_fork_project_path(@project), class: "card-link" %>
+          <%= link_to 'Fork', create_fork_project_path(@project), class: "card-link", title: "Create a copy and start editing" %>
             <%= link_to 'Back', user_path(@author), class: "card-link" %>
           <% if @project.project_access_type != "Private" %>
-            <a class="card-link" data-toggle="collapse" href="#collapseExample" aria-expanded="false" aria-controls="collapseExample" onclick="embed()" >
+            <a class="card-link" data-toggle="collapse" href="#collapseExample" aria-expanded="false" aria-controls="collapseExample" onclick="embed()" title="Add a preview to your website">
               Embed
             </a>
               <div class="collapse" id="collapseExample">

--- a/app/views/users/logix/_dashboard.html.erb
+++ b/app/views/users/logix/_dashboard.html.erb
@@ -24,7 +24,7 @@
               <% if policy(project).user_access? %>
                   <a href=  "<%= simulator_edit_path(project) %>" class="btn btn-primary" target="_blank"> Launch </a>
               <% else %>
-                  <a href=  "<%= create_fork_project_path(project) %>" class="btn btn-primary" target="_blank"> Fork! </a>
+                  <a href=  "<%= create_fork_project_path(project) %>" class="btn btn-primary" target="_blank" title="Create a copy and start editing"> Fork! </a>
               <% end %>
             </div>
           </div>

--- a/app/views/users/logix/favourites.html.erb
+++ b/app/views/users/logix/favourites.html.erb
@@ -38,7 +38,7 @@
                   <% if policy(project).user_access? %>
                       <a href=  "<%= simulator_edit_path(project) %>" class="btn btn-primary" target="_blank"> Launch </a>
                   <% else %>
-                      <a href=  "<%= create_fork_project_path(project) %>" class="btn btn-primary" target="_blank"> Fork! </a>
+                      <a href=  "<%= create_fork_project_path(project) %>" class="btn btn-primary" target="_blank" title="Create a copy and start editing"> Fork! </a>
                   <% end %>
                 </div>
               </div>


### PR DESCRIPTION
Related #580 (partially fixes, alongside #695 which fixes the second part)

#### Describe the changes you have made in this pr -

Added tooltips when hovering over "fork" and "embed" buttons to make those actions easier to understand.

### Screenshots of the changes (If any) -

![Annotation 2019-12-18 212449](https://user-images.githubusercontent.com/19410489/71189268-d3a32a00-2282-11ea-94fb-b78b6032b808.png)
![Annotation 2019-12-18 212518](https://user-images.githubusercontent.com/19410489/71189310-e584cd00-2282-11ea-913a-d3c064ee10d7.png)
![Annotation 2019-12-18 212504](https://user-images.githubusercontent.com/19410489/71189346-f7ff0680-2282-11ea-901c-72372df1ade7.png)
