### PR TITLE
[GCI] Fix navbar not showing on edit projects page

### DIFF
--- a/app/views/wysiwyg/_index.html.erb
+++ b/app/views/wysiwyg/_index.html.erb
@@ -9,8 +9,6 @@
     <link href="/external/google-code-prettify/prettify.css" rel="stylesheet">
 
 
-    <!--Comment the below line to fix CSS issues-->
-    <link href="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.1/css/bootstrap-combined.no-icons.min.css" rel="stylesheet">
 
     <link href="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.1/css/bootstrap-responsive.min.css" rel="stylesheet">
 		<link href="https://netdna.bootstrapcdn.com/font-awesome/3.0.2/css/font-awesome.css" rel="stylesheet">
@@ -100,6 +98,8 @@
       <% end %>
     </div>
   </div>
+</div>
+  </body>
 
 
 <script>


### PR DESCRIPTION
Fixes #552 

#### Describe the changes you have made in this pr -
Remove extra bootstrap library in wysiwyg view that is causing navbar to be hidden.
Closed `<div>` and `<body>` tags ensure footer is centered.
### Screenshots of the changes (If any) -
![image](https://user-images.githubusercontent.com/26194273/71331147-c8dee280-256b-11ea-9f24-519de136c84a.png)

[GCI task](https://codein.withgoogle.com/dashboard/task-instances/6228986888192000/)
Please review, @aayush-05 
Thanks!