### PR TITLE
[GCI] Move user authorization methods to policy, with tests

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -46,30 +46,6 @@ class Project < ApplicationRecord
   # after_commit :send_mail, on: :create
 
   scope :open, -> { where(project_access_type: "Public") }
-  def check_edit_access(user)
-    @user_access =
-        ((!user.nil? and self.author_id == user.id and self.project_submission != true) \
-        or (!user.nil? and Collaboration.find_by(project_id:self.id,user_id:user.id)))
-
-  end
-
-  def check_view_access(user)
-    @user_access =
-        (self.project_access_type != "Private" \
-        or (!user.nil? and self.author_id==user.id) \
-        or (!user.nil? and !self.assignment_id.nil? and self.assignment.group.mentor_id==user.id) \
-        or (!user.nil? and Collaboration.find_by(project_id:self.id,user_id:user.id)) \
-        or (!user.nil? and user.admin))
-  end
-
-
-  def check_direct_view_access(user)
-    @user_access =
-        (self.project_access_type == "Public" or \
-        (self.project_submission == false and  !user.nil? and self.author_id==user.id) or \
-        (!user.nil? and Collaboration.find_by(project_id:self.id,user_id:user.id)) or \
-        (!user.nil? and user.admin))
-  end
 
   def increase_views(user)
 

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -16,7 +16,28 @@ class ProjectPolicy < ApplicationPolicy
   end
 
   def user_access?
-    project.check_edit_access(user) || (user.present? && user.admin?)
+    check_edit_access? || (user.present? && user.admin?)
+  end
+
+  def check_edit_access?
+    ((!user.nil? && project.author_id == user.id && project.project_submission != true) \
+    || (!user.nil? && Collaboration.find_by(project_id: project.id, user_id: user.id)))
+  end
+
+  def check_view_access?
+    (project.project_access_type != "Private" \
+    || (!user.nil? && project.author_id == user.id) \
+    || (!user.nil? && !project.assignment_id.nil? \
+      && project.assignment.group.mentor_id == user.id) \
+    || (!user.nil? && Collaboration.find_by(project_id: project.id, user_id: user.id)) \
+    || (!user.nil? && user.admin))
+  end
+
+  def check_direct_view_access?
+    (project.project_access_type == "Public"  \
+    || (project.project_submission == false && !user.nil? && project.author_id == user.id) \
+    || (!user.nil? && Collaboration.find_by(project_id: project.id, user_id: user.id)) \
+    || (!user.nil? && user.admin))
   end
 
   def edit_access?
@@ -25,7 +46,12 @@ class ProjectPolicy < ApplicationPolicy
   end
 
   def view_access?
-    raise @simulator_exception unless project.check_view_access(user)
+    raise @simulator_exception unless check_view_access?
+    true
+  end
+
+  def direct_view_access?
+    raise @simulator_exception unless check_direct_view_access?
     true
   end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -47,30 +47,6 @@ RSpec.describe Project, type: :model do
           }.to have_enqueued_job.on_queue("mailers")
         end
       end
-
-      describe "#check_edit_access #check_view_access #check_direct_view_access" do
-        it "returns true for author" do
-          expect(@project.check_edit_access(@user)).to be_truthy
-          expect(@project.check_view_access(@user)).to be_truthy
-          expect(@project.check_direct_view_access(@user)).to be_truthy
-        end
-
-        it "returns true for collaborator" do
-          collaborator = FactoryBot.create(:user)
-          FactoryBot.create(:collaboration, project: @project, user: collaborator)
-
-          expect(@project.check_edit_access(collaborator)).to be_truthy
-          expect(@project.check_view_access(collaborator)).to be_truthy
-          expect(@project.check_direct_view_access(collaborator)).to be_truthy
-        end
-
-        it "returns false otherwise" do
-          user = FactoryBot.create(:user)
-          expect(@project.check_edit_access(user)).to be_falsey
-          expect(@project.check_view_access(user)).to be_falsey
-          expect(@project.check_direct_view_access(user)).to be_falsey
-        end
-      end
     end
 
     context "project submission is true" do
@@ -88,13 +64,6 @@ RSpec.describe Project, type: :model do
           expect {
             @project.send_mail
           }.to_not have_enqueued_job.on_queue("mailers")
-        end
-      end
-
-      describe "#check_edit_access #check_direct_view_access" do
-        it "returns false for edit and direct_view access" do
-          expect(@project.check_edit_access(@user)).to be_falsey
-          expect(@project.check_direct_view_access(@user)).to be_falsey
         end
       end
     end

--- a/spec/policies/project_policy_spec.rb
+++ b/spec/policies/project_policy_spec.rb
@@ -9,6 +9,7 @@ describe ProjectPolicy do
     should permit(:user_access)
     should permit(:edit_access)
     should permit(:view_access)
+    should permit(:direct_view_access)
     should permit(:create_fork)
     should permit(:author_access)
   end
@@ -33,12 +34,13 @@ describe ProjectPolicy do
       let(:user) { FactoryBot.create(:user) }
 
       it { should permit(:view_access) }
+      it { should permit(:direct_view_access) }
       it { should permit(:create_fork) }
       it { should permit(:embed) }
       it { should_not permit(:author_access) }
       it { should_not permit(:user_access) }
 
-      it "should not raise error for edit access" do
+      it "should raise error for edit access" do
         check_auth_exception(subject, :edit_access)
       end
     end
@@ -63,6 +65,20 @@ describe ProjectPolicy do
     it { should_not permit(:create_fork) }
   end
 
+  context "project is assignment submission" do
+    let(:user) { FactoryBot.create(:user) }
+    let(:project) { FactoryBot.create(:project, author: user) }
+
+    before do
+      project.project_submission = true
+    end
+
+    it { should permit(:view_access) }
+    it "should raise error for edit access" do
+      check_auth_exception(subject, :edit_access)
+    end
+  end
+
   context "project is private" do
     let(:project) { FactoryBot.create(:project, author: @author, project_access_type: "Private") }
 
@@ -85,6 +101,7 @@ describe ProjectPolicy do
       it "should raise error" do
         check_auth_exception(subject, :edit_access)
         check_auth_exception(subject, :view_access)
+        check_auth_exception(subject, :direct_view_access)
         check_auth_exception(subject, :embed)
       end
     end


### PR DESCRIPTION
Fixes #663 

#### Describe the changes you have made in this pr -
Move authorization methods from user model to project policy.
Includes tests to ensure no decrease in coverage.


[GCI task](https://codein.withgoogle.com/dashboard/task-instances/6229590968631296/)
