### PR TITLE
[GCI] Add bootstrap search dropdown

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,6 +16,6 @@
 //= require jquery_ujs
 //= require commontator/application
 //= require bootstrap-typeahead-rails
+//= require popper.js/dist/umd/popper.min.js
 //= require bootstrap/dist/js/bootstrap.min.js
-//= require popper.js/dist/popper.min.js
 //= require serviceworker-companion

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,3 +1,5 @@
+<link href="/css/search.css" rel="stylesheet">
+<script src="/js/search.js"></script>
 <nav class="navbar navbar-expand-lg navbar-light bg-white">
   <a class="navbar-brand" href="#">
     <%= image_tag("CircuitVerse.png", class: "logo", alt: "CircuitVerse Logo") %>
@@ -42,5 +44,21 @@
         </li>
       <% end %>
     </ul>
+    <div class="form-inline my-2 my-lg-0" id="nav-search">
+      <%= form_tag("/search", method: "get", id: 'search-box', class: 'nav-search-form') do %>
+        <div class="dropdown show nav-bar-search-select">
+          <a class="btn btn-secondary dropdown-toggle" href="#" role="button" id="dropdownSearchMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            Projects
+            <span class="caret"></span>
+          </a>
+          <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
+            <a class="dropdown-item" href="#">Projects</a>
+            <a class="dropdown-item" href="#">Users</a>
+          </div>
+          <input type="hidden" aria-hidden=true name="resource" value="Projects">
+        </div>
+        <%= text_field_tag :q,params[:q],class:'form-control mr-sm-2',placeholder: 'Search',autocomplete:"off", class: "nav-bar-search-input" %>
+      <% end %>
+    </div>
   </div>
 </nav>

--- a/app/views/logix_assets/_search_bar.html.erb
+++ b/app/views/logix_assets/_search_bar.html.erb
@@ -1,8 +1,17 @@
 <div class="container">
-  <%= form_tag("/search", method: "get", id: 'search-box', class: 'search-box-form') do %>
-    <%= select_tag "resource", options_for_select([ "Users", "Projects" ], resource == "Projects" ? "Projects" : "Users"), class: "search-bar-select", id: "search_type"
-%>
-    <%= text_field_tag :q,params[:q],placeholder: 'Search',autocomplete:"off", class: "search-bar-input"  %>
+  <%= form_tag("/search", method: "get", id: 'search-box', class: 'nav-search-form') do %>
+    <div class="dropdown show search-bar-select">
+      <a class="btn btn-secondary dropdown-toggle" href="#" role="button" id="dropdownSearchMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        Projects
+        <span class="caret"></span>
+      </a>
+      <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
+        <a class="dropdown-item" href="#">Projects</a>
+        <a class="dropdown-item" href="#">Users</a>
+      </div>
+      <input type="hidden" aria-hidden=true name="resource" value="Projects">
+    </div>
+    <%= text_field_tag :q,params[:q],class:'form-control mr-sm-2',placeholder: 'Search',autocomplete:"off", class: "search-bar-input" %>
   <% end %>
 </div>
 <script type="text/javascript" src="/js/search.js"></script>

--- a/public/css/search.css
+++ b/public/css/search.css
@@ -29,16 +29,17 @@
 
 .search-bar-select {
     cursor: pointer;
-    width: 105px;
     -webkit-appearance: none;
     -moz-appearance: none;
     appearance: none;
     border-radius: 3px 0 0 3px;
     border: 1px solid #ced4da;
-    background: url("/img/caret.jpg") 100% / 25% no-repeat #ddd;
-    padding: 0.8rem;
     border: 1px solid rgba(0,0,0,.125);
     font-size: 0.9rem;
+}
+
+.search-bar-select .dropdown-toggle {
+    width: 105px;
 }
 
 .nav-search-form {
@@ -52,9 +53,11 @@
     appearance: none;
     border-radius: 3px 0 0 3px;
     border: 1px solid #ced4da;
-    background: url("/img/caret.jpg") 100% / 25% no-repeat #ddd;
     font-size: 0.8rem;
-    padding-right: 1.6rem;
+}
+
+.nav-bar-search-select .dropdown-toggle {
+    width: 100px;
 }
 
 .nav-bar-search-input {

--- a/public/js/search.js
+++ b/public/js/search.js
@@ -1,6 +1,16 @@
+/* jshint esversion: 6 */
+
 $(document).ready(() => {
     // remove search in nav bar on the search page
     if (window.location.href.includes('search')) {
         $('#nav-search').remove();
     }
+
+    $('.dropdown > div > a').on('click', () => {
+        const $a = $(this);
+        $('#dropdownSearchMenuLink').text($a.html());
+        $('.dropdown .dropdown-menu').removeClass('show');
+        $('.dropdown input[name=resource]').val($a.text());
+        return false;
+    });
 });


### PR DESCRIPTION
Fixes #480

#### Describe the changes you have made in this pr -
The original issue referenced the old UI. The new UI does not have a search button in the navbar. 
I have created a new bootstrap based search dropdown and button for the new UI navbar that works in both light and dark mode ( tested in chrome)

###  Demo video:
![Demo gif](https://user-images.githubusercontent.com/26194273/71541390-253e6980-2993-11ea-8b07-607d477d7682.gif)

[GCI task](https://codein.withgoogle.com/dashboard/task-instances/5815287719395328/)