### PR TITLE
Change social absolute links to relative links

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -42,8 +42,8 @@
         </li>
       <% end %>
       <li class="nav-item px-2 nav-social-icons">
-        <a class="nav-link" href="https://circuitverse.org/facebook" target="_blank"><%= image_tag("logos/facebook-logo.png", :alt => "Facebook logo") %></a>
-        <a class="nav-link" href="https://circuitverse.org/twitter" target="_blank"><%= image_tag("logos/twitter-logo.png", :alt => "Twitter logo") %></a>
+        <a class="nav-link" href="/facebook" target="_blank"><%= image_tag("logos/facebook-logo.png", :alt => "Facebook logo") %></a>
+        <a class="nav-link" href="/twitter" target="_blank"><%= image_tag("logos/twitter-logo.png", :alt => "Twitter logo") %></a>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
Fixes issue found in #783

#### Describe the changes you have made in this pr -
Facebook and twitter links are now relative (`/facebook` instead of `circuitverse.org/facebook`)
