### PR TITLE
Add profanity filter for project description

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
+gem 'language_filter'
 gem "paperclip", ">= 5.2.0"
 gem 'hirb'
 gem 'acts_as_votable','~> 0.12.0'

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -88,11 +88,21 @@ class Project < ApplicationRecord
   end
 
   validate :check_validity
+  validate :clean_description
   private
   def check_validity
     if project_access_type != "Private" and !assignment_id.nil?
       errors.add(:project_access_type, "Assignment has to be private")
     end
+  end
+
+  def clean_description
+    profanity_filter = LanguageFilter::Filter.new matchlist: :profanity
+    return nil unless profanity_filter.match? description
+    errors.add(
+      :description,
+      "contains inappropriate language: #{profanity_filter.matched(description).join(', ')}"
+    )
   end
 
   def check_and_remove_featured

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -27,6 +27,12 @@ RSpec.describe Project, type: :model do
       project.project_access_type = "Public"
       expect(project).to be_invalid
     end
+    it "doesn't allow profanities in description" do
+      project = FactoryBot.build(:project, assignment: @assignment, author: @user)
+      expect(project).to be_valid
+      project.description = "Ass"
+      expect(project).to be_invalid
+    end
   end
 
   describe "public methods" do


### PR DESCRIPTION
Fixes #761 

#### Describe the changes you have made in this pr -
Added validations in project model to prevent users from posting inappropriate content.
Uses language_filter gem suggested.

### Demo video
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/26194273/71725509-224de800-2e6f-11ea-9f0d-355f250821bb.gif)

