### PR TITLE
An arrow is set to resize the sidebar to its initial position, when it is collapsed

### DIFF
--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -128,6 +128,11 @@
             <span class="glyphicon glyphicon-zoom-in" aria-hidden="true"></span>
           </button>
         </div>
+        <div style="position: absolute; float: left; padding: 5px; top: 15px; z-index: 100;">
+        <button id="reSizeSideBar" style="display: none" type="button" class="btn">
+          <span><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M13 7v-6l11 11-11 11v-6h-13v-10z"/></svg></span>
+        </button>
+        </div>
         <div class="sk-folding-cube loadingIcon" style="display:none;position:absolute; right:50%; bottom:50%; z-index:100">
           <div class="sk-cube1 sk-cube"></div>
           <div class="sk-cube2 sk-cube"></div>

--- a/public/js/UX.js
+++ b/public/js/UX.js
@@ -75,7 +75,15 @@ function setupUI() {
 
     $("#sideBar").resizable({
         handles: 'e',
-        // minWidth:270,
+        minWidth: 5,
+        stop() {
+            if ($("#sideBar").width() < 32) {
+                document.getElementById("reSizeSideBar").removeAttribute('style');
+            }
+            else if ($("#sideBar").width() >= 32) {
+                document.getElementById("reSizeSideBar").style = "display: none";
+            }
+        }
     });
     $("#menu").accordion({
         collapsible: true,
@@ -86,6 +94,13 @@ function setupUI() {
     // handles: 'n',
     //     // minHeight:200,
     // });
+
+    $('#reSizeSideBar').click(function () {
+        document.getElementById("sideBar").removeAttribute('style');
+        document.getElementById("sideBar").style = "overflow: hidden scroll;overflow-x: hidden;overflow-y: scroll;";
+        document.getElementById("reSizeSideBar").style = "display: none;";
+        resetup();
+    });
 
     $('.logixModules').mousedown(function () {
         //////console.log(smartDropXX,smartDropYY);


### PR DESCRIPTION
Fixes: #471 

#### Describe the changes you have made in this pr -
When the sidebar is closed(collapsed) it can't be opened again ,So a arrow is displayed to set the size of the sidebar back to its initial position only when the side bar is completely closed.
This makes the sidebar not be accessible and currently only reloading the page is an option.
This PR will fix that problem by setting the sidebar back to its initial size.

### Screenshots of the changes (If any) -
![CircuitVerse - Digital Circuit Simulator online - Google Chrome 2020-01-19 13-15-25](https://user-images.githubusercontent.com/58560983/72678129-efd7f800-3ac8-11ea-83e7-93d28f255705.gif)
