### PR TITLE
Remove Unwanted Popups while Editing Label

### DIFF
--- a/public/js/listeners.js
+++ b/public/js/listeners.js
@@ -190,13 +190,6 @@ function startListeners() {
             // e.preventDefault(); //browsers normally open a new tab
             simulationArea.changeClockTime(prompt("Enter Time:"));
         }
-        if ((e.keyCode == 108 || e.keyCode == 76) && simulationArea.lastSelected != undefined) {
-            if (simulationArea.lastSelected.setLabel !== undefined){
-                var labl = prompt("Enter The Label : ", simulationArea.lastSelected.label);
-                if(labl)
-                    simulationArea.lastSelected.setLabel(labl);
-            }
-        }
     })
 
     document.getElementById("simulationArea").addEventListener('dblclick', function(e) {


### PR DESCRIPTION
Fixes #852

#### Describe the changes you have made in this pr -
I have removed the Unwanted pop-up when editing element's label in simulator. Actually this was due to pressing of L or l key in the simulator selected area while editing label. 
This is really a rare case when you see that pop-up while changing the label and also it does not updates the Current Label Name hence I have removed this Piece of Code.

### Screenshots of the changes (If any) - Will update Soon
