### PR TITLE
Email Case Sensitive Fix

### DIFF
--- a/app/helpers/utils.rb
+++ b/app/helpers/utils.rb
@@ -6,7 +6,7 @@ module Utils
   def self.parse_mails(mails)
     mails.split(/[\s,\,]/).select do |email|
       email.present? && URI::MailTo::EMAIL_REGEXP.match(email)
-    end.uniq
+    end.uniq.map(&:downcase)
   end
 
   # Forms notice string for given email input


### PR DESCRIPTION
Fixes Case Sensitive Issue in emails when added to a group. Now all emails are stored in lower case only. 