### PR TITLE
Fixed drop down not padded when text wraps

### DIFF
--- a/public/css/UX.css
+++ b/public/css/UX.css
@@ -776,6 +776,7 @@ div.icon img {
 .dropdown-menu > li > a {
     color: #939393 !important;
     padding: 3px 14px;
+    display: inline-block;
 }
 
 .dropdown-menu > li > a:hover {


### PR DESCRIPTION
Fixes #
Dropdowns didn't pad when text wrapped
#### Describe the changes you have made in this pr -
I made dropdown links of type `display: inline-block;` which makes inline elements have designs like block elements.
### Screenshots of the changes (If any) -
Buggy
![dd-err](https://user-images.githubusercontent.com/31929374/74087063-ef6ec380-4aae-11ea-88c3-c7567e58dc4d.png)
Fixed
![dd-fix](https://user-images.githubusercontent.com/31929374/74087064-f1d11d80-4aae-11ea-88b0-671996f45100.png)

