### PR TITLE
Added validation to group,Assignment,Project names

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -1,5 +1,5 @@
 class Assignment < ApplicationRecord
-
+  validates :name, length: { minimum: 1 }
   belongs_to :group
   has_many :projects, class_name: 'Project', foreign_key: 'assignment_id', dependent: :nullify
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,4 +1,5 @@
 class Group < ApplicationRecord
+  validates :name, length: { minimum: 1 }
   belongs_to :mentor, class_name: 'User'
   has_many :group_members, dependent: :destroy
   has_many :users, through: :group_members

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,7 @@
 class Project < ApplicationRecord
   require "pg_search"
   require "custom_optional_targets/web_push"
+  validates :name, length: { minimum: 1 }
   belongs_to :author, class_name: 'User'
   has_many :forks , class_name: 'Project', foreign_key: 'forked_project_id', dependent: :nullify
   belongs_to :forked_project , class_name: 'Project' , optional: true

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -163,7 +163,7 @@ describe AssignmentsController, type: :request do
         sign_in @mentor
         expect {
           post group_assignments_path(@group), params: { assignment:
-            { description: "group assignment" } }
+            { description: "group assignment", name: "Test Name" } }
         }.to change { Assignment.count }.by(1)
       end
     end

--- a/spec/controllers/simulator_controller_spec.rb
+++ b/spec/controllers/simulator_controller_spec.rb
@@ -19,7 +19,7 @@ describe SimulatorController, type: :request do
         it "creates project with default image" do
           expect_any_instance_of(SimulatorHelper).to receive(:sanitize_data)
           expect {
-            post "/simulator/create_data", params: { image: "" }
+            post "/simulator/create_data", params: { image: "", name: "Test Name" }
           }.to change { Project.count }.by(1)
           expect(response.status).to eq(302)
           created_project = Project.order("created_at").last
@@ -31,7 +31,7 @@ describe SimulatorController, type: :request do
         it "creates project with its own image file" do
           expect {
             post "/simulator/create_data", params: { image:
-              "data:image/jpeg;base64,#{Faker::Alphanumeric.alpha(number: 20)}" }
+              "data:image/jpeg;base64,#{Faker::Alphanumeric.alpha(number: 20)}", name: "Test Name" }
           }.to change { Project.count }.by(1)
           created_project = Project.order("created_at").last
           expect(created_project.image_preview.path.split("/")[-1]).to start_with("preview_")

--- a/spec/factories/group.rb
+++ b/spec/factories/group.rb
@@ -2,5 +2,6 @@
 
 FactoryBot.define do
   factory :group do
+    name { "Test Name" }
   end
 end

--- a/spec/system/assignment_spec.rb
+++ b/spec/system/assignment_spec.rb
@@ -28,6 +28,20 @@ describe "Assignments", type: :system do
       check_show_page(name, deadline, description, "Input, Button, Power")
     end
 
+    it "should not create assignment when name is blank" do
+      sign_in @mentor
+      visit new_group_assignment_path(@group)
+
+      name = nil
+      deadline = Faker::Date.forward(days: 23)
+      description = Faker::Lorem.sentence
+
+      fill_assignments(name, deadline, description, grading: true)
+
+      click_button "Create Assignment"
+      expect(page).to have_text("Name is too short (minimum is 1 character)")
+    end
+
     it "should be able to edit assignment" do
       sign_in @mentor
       @assignment = FactoryBot.create(:assignment, group: @group)

--- a/spec/system/group_spec.rb
+++ b/spec/system/group_spec.rb
@@ -26,6 +26,13 @@ describe "Group management", type: :system do
     expect(page).to have_text("Group was successfully created.")
   end
 
+  it "should not create a group when name is blank" do
+    visit "/groups/new"
+    fill_in "group[name]", with: ""
+    click_button "Create Group"
+
+    expect(page).to have_text("Name is too short (minimum is 1 character)")
+  end
 
   it "should add a member to the group" do
     visit "/groups/#{@group.id}"


### PR DESCRIPTION
Fixes  https://github.com/CircuitVerse/CircuitVerse/issues/598


#### Describe the changes you have made in this pr -
- Added validation to the Group, Assignment, Project names so that name's cannot be blank.
- Also added system tests for group,assignment.
### Screenshots of the changes -

### Project:
![CircuitVerse - Digital Circuit Simulator online](https://user-images.githubusercontent.com/49101492/74155321-66849300-4c3a-11ea-9b68-1bcc2cbb16fd.gif)


For Assignment and Group, it works in the same way

