### PR TITLE
Project Name Position Changed to Static

### DIFF
--- a/public/css/UX.css
+++ b/public/css/UX.css
@@ -93,7 +93,7 @@ button:focus {
     margin: 0 auto;
     text-align: center;
     font-size: 1.4em;
-    position: absolute;
+    position: static;
     left: 50%;
     display: block;
     width: 500px;


### PR DESCRIPTION
Fixes #807 

#### Describe the changes you have made in this pr -
The Project Name position has been changed to static to prevent overlapping of Project name and Help on resizing.

### Screenshots of the changes (If any) -
![patch-13](https://user-images.githubusercontent.com/42182955/74177449-be81c080-4c5f-11ea-830d-eb435199d410.gif)

