### PR TITLE
Adding Config Settings for MailCatcher

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -118,6 +118,7 @@ group :development do
   gem 'rubocop'
   gem 'dotenv', '~> 2.2.1'
   gem 'sunspot_solr'
+  gem "mailcatcher"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -67,7 +67,8 @@ Rails.application.configure do
     :authentication       => :login,
     :enable_starttls_auto => true,
   }
-
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = { :address => "localhost", :port => 1025 }
   config.vapid_public_key = ENV["VAPID_PUBLIC_KEY"] || "BGxnigbQCa435vZ8_3uFdqLC0XJHXtONgEdI-ydMMs0JaBsnpUfLxR1UDagq6_cDwHyhqjw77tTlp0ULZkx8Xos="
   config.vapid_private_key = ENV["VAPID_PRIVATE_KEY"] || "FkEMkOQHvMybUlCGH-DsOljTJlLzYGb3xEYsFY5Roxk="
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -53,7 +53,6 @@ Rails.application.configure do
 
   config.active_job.queue_adapter = :sidekiq
   config.action_mailer.default_url_options = { host: "http://localhost:8080/" }
-  config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
 


### PR DESCRIPTION
Fixes #664 

#### Describe the changes you have made in this pr -
I have added Config Settings for Mailcatcher . Hence whenever we type `gem install mailcatcher` and then type `mailcatcher` . So Mailcatcher gets activated in the Development Environment and Any emails sent will be catched using this.

### Screenshots of the changes (If any) -
![patch-16](https://user-images.githubusercontent.com/42182955/74407860-e4be8080-4e58-11ea-8e5d-eea1cd474dac.gif)

