### PR TITLE
wire node overlapped on circuit elements is now extendible

### DIFF
--- a/public/js/Node.js
+++ b/public/js/Node.js
@@ -426,7 +426,7 @@ Node.prototype.update = function() {
         simulationArea.hover = this;
     }
 
-    if (simulationArea.mouseDown && ((this.hover && !simulationArea.selected) || simulationArea.lastSelected == this)) {
+    if (simulationArea.mouseDown && ((this.hover && !simulationArea.selected) || simulationArea.lastSelected == this || simulationArea.hover == this)) {
         simulationArea.selected = true;
         simulationArea.lastSelected = this;
         this.clicked = true;

--- a/public/js/logix.js
+++ b/public/js/logix.js
@@ -1159,7 +1159,7 @@ CircuitElement.prototype.update = function() {
         this.hover = false;
     }
 
-    if (simulationArea.mouseDown && (this.clicked)) {
+    if (simulationArea.mouseDown && (this.clicked) && simulationArea.lastSelected == this) {
 
         this.drag();
         if (!simulationArea.shiftDown && simulationArea.multipleObjectSelections.contains(this)) {


### PR DESCRIPTION
Fixes #856

#### Describe the changes you have made in this pr -
I put condition that the node can be extended if it is hovered upon.
And a CircuitElement can be dragged if it was last selected otherwise it was also being dragged when the wire node was being extended.
### Screenshots of the changes (If any) -
