### PR TITLE
[WIP] Fix Illegal Filename Error on Windows

### DIFF
--- a/app/helpers/simulator_helper.rb
+++ b/app/helpers/simulator_helper.rb
@@ -7,7 +7,7 @@ module SimulatorHelper
 
     else
       jpeg       = Base64.decode64(str)
-      image_file = File.new("preview_#{Time.now.getutc.strftime('%Y%m%dT%H%M%S')}.jpeg", "wb")
+      image_file = File.new("preview_#{Time.now.getutc.strftime('%Y%m%dT%H%M%S')}.jpeg", "w+b")
       image_file.write(jpeg)
     end
 

--- a/app/helpers/simulator_helper.rb
+++ b/app/helpers/simulator_helper.rb
@@ -7,7 +7,7 @@ module SimulatorHelper
 
     else
       jpeg       = Base64.decode64(str)
-      image_file = File.new("preview_#{Time.now()}.jpeg", "wb")
+      image_file = File.new("preview_#{Time.now.getutc.strftime('%Y%m%dT%H%M%S%z')}.jpeg", "wb")
       image_file.write(jpeg)
     end
 

--- a/app/helpers/simulator_helper.rb
+++ b/app/helpers/simulator_helper.rb
@@ -7,7 +7,7 @@ module SimulatorHelper
 
     else
       jpeg       = Base64.decode64(str)
-      image_file = File.new("preview_#{Time.now.getutc.strftime('%Y%m%dT%H%M%S%z')}.jpeg", "wb")
+      image_file = File.new("preview_#{Time.now.getutc.strftime('%Y%m%dT%H%M%S')}.jpeg", "wb")
       image_file.write(jpeg)
     end
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,4 +28,4 @@ before_test:
 
 
 test_script:
-  - bundle exec rspec --format RspecJunitFormatter --out test_results/rspec.xml --format progress --tag ~@skip_windows
+  - bundle exec rspec --format RspecJunitFormatter --out test_results/rspec.xml --format progress

--- a/spec/controllers/simulator_controller_spec.rb
+++ b/spec/controllers/simulator_controller_spec.rb
@@ -27,7 +27,7 @@ describe SimulatorController, type: :request do
         end
       end
 
-      context "there is image data", :skip_windows do
+      context "there is image data", do
         it "creates project with its own image file" do
           expect {
             post "/simulator/create_data", params: { image:

--- a/spec/controllers/simulator_controller_spec.rb
+++ b/spec/controllers/simulator_controller_spec.rb
@@ -27,7 +27,7 @@ describe SimulatorController, type: :request do
         end
       end
 
-      context "there is image data", do
+      context "there is image data" do
         it "creates project with its own image file" do
           expect {
             post "/simulator/create_data", params: { image:

--- a/spec/helpers/simulator_helper_spec.rb
+++ b/spec/helpers/simulator_helper_spec.rb
@@ -32,7 +32,7 @@ describe SimulatorHelper do
       end
 
       it "creates new preview file" do
-        expect(File).to receive(:new).with(/^preview_.*\.jpeg$/, "wb")
+        expect(File).to receive(:new).with(/^preview_.*\.jpeg$/, "w+b")
         return_image_file(data_url(Faker::Alphanumeric.alpha))
       end
     end


### PR DESCRIPTION
Fixes #638 

#### Describe the changes you have made in this pr -

1. Removed the `skip_windows` flag
2. Formatted the filename such that it does not contain colons using inbuilt [`strftime`](http://ruby-doc.org/core-2.2.3/Time.html#method-i-strftime) method
