### PR TITLE
Refactor wire.js

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,16 +1,16 @@
 {
-    "extends": "airbnb-base",
-    "globals": {
-    },
-    "rules": {
-        "indent": ["error", 4],
-        "no-undef": 0,
-        "max-len": 0,
-        "no-var": 0,
-        "no-plusplus": 0,
-        "vars-on-top": 0,
-        "no-unused-vars": 0,
-        "max-lines-per-function": 0
-    }
-
+  "extends": "airbnb-base",
+  "globals": {},
+  "rules": {
+    "indent": ["error", 4],
+    "no-undef": 0,
+    "max-len": 0,
+    "no-var": 0,
+    "no-plusplus": 0,
+    "vars-on-top": 0,
+    "no-unused-vars": 0,
+    "max-lines-per-function": 0,
+    "no-param-reassign": 0,
+    "operator-linebreak": ["error", "after"]
+  }
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,10 @@
+{
+    "trailingComma": "es5",
+    "tabWidth": 4,
+    "useTabs": false,
+    "semi": true,
+    "singleQuote": true,
+    "bracketSpacing": true,
+    "arrowParens": "always",
+    "printWidth": 160
+}

--- a/public/js/wire.js
+++ b/public/js/wire.js
@@ -1,166 +1,172 @@
-//wire object
-function Wire(node1, node2, scope) {
+/* jshint esversion: 6 */
+/*
+ * @desc: This file handles operations related to wires
+ */
 
-    this.objectType = "Wire";
-    this.node1 = node1;
-    this.scope = scope;
-    this.node2 = node2;
-    this.type = "horizontal";
+// the globally accessible Wire class
+class Wire {
+    // to load node1, node2 and scope into wire object
+    constructor(node1, node2, scope) {
+        this.objectType = 'Wire';
+        this.node1 = node1;
+        this.scope = scope;
+        this.node2 = node2;
+        this.type = 'horizontal';
 
-
-
-    this.updateData();
-    this.scope.wires.push(this);
-	forceResetNodes=true;
-
-
-}
-
-//if data changes
-Wire.prototype.updateData = function() {
-
-    this.x1 = this.node1.absX();
-    this.y1 = this.node1.absY();
-    this.x2 = this.node2.absX();
-    this.y2 = this.node2.absY();
-    if (this.x1 == this.x2) this.type = "vertical";
-}
-
-Wire.prototype.updateScope=function(scope){
-    this.scope=scope;
-    this.checkConnections();
-}
-
-//to check if nodes are disconnected
-Wire.prototype.checkConnections = function() {
-    var check = this.node1.deleted||this.node2.deleted||!this.node1.connections.contains(this.node2) || !this.node2.connections.contains(this.node1);
-    if (check) this.delete();
-    return check;
-}
-
-
-Wire.prototype.update = function() {
-
-    if(embed)return;
-
-    if(this.node1.absX()==this.node2.absX()){
-        this.x1=this.x2=this.node1.absX();
-        this.type="vertical";
-    }
-    else if(this.node1.absY()==this.node2.absY()){
-        this.y1=this.y2=this.node1.absY();
-        this.type="horizontal";
+        this.updateData();
+        this.scope.wires.push(this);
+        forceResetNodes = true;
     }
 
-    var updated = false;
-    if (wireToBeChecked && this.checkConnections()) {
-        this.delete();
-        return;
-    } // SLOW , REMOVE
-    if (simulationArea.shiftDown==false&&simulationArea.mouseDown == true && simulationArea.selected == false && this.checkWithin(simulationArea.mouseDownX, simulationArea.mouseDownY)) {
-        simulationArea.selected = true;
-
-
-        simulationArea.lastSelected = this;
-
-        updated = true;
-    }
-    else if(simulationArea.mouseDown && simulationArea.lastSelected==this&& !this.checkWithin(simulationArea.mouseX, simulationArea.mouseY)){
-        var n = new Node(simulationArea.mouseDownX, simulationArea.mouseDownY, 2, this.scope.root);
-        n.clicked = true;
-        n.wasClicked = true;
-        simulationArea.lastSelected=n;
-        this.converge(n);
-    }
-    if (simulationArea.lastSelected == this) {
-        
+    // to update data whenever any change done to wire
+    updateData() {
+        this.x1 = this.node1.absX();
+        this.y1 = this.node1.absY();
+        this.x2 = this.node2.absX();
+        this.y2 = this.node2.absY();
+        if (this.x1 === this.x2) this.type = 'vertical';
     }
 
-    if (this.node1.deleted || this.node2.deleted){
-        this.delete();
-        return;
-    } //if either of the nodes are deleted
+    // to update scope when changed
+    updateScore() {
+        this.scope = scope;
+        this.checkConnections();
+    }
 
-    if (simulationArea.mouseDown == false) {
-        if (this.type == "horizontal") {
-            if (this.node1.absY() != this.y1) {
-                // if(this.checkConnections()){this.delete();return;}
-                var n = new Node(this.node1.absX(), this.y1, 2, this.scope.root);
-                this.converge(n);
-                updated = true;
-            } else if (this.node2.absY() != this.y2) {
-                // if(this.checkConnections()){this.delete();return;}
-                var n = new Node(this.node2.absX(), this.y2, 2, this.scope.root);
-                this.converge(n);
-                updated = true;
-            }
-        } else if (this.type == "vertical") {
-            if (this.node1.absX() != this.x1) {
-                // if(this.checkConnections()){this.delete();return;}
-                var n = new Node(this.x1, this.node1.absY(), 2, this.scope.root);
-                this.converge(n);
-                updated = true;
-            } else if (this.node2.absX() != this.x2) {
-                // if(this.checkConnections()){this.delete();return;}
-                var n = new Node(this.x2, this.node2.absY(), 2, this.scope.root);
-                this.converge(n);
-                updated = true;
+    // to check validity of connections, disconnected nodes
+    checkConnections() {
+        const check = this.node1.deleted || this.node2.deleted || !this.node1.connections.contains(this.node2) || !this.node2.connections.contains(this.node1);
+        if (check) this.delete();
+        return check;
+    }
+
+    // to update the state of wire
+    update() {
+        let updated = false;
+        if (embed) return updated;
+
+        if (this.node1.absX() === this.node2.absX()) {
+            this.x1 = this.node1.absX();
+            this.x2 = this.node1.absX();
+            this.type = 'vertical';
+        } else if (this.node1.absY() === this.node2.absY()) {
+            this.y1 = this.node1.absY();
+            this.y2 = this.node1.absY();
+            this.type = 'horizontal';
+        }
+
+        if (wireToBeChecked && this.checkConnections()) {
+            this.delete();
+            return updated;
+        } // SLOW , REMOVE
+
+        if (
+            simulationArea.shiftDown === false &&
+            simulationArea.mouseDown === true &&
+            simulationArea.selected === false &&
+            this.checkWithin(simulationArea.mouseDownX, simulationArea.mouseDownY)
+        ) {
+            simulationArea.selected = true;
+            simulationArea.lastSelected = this;
+            updated = true;
+        } else if (simulationArea.mouseDown && simulationArea.lastSelected === this && !this.checkWithin(simulationArea.mouseX, simulationArea.mouseY)) {
+            const n = new Node(simulationArea.mouseDownX, simulationArea.mouseDownY, 2, this.scope.root);
+            n.clicked = true;
+            n.wasClicked = true;
+            simulationArea.lastSelected = n;
+            this.converge(n);
+        }
+        /*
+        * @reason: not clear why this was added
+        *
+        if (simulationArea.lastSelected == this) {
+
+        }
+        */
+
+        // if either of the nodes are deleted
+        if (this.node1.deleted || this.node2.deleted) {
+            this.delete();
+            return updated;
+        }
+
+        if (simulationArea.mouseDown === false) {
+            if (this.type === 'horizontal') {
+                if (this.node1.absY() !== this.y1) {
+                    // if(this.checkConnections()){this.delete();return;}
+                    this.converge(new Node(this.node1.absX(), this.y1, 2, this.scope.root));
+                    updated = true;
+                } else if (this.node2.absY() !== this.y2) {
+                    // if(this.checkConnections()){this.delete();return;}
+                    this.converge(new Node(this.node2.absX(), this.y2, 2, this.scope.root));
+                    updated = true;
+                }
+            } else if (this.type === 'vertical') {
+                if (this.node1.absX() !== this.x1) {
+                    // if(this.checkConnections()){this.delete();return;}
+                    this.converge(new Node(this.x1, this.node1.absY(), 2, this.scope.root));
+                    updated = true;
+                } else if (this.node2.absX() !== this.x2) {
+                    // if(this.checkConnections()){this.delete();return;}
+                    this.converge(new Node(this.x2, this.node2.absY(), 2, this.scope.root));
+                    updated = true;
+                }
             }
         }
+        return updated;
     }
-    return updated;
-}
-Wire.prototype.draw = function() {
 
-// for calculating min-max Width,min-max Height
+    // for calculating min-max Width,min-max Height
+    draw() {
+        let color;
+        ctx = simulationArea.context;
 
-    ctx = simulationArea.context;
+        if (simulationArea.lastSelected === this) {
+            color = 'blue';
+        } else if (this.node1.value === undefined || this.node2.value === undefined) {
+            color = 'red';
+        } else if (this.node1.bitWidth === 1) {
+            color = ['red', 'DarkGreen', 'Lime'][this.node1.value + 1];
+        } else {
+            color = 'black';
+        }
+        drawLine(ctx, this.node1.absX(), this.node1.absY(), this.node2.absX(), this.node2.absY(), color, 3);
+    }
 
-    var color;
-    if (simulationArea.lastSelected == this)
-        color = "blue";
-    else if (this.node1.value == undefined||this.node2.value == undefined)
-        color = "red";
-    else if (this.node1.bitWidth == 1)
-        color = ["red", "DarkGreen", "Lime"][this.node1.value + 1];
-    else
-        color = "black";
-    drawLine(ctx, this.node1.absX(), this.node1.absY(), this.node2.absX(), this.node2.absY(), color, 3);
+    // checks if node lies on wire
+    checkConvergence(n) {
+        return this.checkWithin(n.absX(), n.absY());
+    }
 
-}
+    checkWithin(x, y) {
+        if (this.type === 'horizontal' && y === this.node2.absY()) {
+            if (this.node1.absX() < this.node2.absX() && x > this.node1.absX() && x < this.node2.absX()) return true;
+            if (this.node1.absX() > this.node2.absX() && x < this.node1.absX() && x > this.node2.absX()) return true;
+        }
 
-// checks if node lies on wire
-Wire.prototype.checkConvergence = function(n) {
-    return this.checkWithin(n.absX(), n.absY());
-}
-// fn checks if coordinate lies on wire
-Wire.prototype.checkWithin = function(x, y) {
-    if ((this.type == "horizontal") && (this.node1.absX() < this.node2.absX()) && (x > this.node1.absX()) && (x < this.node2.absX()) && (y === this.node2.absY()))
-        return true;
-    else if ((this.type == "horizontal") && (this.node1.absX() > this.node2.absX()) && (x < this.node1.absX()) && (x > this.node2.absX()) && (y === this.node2.absY()))
-        return true;
-    else if ((this.type == 'vertical') && (this.node1.absY() < this.node2.absY()) && (y > this.node1.absY()) && (y < this.node2.absY()) && (x === this.node2.absX()))
-        return true;
-    else if ((this.type == 'vertical') && (this.node1.absY() > this.node2.absY()) && (y < this.node1.absY()) && (y > this.node2.absY()) && (x === this.node2.absX()))
-        return true
-    return false;
+        if (this.type === 'vertical' && x === this.node2.absX()) {
+            if (this.node1.absY() < this.node2.absY() && y > this.node1.absY() && y < this.node2.absY()) return true;
+            if (this.node1.absY() > this.node2.absY() && y < this.node1.absY() && y > this.node2.absY()) return true;
+        }
 
-}
+        return false;
+    }
 
-//add intermediate node between these 2 nodes
-Wire.prototype.converge = function(n) {
-    this.node1.connect(n);
-    this.node2.connect(n);
-    this.delete();
-}
+    // add intermediate node between these 2 nodes
+    converge(n) {
+        this.node1.connect(n);
+        this.node2.connect(n);
+        this.delete();
+    }
 
-
-Wire.prototype.delete = function() {
-	forceResetNodes=true;
-    updateSimulation = true;
-    this.node1.connections.clean(this.node2);
-    this.node2.connections.clean(this.node1);
-    this.scope.wires.clean(this);
-    this.node1.checkDeleted();
-    this.node2.checkDeleted();
+    // to delete the wire
+    delete() {
+        forceResetNodes = true;
+        updateSimulation = true;
+        this.node1.connections.clean(this.node2);
+        this.node2.connections.clean(this.node1);
+        this.scope.wires.clean(this);
+        this.node1.checkDeleted();
+        this.node2.checkDeleted();
+    }
 }


### PR DESCRIPTION
Partial for #905 

Refactor `wire.js` to use modular classes and follow eslint configurations.
Some configs have been edited in favor of the style the code was initially written.
![image](https://user-images.githubusercontent.com/14032427/75020650-2682a300-54b9-11ea-98d7-19fe27bb89b8.png)

~ 194 Problems solved.