### PR TITLE
Flowing text out of div in subcircuit

### DIFF
--- a/public/css/UX.css
+++ b/public/css/UX.css
@@ -68,6 +68,8 @@ button:focus {
     padding: 5px;
     width: 200px;
     margin: 3px;
+    word-wrap:break-word;
+    overflow-x:hidden;
 }
 
 .pannel-heading {


### PR DESCRIPTION
Fixes https://github.com/CircuitVerse/CircuitVerse/issues/899

#### Describe the changes you have made in this pr -
Prevented the overflowing of div when the circuit name is long in subcircuit

### Screenshots of the changes (If any) -
Before:
![Screenshot (57)](https://user-images.githubusercontent.com/49101492/75051383-cfe68a80-54f3-11ea-8dea-ff7bc2a69a28.png)

After:
![Screenshot (56)](https://user-images.githubusercontent.com/49101492/75051406-d96ff280-54f3-11ea-9005-3033f33c76e8.png)
