### PR TITLE
Backspace Enabled in Text Fields

### DIFF
--- a/public/js/listeners.js
+++ b/public/js/listeners.js
@@ -144,7 +144,7 @@ function startListeners() {
             }
         }
 
-        if (e.keyCode == 8 || e.key == "Delete") {
+        if (e.key == "Delete") {
             delete_selected();
         }
 

--- a/public/js/listeners.js
+++ b/public/js/listeners.js
@@ -144,7 +144,7 @@ function startListeners() {
             }
         }
 
-        if (e.key == "Delete") {
+        if (e.keycode == 8 || e.keycode == 46) {
             delete_selected();
         }
 


### PR DESCRIPTION
Fixes #602 

#### Describe the changes you have made in this pr -
Earlier in the website whenever we used to press backspace in the text field in Combinational Analysis then it would not work. 
I have removed the event occurring on pressing backspace as it performs delete_selected() function and that too on the whole page hence it is not able to work whenever the text field pops up.

### Screenshots of the changes (If any) -
Before :
![patch21b](https://user-images.githubusercontent.com/42182955/75327112-d6815300-58a1-11ea-88a5-6c38e7882ad5.gif)
After :
![patch21a](https://user-images.githubusercontent.com/42182955/75327142-e305ab80-58a1-11ea-9bc3-c57c7dd4ea32.gif)
