### PR TITLE
Alignment bug of Tools dropdown list

### DIFF
--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -41,7 +41,7 @@
       <li class="dropdown">
         <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Tools<span class="caret"></span></a>
         <ul class="dropdown-menu">
-          <li class="toolbarButton logixButton" id="createCombinationalAnalysisPrompt"><a>Combinational   &nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp  &nbsp&nbsp&nbsp Analysis</a></li>
+          <li class="toolbarButton logixButton" id="createCombinationalAnalysisPrompt"><a>Combinational   &nbsp&nbsp&nbsp&nbsp&nbsp  &nbsp&nbsp&nbsp Analysis</a></li>
           <li class="toolbarButton logixButton" id="startPlot"><a>Start Plot</a></li>
           <li class="toolbarButton logixButton" id="createSaveAsImgPrompt" ><a>Download Image</a></li>
         </ul>

--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -41,7 +41,7 @@
       <li class="dropdown">
         <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Tools<span class="caret"></span></a>
         <ul class="dropdown-menu">
-          <li class="toolbarButton logixButton" id="createCombinationalAnalysisPrompt"><a>Combinational Analysis</a></li>
+          <li class="toolbarButton logixButton" id="createCombinationalAnalysisPrompt"><a>Combinational &nbsp Analysis</a></li>
           <li class="toolbarButton logixButton" id="startPlot"><a>Start Plot</a></li>
           <li class="toolbarButton logixButton" id="createSaveAsImgPrompt" ><a>Download Image</a></li>
         </ul>

--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -41,7 +41,7 @@
       <li class="dropdown">
         <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Tools<span class="caret"></span></a>
         <ul class="dropdown-menu">
-          <li class="toolbarButton logixButton" id="createCombinationalAnalysisPrompt"><a>Combinational &nbsp Analysis</a></li>
+          <li class="toolbarButton logixButton" id="createCombinationalAnalysisPrompt"><a>Combinational   &nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp  &nbsp&nbsp&nbsp Analysis</a></li>
           <li class="toolbarButton logixButton" id="startPlot"><a>Start Plot</a></li>
           <li class="toolbarButton logixButton" id="createSaveAsImgPrompt" ><a>Download Image</a></li>
         </ul>


### PR DESCRIPTION
Fixes # Alignment of combinational analysis tab

#### Describe the changes you have made in this pr -
In tools tab on simulator combinational analysis tab was not properly indented

### Screenshots of the changes (If any) -
### Before
<img width="740" alt="Screenshot 2020-02-27 at 5 45 12 AM" src="https://user-images.githubusercontent.com/52625656/75400178-80a1bf00-5924-11ea-8532-d824e267b757.png">

### Now

<img width="742" alt="Screenshot 2020-02-27 at 5 43 07 AM" src="https://user-images.githubusercontent.com/52625656/75400154-754e9380-5924-11ea-8ad1-b8bf3a34f5e6.png">
