### PR TITLE
Enabled Copy/Paste Feature in Text Fields

### DIFF
--- a/public/js/listeners.js
+++ b/public/js/listeners.js
@@ -52,7 +52,11 @@ function startListeners() {
     });
     window.addEventListener('mousemove', onMouseMove);
 
-
+    window.addEventListener('copy', (event) => {
+        const selection = document.getSelection();
+        event.clipboardData.setData('text/plain', selection.toString());
+        event.preventDefault();
+    });
 
     window.addEventListener('keydown', function(e) {
 
@@ -102,16 +106,16 @@ function startListeners() {
         wireToBeChecked = 1;
 
         // Needs to be deprecated, moved to more recent listeners
-        if (simulationArea.controlDown && (e.key == "C" || e.key == "c")) {
+       // if (simulationArea.controlDown && (e.key == "C" || e.key == "c")) {
             //    simulationArea.copyList=simulationArea.multipleObjectSelections.slice();
             //    if(simulationArea.lastSelected&&simulationArea.lastSelected!==simulationArea.root&&!simulationArea.copyList.contains(simulationArea.lastSelected)){
             //        simulationArea.copyList.push(simulationArea.lastSelected);
             //    }
             //    copy(simulationArea.copyList);
-        }
-        if (simulationArea.controlDown && (e.key == "V" || e.key == "v")) {
+       // }
+       // if (simulationArea.controlDown && (e.key == "V" || e.key == "v")) {
             //    paste(simulationArea.copyData);
-        }
+       // }
 
         if (simulationArea.lastSelected && simulationArea.lastSelected.keyDown) {
             if (e.key.toString().length == 1 || e.key.toString() == "Backspace") {


### PR DESCRIPTION
Fixes #470 

#### Describe the changes you have made in this pr -
Here I have added a Javascript function to enable Copy/Paste feature. Before that whenever we used to copy the text in text field to clipboard then it used to copy the circuit element and not the text but now the text gets copied and nothing else. We can now copy and paste from the Project Name , Circuit Name and Combinational Analysis Popup Text fields.

### Screenshots of the changes (If any) -
![patch22](https://user-images.githubusercontent.com/42182955/75404066-71743e80-592f-11ea-882c-dd4cd0407161.gif)

