### PR TITLE
Adding Back Button To Edit Profile page

### DIFF
--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -6,6 +6,10 @@
 .btn-secondary-profile-page {
   background-color: $green;
   color: $pure-white;
+  margin-bottom: 4px;
+  margin-left: 4px;
+  margin-right: 4px;
+  margin-top: 4px;
   padding: .5em 3em;
 }
 

--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -13,6 +13,21 @@
   padding: .5em 3em;
 }
 
+.btn-secondary-to-profile-page {
+  color: $teal;
+  margin-bottom: 4px;
+  margin-left: 4px;
+  margin-right: 4px;
+  margin-top: 4px;
+  padding: .5em 3em;
+  text-decoration: underline;
+
+  &:hover {
+    color: $green;
+    text-decoration: none;
+  }
+}
+
 .edit-profile-page-bg {
   background-color: $slightblack;
 }

--- a/app/views/users/logix/edit.html.erb
+++ b/app/views/users/logix/edit.html.erb
@@ -46,7 +46,8 @@
           </label>
         </div>
 
-         <button type="submit" class="btn btn-secondary btn-secondary-profile-page rounded-0">Save</button>
+         <a class="btn btn-secondary btn-secondary-profile-page rounded-0 float-left" href="<%= profile_path(current_user) %>">Back </a>
+         <button type="submit" class="btn btn-secondary btn-secondary-profile-page rounded-0 float-sm-left float-md-right float-lg-right float-xl-right">Save</button>
       <% end %>
 
     </div>

--- a/app/views/users/logix/edit.html.erb
+++ b/app/views/users/logix/edit.html.erb
@@ -46,8 +46,8 @@
           </label>
         </div>
 
-         <a class="btn btn-secondary btn-secondary-profile-page rounded-0 float-left" href="<%= profile_path(current_user) %>">Back </a>
-         <button type="submit" class="btn btn-secondary btn-secondary-profile-page rounded-0 float-sm-left float-md-right float-lg-right float-xl-right">Save</button>
+         <button type="submit" class="btn btn-secondary btn-secondary-profile-page rounded-0 float-left ">Save</button>
+         <a class="btn btn-secondary-to-profile-page rounded-0 float-left " href="<%= profile_path(current_user) %>">Back </a>
       <% end %>
 
     </div>


### PR DESCRIPTION
Fixes #1009  Adding Back Button To Edit Profile page

#### Describe the changes you have made in this PR -
Adding Back Button To Edit Profile page
### Screenshots of the changes (If any) -
<img width="1088" alt="Screenshot 2020-03-04 at 2 49 38 PM" src="https://user-images.githubusercontent.com/52625656/75864068-79e4e180-5e27-11ea-80f0-cf05bd8a9362.png">
<img width="435" alt="Screenshot 2020-03-04 at 2 49 58 PM" src="https://user-images.githubusercontent.com/52625656/75864076-7d786880-5e27-11ea-9b96-f955b9e734ad.png">
