### PR TITLE
Added navigational Feedback to login page

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -49,7 +49,7 @@
         </div>
         </li>
       <% else %>
-        <li class="nav-item px-2">
+        <li class="nav-item px-2 <%= request.path == '/users/sign_in' ? 'active' : '' %>">
           <a class="nav-link text-dark" href="/users/sign_in">Login</a>
         </li>
       <% end %>


### PR DESCRIPTION
Fixes  https://github.com/CircuitVerse/CircuitVerse/issues/1027

#### Describe the changes you have made in this PR -
when we navigate to other pages like teachers or about we  see navigational feedback i.e underline section on navbar in this pr I added the navigational feedback to the login page which was not available

### Screenshots of the changes (If any) -
Before:
![image](https://user-images.githubusercontent.com/49101492/76069587-20acb780-5fb9-11ea-8700-b970c5e9cf9c.png)


After:
![image](https://user-images.githubusercontent.com/49101492/76069721-4e91fc00-5fb9-11ea-9e67-3fde9b355f9c.png)


