### PR TITLE
Fix illustration in login and signup

### DIFF
--- a/app/views/logix/index.html.erb
+++ b/app/views/logix/index.html.erb
@@ -42,7 +42,7 @@
           <h1>Dive into the world of Logic Circuits for free!</h1> <br>
           <p>From simple gates to complex sequential circuits, plot timing diagrams, automatic circuit generation, explore standard ICs, and much more</p>
           <button type="button" class="btn btn-homepage btn-about" onclick="window.location.href = '/simulator';">Launch Simulator</button>
-          <a href="https://learn.circuitverse.org/" class="a-homepage">Learn Logic Design</a>
+          <a href="https://learn.circuitverse.org/" class="btn btn-homepage btn-about" role="button">Learn Logic Design</a>
         </div>
         <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6">
           <%= image_tag "homepage/new_homepage_sketch.png", alt: "HomepageSketch", :class => "homepage-cover center-block" %>

--- a/app/views/logix/index.html.erb
+++ b/app/views/logix/index.html.erb
@@ -42,7 +42,7 @@
           <h1>Dive into the world of Logic Circuits for free!</h1> <br>
           <p>From simple gates to complex sequential circuits, plot timing diagrams, automatic circuit generation, explore standard ICs, and much more</p>
           <button type="button" class="btn btn-homepage btn-about" onclick="window.location.href = '/simulator';">Launch Simulator</button>
-          <a href="https://learn.circuitverse.org/" class="btn btn-homepage btn-about" role="button">Learn Logic Design</a>
+          <a href="https://learn.circuitverse.org/" class="a-homepage">Learn Logic Design</a>
         </div>
         <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6">
           <%= image_tag "homepage/new_homepage_sketch.png", alt: "HomepageSketch", :class => "homepage-cover center-block" %>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,6 +1,6 @@
 <div class="container">
   <div class="row">
-    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 center-block">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 center-block d-none d-md-block">
       <%= image_tag "SVGs/signup.svg", alt: "signup-logo", :class => "signup-cover center-block" %>
       <h5>Get yourself registered to start away with saving circuits, building groups and much more!</h5>
     </div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,6 +1,6 @@
 <div class="container">
   <div class="row">
-    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 center-block">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 center-block d-none d-md-block">
       <%= image_tag "SVGs/login.svg", alt: "login-theme", :class => "signup-cover center-block" %>
       <h5>Welcome back to the Digital Circuit Universe!</h5>
     </div>


### PR DESCRIPTION
**Fixes** #1026 

**Make changes in login and signup page to hide illustration and descriptive text in mobile view
Before Change**
![Untitled](https://user-images.githubusercontent.com/57035408/76142726-4956af00-6096-11ea-9148-59d9cec6d503.png)
![fix10261](https://user-images.githubusercontent.com/57035408/76142730-4cea3600-6096-11ea-9235-1ffea33d3312.png)

**After Change**
![a2](https://user-images.githubusercontent.com/57035408/76138907-4e553780-6071-11ea-812a-a5ebda295ae1.png)
![a1](https://user-images.githubusercontent.com/57035408/76138909-51e8be80-6071-11ea-9d60-0665d0a5c0c6.png)