### PR TITLE
fixed Same name of Group and same name of Assignments should not be their

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -1,5 +1,5 @@
 class Assignment < ApplicationRecord
-  validates :name, length: { minimum: 1 }, uniqueness: true
+  validates :name, length: { minimum: 1 }, uniqueness:{ case_sensitive: false }
   belongs_to :group
   has_many :projects, class_name: 'Project', foreign_key: 'assignment_id', dependent: :nullify
 

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -1,5 +1,5 @@
 class Assignment < ApplicationRecord
-  validates :name, length: { minimum: 1 }
+  validates :name, length: { minimum: 1 }, :uniqueness => true
   belongs_to :group
   has_many :projects, class_name: 'Project', foreign_key: 'assignment_id', dependent: :nullify
 

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -1,5 +1,5 @@
 class Assignment < ApplicationRecord
-  validates :name, length: { minimum: 1 }, uniqueness: { case_sensitive: false }
+  validates :name, length: { minimum: 1 }
   belongs_to :group
   has_many :projects, class_name: 'Project', foreign_key: 'assignment_id', dependent: :nullify
 

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -1,5 +1,5 @@
 class Assignment < ApplicationRecord
-  validates :name, length: { minimum: 1 }, :uniqueness => true
+  validates :name, length: { minimum: 1 }, uniqueness: true
   belongs_to :group
   has_many :projects, class_name: 'Project', foreign_key: 'assignment_id', dependent: :nullify
 

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -1,5 +1,5 @@
 class Assignment < ApplicationRecord
-  validates :name, length: { minimum: 1 }, uniqueness:{ case_sensitive: false }
+  validates :name, length: { minimum: 1 }, uniqueness: { case_sensitive: false }
   belongs_to :group
   has_many :projects, class_name: 'Project', foreign_key: 'assignment_id', dependent: :nullify
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,5 +1,5 @@
 class Group < ApplicationRecord
-  validates :name, length: { minimum: 1 }
+  validates :name, length: { minimum: 1 }, :uniqueness => true
   belongs_to :mentor, class_name: 'User'
   has_many :group_members, dependent: :destroy
   has_many :users, through: :group_members

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,5 +1,5 @@
 class Group < ApplicationRecord
-  validates :name, length: { minimum: 1 }, :uniqueness => true
+  validates :name, length: { minimum: 1 }, uniqueness: true
   belongs_to :mentor, class_name: 'User'
   has_many :group_members, dependent: :destroy
   has_many :users, through: :group_members

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,5 +1,5 @@
 class Group < ApplicationRecord
-  validates :name, length: { minimum: 1 }, uniqueness: true
+  validates :name, length: { minimum: 1 }, uniqueness:{ case_sensitive: false }
   belongs_to :mentor, class_name: 'User'
   has_many :group_members, dependent: :destroy
   has_many :users, through: :group_members

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,5 +1,5 @@
 class Group < ApplicationRecord
-  validates :name, length: { minimum: 1 }, uniqueness:{ case_sensitive: false }
+  validates :name, length: { minimum: 1 }, uniqueness: { case_sensitive: false }
   belongs_to :mentor, class_name: 'User'
   has_many :group_members, dependent: :destroy
   has_many :users, through: :group_members


### PR DESCRIPTION
Fixes  https://github.com/CircuitVerse/CircuitVerse/issues/1051

#### Describe the changes you have made in this PR -
Added uniqueness to the Group name and Assignments name 
### Screenshots of the changes (If any) -
A group name "meet123" already their:
![image](https://user-images.githubusercontent.com/49101492/76145020-a6109480-60ab-11ea-819b-136b0f619023.png)

Creating group of same name "meet123" :
![image](https://user-images.githubusercontent.com/49101492/76145052-ef60e400-60ab-11ea-958c-a9cf7d25c8f0.png)

Assignment of name "yash123":
![image](https://user-images.githubusercontent.com/49101492/76145081-37800680-60ac-11ea-8899-4289a8bacafc.png)

Creating same name of Assignment i.e "yash123"
![image](https://user-images.githubusercontent.com/49101492/76145109-7d3ccf00-60ac-11ea-8768-97ec5b7bf99c.png)


Case Sensitivity check :
![image](https://user-images.githubusercontent.com/49101492/76146716-330f1a00-60bb-11ea-86b7-c606237e6985.png)


![image](https://user-images.githubusercontent.com/49101492/76146699-fe9b5e00-60ba-11ea-9a93-645c2ba65e71.png)
