### PR TITLE
Fix button alignment in examples

### DIFF
--- a/app/assets/stylesheets/logixRelease.scss
+++ b/app/assets/stylesheets/logixRelease.scss
@@ -3,6 +3,11 @@
     padding: 1.25rem;
     border-radius: .25em;
 }
+@media (max-width: 767px){
+  .feature{
+    flex-direction: column-reverse;
+  }
+}
 
 .gif-box {
     position: absolute;


### PR DESCRIPTION
Fixes #1055 

Fix the "view example" button in examples in mobile view

Screenshots of the changes -

**Before**
Button align above example diagram
![bug1w](https://user-images.githubusercontent.com/57035408/76146967-ee38b280-60bd-11ea-8c91-5466c210b653.png)

**After**
![bug1](https://user-images.githubusercontent.com/57035408/76146996-22ac6e80-60be-11ea-89b1-1d1b9c2becae.png)

