### PR TITLE
Fix user's image in edit comment

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -22,3 +22,6 @@
   float: none;
   margin: 0 auto;
 }
+.mentions-input-box{
+  position: static;
+}


### PR DESCRIPTION
Fixes #1067 

#### Describe the changes you have made in this PR -
Fix user image not shown issue when users go to edit option
Now, users image show in the edit option
### Screenshots of the changes -
**Before Fix**
![fix1](https://user-images.githubusercontent.com/57035408/76158631-ba04d680-613d-11ea-8384-a4dea1bbcf09.png)

**After fix**
![fix1c](https://user-images.githubusercontent.com/57035408/76158633-bcffc700-613d-11ea-8a76-74280467c86e.png)

