### PR TITLE
Add Tooltip to FA Icons in Simulator

### DIFF
--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -121,7 +121,7 @@
           </div>
           <div style="position:absolute; right:30px; top:30px; z-index:100">
             <button type="button" class="btn zoomButton btn-lg" onclick="changeScale(0.2,'zoomButton','zoomButton',2)">              
-              <span class="fa fa-search-plus" aria-hidden="true"></span>
+              <span class="fa fa-search-plus" aria-hidden="true" title="Zoom In"></span>
             </button>
           </div>
           <div class="sk-folding-cube loadingIcon" style="display:none;position:absolute; right:50%; bottom:50%; z-index:100">
@@ -132,22 +132,22 @@
           </div>
           <div style="position:absolute; right:60px; top:30px; z-index:100">
             <button type="button" class="btn zoomButton btn-lg" onclick="globalScope.centerFocus(false)">
-              <i class="fa fa-arrows" aria-hidden="true"></i>
+              <span class="fa fa-arrows" aria-hidden="true" title="Center Focus"></span>
             </button>
           </div>
           <div style="position:absolute; right:90px; top:30px; z-index:100">
             <button type="button" class="btn zoomButton btn-lg" onclick="changeScale(-0.2,'zoomButton','zoomButton',2)">
-              <span class="fa fa-search-minus" aria-hidden="true"></span>
+              <span class="fa fa-search-minus" aria-hidden="true" title="Zoom Out"></span>
             </button>
           </div>
           <div style="position:absolute; right:120px; top:30px; z-index:100">
             <button type="button" class="btn zoomButton btn-lg" onclick="undo()">
-              <span class="fa fa-repeat" aria-hidden="true"></span>
+              <span class="fa fa-repeat" aria-hidden="true" title="Undo"></span>
             </button>
           </div>
           <div style="position:absolute; right:150px; top:30px; z-index:100">
             <button type="button" class="btn zoomButton btn-lg" onclick="delete_selected()">
-              <span class="fa fa-times" aria-hidden="true"></span>
+              <span class="fa fa-times" aria-hidden="true" title="Delete"></span>
             </button>
           </div>
           <div id="layoutDialog" style="display:none;Width:210px;" class="" title="Layout Options">
@@ -156,55 +156,55 @@
               <div class="">
                 Width:
                 <button type="button" class="btn zoomButton btn-lg" onclick="decreaseLayoutWidth()">
-                  <span class="fa fa-minus" aria-hidden="true"></span>
+                  <span class="fa fa-minus" aria-hidden="true" title="Decrease Width"></span>
                 </button>
                 <button type="button" class="btn zoomButton btn-lg" onclick="increaseLayoutWidth()">
-                  <span class="fa fa-plus" aria-hidden="true"></span>
+                  <span class="fa fa-plus" aria-hidden="true" title="Increase Width"></span>
                 </button>
               </div>
               <div class="">
                 Height:
                 <button type="button" class="btn zoomButton btn-lg" onclick="decreaseLayoutHeight()">
-                  <span class="fa fa-minus" aria-hidden="true"></span>
+                  <span class="fa fa-minus" aria-hidden="true" title="Decrease Height"></span>
                 </button>
                 <button type="button" class="btn zoomButton btn-lg" onclick="increaseLayoutHeight()">
-                  <span class="fa fa-plus" aria-hidden="true"></span>
+                  <span class="fa fa-plus" aria-hidden="true" title="Increase Height"></span>
                 </button>
               </div>
               <div class="">
                 Reset all nodes:
                 <button type="button" class="btn zoomButton btn-lg" onclick="layoutResetNodes()">
-                  <span class="fa fa-refresh" aria-hidden="true"></span>
+                  <span class="fa fa-refresh" aria-hidden="true" title="Reset"></span>
                 </button>
               </div>
               <div class="">
                 Title:
                 <button type="button" class="btn zoomButton btn-lg" onclick="layoutTitleUp()">
-                  <span class="fa fa-arrow-up" aria-hidden="true"></span>
+                  <span class="fa fa-arrow-up" aria-hidden="true" title="Up"></span>
                 </button>
                 <button type="button" class="btn zoomButton btn-lg" onclick="layoutTitleDown()">
-                  <span class="fa fa-arrow-down" aria-hidden="true"></span>
+                  <span class="fa fa-arrow-down" aria-hidden="true" title="Down"></span>
                 </button>
                 <button type="button" class="btn zoomButton btn-lg" onclick="layoutTitleLeft()">
-                  <span class="fa fa-arrow-left" aria-hidden="true"></span>
+                  <span class="fa fa-arrow-left" aria-hidden="true" title="Left"></span>
                 </button>
                 <button type="button" class="btn zoomButton btn-lg" onclick="layoutTitleRight()">
-                  <span class="fa fa-arrow-right" aria-hidden="true"></span>
+                  <span class="fa fa-arrow-right" aria-hidden="true" title="Right"></span>
                 </button>
               </div>
               <div class="">
                 <p>Title Enabled : <label class='switch'>
                   <input type='checkbox' checked id="toggleLayoutTitle" onclick="toggleLayoutTitle()">
-                  <span class='slider2'></span> </label></p>
+                  <span class='slider2' title="Title"></span> </label></p>
               </div>
               <div class="">
                 Save:
                 <button type="button" class="btn zoomButton btn-lg" onclick="saveLayout()">
-                  <span class="fa fa-check" aria-hidden="true"></span>
+                  <span class="fa fa-check" aria-hidden="true" title="Save Layout"></span>
                 </button>
                 Cancel:
                 <button type="button" class="btn zoomButton btn-lg" onclick="cancelLayout()">
-                  <span class="fa fa-times" aria-hidden="true"></span>
+                  <span class="fa fa-times" aria-hidden="true" title="Cancel"></span>
                 </button>
               </div>
             </div>

--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -132,7 +132,7 @@
           </div>
           <div style="position:absolute; right:60px; top:30px; z-index:100">
             <button type="button" class="btn zoomButton btn-lg" onclick="globalScope.centerFocus(false)">
-              <span class="fa fa-arrows" aria-hidden="true" title="Center Focus"></span>
+              <span class="fa fa-arrows" aria-hidden="true" title="Zoom To Fit"></span>
             </button>
           </div>
           <div style="position:absolute; right:90px; top:30px; z-index:100">

--- a/app/views/simulator/embed.html.erb
+++ b/app/views/simulator/embed.html.erb
@@ -43,12 +43,12 @@
 
       <div style="position:absolute; right:20px; top:25px; z-index:100" class="noSelect">
         <button type="button" class="btn zoomButton" style="font-size: 25px;" onclick="changeScale(0.2,'zoomButton','zoomButton',2)">
-          <i class="fa fa-search-plus" aria-hidden="true"></i>
+          <span class="fa fa-search-plus" aria-hidden="true" title="Zoom In"></span>
         </button>
       </div>
       <div style="position:absolute; right:20px; top:52px; z-index:100" class="noSelect">
         <button type="button" class="btn zoomButton" style="font-size: 25px;" onclick="changeScale(-0.2,'zoomButton','zoomButton',2)">
-          <span class="fa fa-search-minus" aria-hidden="true"></span>
+          <span class="fa fa-search-minus" aria-hidden="true" title="Zoom Out"></span>
         </button>
       </div>
       <div style="position:absolute; right:60px; top:25px; z-index:100" class="clockPropertyHeader noSelect">


### PR DESCRIPTION
Fixes https://github.com/CircuitVerse/CircuitVerse/pull/1072#issuecomment-596218306

#### Describe the changes you have made in this PR -
I have added Tooltip to the Font Awesome Icons Present in the Simulator (Also to the Edit Layout Icons).

### Screenshots of the changes (If any) -
![patch-29](https://user-images.githubusercontent.com/42182955/76167205-ff9bc080-618a-11ea-95f8-cf46972b9075.gif)

