### PR TITLE
fixed broken footer of group discription page and assignment details page

### DIFF
--- a/app/views/assignments/show.html.erb
+++ b/app/views/assignments/show.html.erb
@@ -1,3 +1,4 @@
+<div>
 <div class="container">
   <div class="row row-about">
     <div class="col-xs col-sm col-md col-lg">
@@ -121,4 +122,5 @@
                 this.innerHTML = formatDate(new Date(this.innerHTML), "dddd hh:mmTT zz, dd MMM yyyy")
             })})
     </script>
+</div>
 </div>

--- a/app/views/assignments/show.html.erb
+++ b/app/views/assignments/show.html.erb
@@ -1,4 +1,3 @@
-<div>
 <div class="container">
   <div class="row row-about">
     <div class="col-xs col-sm col-md col-lg">

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -86,6 +86,11 @@
           <br>
           <br>
       <%end%>
+      <% if @group.assignments.blank? %>
+       <div class="container h5 text-center">
+         You haven't added any assignments yet!
+       </div>
+      <% else %>
       <table class="table assignment-table">
         <thead>
         <tr>
@@ -98,11 +103,6 @@
           <% end %>
         </tr>
         </thead>
-       <% if @group.assignments.blank? %>
-       <div class="container h5 text-center">
-         You haven't added any assignments yet!
-       </div>
-       <% else %>
         <tbody>
         <tbody>
         <% @group.assignments.includes(projects: :grade).each do |assignment| %>


### PR DESCRIPTION
Fixes #1100 

#### Describe the changes you have made in this PR -
Fixed broken footer when no assignment is available

### Screenshots of the changes (If any) -
Group Discription page:

<img width="1432" alt="Screenshot 2020-03-10 at 2 33 49 PM" src="https://user-images.githubusercontent.com/52625656/76296451-2a495e80-62dc-11ea-9fe4-53d01a83ab42.png">

Assignment details page:
<img width="1432" alt="Screenshot 2020-03-10 at 3 01 09 PM" src="https://user-images.githubusercontent.com/52625656/76298771-fc661900-62df-11ea-86bd-3a771d282a08.png">
