### PR TITLE
Fix About/Contribute Page - Responsive

### DIFF
--- a/app/assets/stylesheets/about.scss
+++ b/app/assets/stylesheets/about.scss
@@ -46,11 +46,11 @@
   box-shadow: 0px 2px 7px $shadow-black;
   opacity: 0.89;
   height: 89px;
-  width: 300px;
   margin-top: 50px;
   margin-left: 7px;
   margin-right: 7px;
   margin-bottom: 40px;
+  width: 300px;
   padding: 15px;
   cursor: pointer;
   transition: box-shadow 0.2s ease-in;
@@ -92,4 +92,20 @@
   background-color: $green;
   opacity: 1;
   color: white;
+}
+
+@media (max-width:350px) {
+  .about-card-image {
+    display: none;
+  }
+
+  .contact {
+    margin-bottom: 10px;
+    margin-top: 10px;
+    width: 230px;
+  }
+
+  .card-about {
+    margin: 30px 8px;
+  }
 }

--- a/app/assets/stylesheets/contribute.scss
+++ b/app/assets/stylesheets/contribute.scss
@@ -50,3 +50,10 @@
     width: 160px;
   }
 }
+
+@media (max-width:350px) {
+  .card-contribute {
+    padding-left: 0;
+    width: 250px;
+  }
+}

--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -15,12 +15,12 @@
         <div class="row row-about">
           <div class="col-xs col-sm col-md col-lg">
             <div class="contact" onclick="window.location.href='mailto:support@circuitverse.org';">
-              <%= image_tag "SVGs/email.svg", height: '60', width: '60', alt: "" %>
+              <%= image_tag "SVGs/email.svg", height: '60', width: '60', alt: "", class: 'about-card-image' %>
               <h6>Email us at</h6>
               <p id="tab">support@circuitverse.org</p>
             </div>
             <div class="contact" onclick="window.location.href='<%= Rails.configuration.slack_url %>';">
-              <%= image_tag "SVGs/slack.svg", height: '60', width: '60', alt: "" %>
+              <%= image_tag "SVGs/slack.svg", height: '60', width: '60', alt: "", class: 'about-card-image' %>
               <h6>Join and chat with us at</h6>
               <p id="tab">Slack Channel</p>
             </div>

--- a/app/views/logix/contribute.html.erb
+++ b/app/views/logix/contribute.html.erb
@@ -13,17 +13,17 @@
         <div class="row row-about">
           <div class="col-xs col-sm col-md col-lg">
             <div class="contact" onclick="window.location.href='mailto:support@circuitverse.org';">
-              <%= image_tag "SVGs/email.svg", alt: "", height: '60', width: '60' %>
+              <%= image_tag "SVGs/email.svg", alt: "", height: '60', width: '60', class: 'about-card-image' %>
               <h6>Email us at</h6>
               <p id="tab">support@circuitverse.org</p>
             </div>
             <div class="contact" onclick="window.location.href='<%= Rails.configuration.slack_url %>';">
-              <%= image_tag "SVGs/slack.svg", alt: "", height: '60', width: '60' %>
+              <%= image_tag "SVGs/slack.svg", alt: "", height: '60', width: '60', class: 'about-card-image' %>
               <h6>Join and chat with us at</h6>
               <p id="tab">Slack Channel</p>
             </div>
             <div class="contact" onclick="window.location.href='https://github.com/CircuitVerse';">
-              <%= image_tag "SVGs/github.svg", alt: "", height: '60', width: '60' %>
+              <%= image_tag "SVGs/github.svg", alt: "", height: '60', width: '60', class: 'about-card-image' %>
               <h6>Contribute to Open Source</h6>
               <p id="tab">Github</p>
             </div>


### PR DESCRIPTION
Made the About Page and Contribute page responsive by disabling icons on cards for smaller displays.
_(There still is some horizontal scroll present due to footer misalignment - will fix in another pr)_
**Screenshots**
1.
![image](https://user-images.githubusercontent.com/47032027/76488981-1ec97500-644d-11ea-93e4-a2bf49ce1898.png)
2.
![image](https://user-images.githubusercontent.com/47032027/76488987-225cfc00-644d-11ea-8cac-4b22b1a5f3b1.png)
3.
![image](https://user-images.githubusercontent.com/47032027/76488992-24bf5600-644d-11ea-948b-a420a85bc801.png)
4.
![image](https://user-images.githubusercontent.com/47032027/76488996-2721b000-644d-11ea-8fb5-a42e33083e0c.png)
