### PR TITLE
Opens new tab on clicking github and slack buttons on contribute page

### DIFF
--- a/app/views/logix/contribute.html.erb
+++ b/app/views/logix/contribute.html.erb
@@ -17,12 +17,12 @@
               <h6>Email us at</h6>
               <p id="tab">support@circuitverse.org</p>
             </div>
-            <div class="contact" onclick="window.location.href='<%= Rails.configuration.slack_url %>';">
+            <div class="contact" onclick="window.open('<%= Rails.configuration.slack_url %>')">
               <%= image_tag "SVGs/slack.svg", alt: "", height: '60', width: '60', class: 'about-card-image' %>
               <h6>Join and chat with us at</h6>
               <p id="tab">Slack Channel</p>
             </div>
-            <div class="contact" onclick="window.location.href='https://github.com/CircuitVerse';">
+            <div class="contact" onclick="window.open('https://github.com/CircuitVerse')">
               <%= image_tag "SVGs/github.svg", alt: "", height: '60', width: '60', class: 'about-card-image' %>
               <h6>Contribute to Open Source</h6>
               <p id="tab">Github</p>


### PR DESCRIPTION
Fixes #
Opens new tab on clicking github and slack buttons
#### Describe the changes you have made in this PR -
Opens new tab onclicking github and slack button on contribute page as its annoying for user to view get back to website  and user wants to see it in both tabs
