### PR TITLE
Fixed the UserName Underline

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -32,7 +32,7 @@
       </li>
       <% if user_signed_in? %>
        <div class="navbar-nav nav-item dropdown">
-        <li class="nav-item px-2">
+        <li class="nav-item px-2 <%= request.path == profile_path(current_user) || request.path == notifications_path(current_user) || request.path == user_path(current_user) || request.path == user_groups_path(current_user) || request.path == user_favourites_path(current_user) ? 'active' : '' %>">
           <a class="nav-link text-dark dropdown-toggle" style="cursor: pointer;" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <%= current_user.name %>
          </a>


### PR DESCRIPTION
Fixes #1169 

#### Describe the changes you have made in this PR -
Now when the user clicks on any link in the drop-down then User name is underlined to show that which Page is active.

**Screenshot**
![patch33](https://user-images.githubusercontent.com/42182955/76648019-e4162880-6583-11ea-8000-c80080149ec7.gif)
