### PR TITLE
Fixed Navbar bug #1190

### DIFF
--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -46,7 +46,7 @@
         <a href="https://docs.circuitverse.org" class="text-light" target="_blank" role="button" aria-haspopup="true" aria-expanded="false">Help</a>
       </li>
     </ul>
-    <span class="projectName noSelect defaultCursor font-weight-bold" id="projectName">
+    <span class="projectName noSelect defaultCursor font-weight-bold mr-auto ml-auto ml-lg-0" id="projectName">
       Untitled
     </span>
     <ul class="nav navbar-nav noSelect pointerCursor pull-right">


### PR DESCRIPTION
Now "untitled" (project name) Appears correctly in both desktop and mobile screen sizes

Fixes #
Fixed wrong alignment of "project name" in tablet and lower screen sizes
### Screenshots of the changes (If any) -
BEFORE
![circuit6](https://user-images.githubusercontent.com/55310756/76705361-86a9e500-6705-11ea-8677-2cbe403aa69a.png)

AFTER
![circuit7](https://user-images.githubusercontent.com/55310756/76705354-7f82d700-6705-11ea-8414-acc29ba3edff.png)
