### PR TITLE
Adds Check for group mentor in entered emails for new group member

### DIFF
--- a/app/controllers/group_members_controller.rb
+++ b/app/controllers/group_members_controller.rb
@@ -37,6 +37,9 @@ class GroupMembersController < ApplicationController
     present_members = User.where(id: @group.group_members.pluck(:user_id)).pluck(:email)
     newly_added = group_member_emails - present_members
 
+    # Keeps track if the parsed emails contains the mentor's email..
+    is_group_mentor = false
+
     newly_added.each do |email|
       email = email.strip
       user = User.find_by(email: email)
@@ -45,7 +48,7 @@ class GroupMembersController < ApplicationController
         # @group.pending_invitations.create(email:email)
       else
         if @group.mentor_id.eql? user.id
-          
+          is_group_mentor = true
         else
           GroupMember.where(group_id:@group.id,user_id:user.id).first_or_create
           # group_member = @group.group_members.new
@@ -58,9 +61,10 @@ class GroupMembersController < ApplicationController
     end
 
     notice = Utils.mail_notice(group_member_params[:emails], group_member_emails, newly_added)
+    notice += (is_group_mentor ? " Mentor cannot be added as a member to the same group" : "")
 
     respond_to do |format|
-      format.html { redirect_to group_path(@group), notice: Utils.mail_notice(group_member_params[:emails], group_member_emails, newly_added)
+      format.html { redirect_to group_path(@group), notice: notice
 }
     end
     # redirect_to group_path(@group)

--- a/app/controllers/group_members_controller.rb
+++ b/app/controllers/group_members_controller.rb
@@ -46,22 +46,19 @@ class GroupMembersController < ApplicationController
       if user.nil?
         PendingInvitation.where(group_id:@group.id,email:email).first_or_create
         # @group.pending_invitations.create(email:email)
+      elsif @group.mentor_id.eql? user.id
+        is_group_mentor = true
       else
-        if @group.mentor_id.eql? user.id
-          is_group_mentor = true
-        else
-          GroupMember.where(group_id:@group.id,user_id:user.id).first_or_create
-          # group_member = @group.group_members.new
-          # group_member.user_id = user.id
-          # group_member.save
-        end
-
+        GroupMember.where(group_id:@group.id,user_id:user.id).first_or_create
+        # group_member = @group.group_members.new
+        # group_member.user_id = user.id
+        # group_member.save
       end
 
     end
 
-    notice = Utils.mail_notice(group_member_params[:emails], group_member_emails, newly_added)
-    notice += (is_group_mentor ? " Mentor cannot be added as a member to the same group" : "")
+    notice = Utils.mail_notice(group_member_params[:emails], group_member_emails, newly_added) +
+              (is_group_mentor ? " Mentor cannot be added as a member to the same group" : "")
 
     respond_to do |format|
       format.html { redirect_to group_path(@group), notice: notice

--- a/app/controllers/group_members_controller.rb
+++ b/app/controllers/group_members_controller.rb
@@ -44,11 +44,15 @@ class GroupMembersController < ApplicationController
         PendingInvitation.where(group_id:@group.id,email:email).first_or_create
         # @group.pending_invitations.create(email:email)
       else
-        GroupMember.where(group_id:@group.id,user_id:user.id).first_or_create
+        if @group.mentor_id.eql? user.id
+          
+        else
+          GroupMember.where(group_id:@group.id,user_id:user.id).first_or_create
+          # group_member = @group.group_members.new
+          # group_member.user_id = user.id
+          # group_member.save
+        end
 
-        # group_member = @group.group_members.new
-        # group_member.user_id = user.id
-        # group_member.save
       end
 
     end

--- a/spec/controllers/group_members_controller_spec.rb
+++ b/spec/controllers/group_members_controller_spec.rb
@@ -14,7 +14,8 @@ describe GroupMembersController, type: :request do
         group_member: {
           group_id: @group.id,
           emails: "#{@already_present.email}
-           #{FactoryBot.create(:user).email} #{Faker::Internet.email}"
+           #{FactoryBot.create(:user).email} #{Faker::Internet.email}
+           #{@mentor.email}"
         }
       }
     }
@@ -26,7 +27,8 @@ describe GroupMembersController, type: :request do
     end
 
     context "mentor is logged in" do
-      it "creates members that are not present and pending invitations for others" do
+      it "creates members that are not present, pending invitations for others" + \
+       "and mentor should not be able to add himself as member" do
         expect {
           post group_members_path, params: create_params
         }.to change { GroupMember.count }.by(1)


### PR DESCRIPTION
Fixes #1191 

#### Describe the changes you have made in this PR -
Added a check for equality of *mentor_id* and *group_id* while adding members..

### Screenshots of the changes (If any) -
