### PR TITLE
Circuits follow the cursor when pasting

### DIFF
--- a/public/js/listeners.js
+++ b/public/js/listeners.js
@@ -290,7 +290,16 @@ function startListeners() {
         } else {
             e.clipboardData.setData('text/plain', textToPutOnClipboard);
         }
+        // since the 'textToPutOnClipboard' variable is a string, we need to
+        // parse it as a JSON
+        const clipboardDataObject = JSON.parse(textToPutOnClipboard);
+        const objectKeys = Object.keys(clipboardDataObject);
 
+        // the id of the element to be copied would be the key after the key
+        // 'name'
+        const elementId = objectKeys[objectKeys.indexOf('name') + 1]
+        const obj = new window[elementId]();
+        simulationArea.lastSelected = obj;
     });
 
     document.addEventListener('paste', function(e) {


### PR DESCRIPTION
Fixes #971 

#### Describe the changes you have made in this PR -
When a circuit is copied, the circuit will follow the cursor until the user left clicks on the simulator area or when the user clicks Ctrl+Z.

### Screenshots of the changes (If any) -
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/33577657/76799666-f5676b00-67f7-11ea-995e-9dfd951376c2.gif)
