### PR TITLE
Added yarn installation commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,13 @@ RUN apt-get update -qq && apt-get install -y imagemagick && apt-get clean
 
 RUN wget -qO- https://deb.nodesource.com/setup_8.x | bash - && apt-get install -y nodejs && apt-get clean
 
+# install yarn
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN apt update
+RUN apt install -y yarn
+RUN yarn
+
 COPY Gemfile /circuitverse/Gemfile
 COPY Gemfile.lock /circuitverse/Gemfile.lock
 

--- a/bin/docker_run
+++ b/bin/docker_run
@@ -1,5 +1,17 @@
 #!/bin/bash
 
+# Remove default old version of cmdtest/yarn
+apt uninstall cmdtest
+
+# Install new version of yarn
+curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+apt update
+apt install -y yarn
+
+# Install yarn packages
+yarn
+
 echo "Waiting for db to be available"
 for i in $(seq 1 30) ; do timeout 1 bash -c "echo > /dev/tcp/db/5432" > /dev/null 2>&1 && status=0 && break || status=$? && sleep 1 ; done
 
@@ -18,5 +30,5 @@ bundle exec rails db:seed
 
 rm -f /circuitverse/tmp/pids/server.pid
 
-echo "Starting on 127.0.0.1:3000"
+echo "Starting on 0.0.0.0:3000"
 bundle exec rails s -p 3000 -b '0.0.0.0'

--- a/bin/docker_run
+++ b/bin/docker_run
@@ -1,17 +1,5 @@
 #!/bin/bash
 
-# Remove default old version of cmdtest/yarn
-apt uninstall cmdtest
-
-# Install new version of yarn
-curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-apt update
-apt install -y yarn
-
-# Install yarn packages
-yarn
-
 echo "Waiting for db to be available"
 for i in $(seq 1 30) ; do timeout 1 bash -c "echo > /dev/tcp/db/5432" > /dev/null 2>&1 && status=0 && break || status=$? && sleep 1 ; done
 


### PR DESCRIPTION
Fixes #1213 

#### Describe the changes you have made in this PR -
Added yarn installation commands in bin/docker_run file so that ```docker-compose up``` runs successfully after a fresh clone.

### Screenshots of the changes (If any) -
Before:
![image](https://user-images.githubusercontent.com/33577657/76852556-9cd4b400-6871-11ea-9c27-f70eb8dabc1e.png)

After:
![image](https://user-images.githubusercontent.com/33577657/76853558-8a5b7a00-6873-11ea-845c-96c9500a11e8.png)


