### PR TITLE
Minor UI fixes in back button in new group page

### DIFF
--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -14,7 +14,7 @@
     <%= form.text_field :name, id: :group_name, class: 'm-1 m-md-2' %>
   </div>
   <div class="d-flex flex-row justify-content-center align-items-center">
-    <%= link_to 'Back', :back, class: 'btn underline m-1 m-md-2' %>
     <%= form.submit 'Save', class: 'btn btn-primary m-1 m-md-2' %>
+    <%= link_to 'Back', :back, class: 'btn underline text-success m-1 m-md-2' %>
   </div>
 <% end %>


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -
In New Group Page :
- Adds *text-success* to back button. 
- Shifts *Back* button to right.

### Screenshots of the changes (If any) -
### BEFORE
![Screenshot from 2020-03-17 22-08-41](https://user-images.githubusercontent.com/45434030/76879231-fa7df600-689b-11ea-87ad-6bb063639512.png)

### AFTER
![Screenshot from 2020-03-17 22-05-35](https://user-images.githubusercontent.com/45434030/76879099-c4407680-689b-11ea-96ed-cfe2d94d6f96.png)
