### PR TITLE
Added margin-left to 'icon' class

### DIFF
--- a/public/css/UX.css
+++ b/public/css/UX.css
@@ -597,6 +597,7 @@ input:checked + .slider2:before {
     width: 60px;
     /*margin: 1px;*/
     margin-bottom: 5px;
+    margin-left: 3px;
     display: inline-block;
     background-color: white;
     border-radius: 4px;


### PR DESCRIPTION
Fixes #1218

#### Describe the changes you have made in this PR -
I added a margin-left to the 'icon' class so that it looks more aesthetically pleasing as the borders don't collide.


### Screenshots of the changes (If any) -
**Before :**
![Screenshot from 2020-03-18 00-18-15](https://user-images.githubusercontent.com/54415525/76890788-feb30f00-68ad-11ea-8a32-3c5e8241bf49.png)
**Now :**
![Screenshot from 2020-03-18 00-14-18](https://user-images.githubusercontent.com/54415525/76890684-cd3a4380-68ad-11ea-8c6d-a6b9a0b7a2b1.png)