### PR TITLE
Styling fix for simulator buttons#1219

### DIFF
--- a/public/css/UX.css
+++ b/public/css/UX.css
@@ -658,6 +658,7 @@ div.icon img {
 
 .objectPropertyAttributeChecked.btn {
     width: 100%;
+    margin-bottom: 1px;
 }
 
 /* For loading screen - pace.js */

--- a/public/css/UX.css
+++ b/public/css/UX.css
@@ -656,6 +656,10 @@ div.icon img {
     transition: height 0.2s margin 0.2s;
 }
 
+.objectPropertyAttributeChecked.btn {
+    width: 100%;
+}
+
 /* For loading screen - pace.js */
 
 .pace {

--- a/public/css/UX.css
+++ b/public/css/UX.css
@@ -658,7 +658,7 @@ div.icon img {
 
 .objectPropertyAttributeChecked.btn {
     width: 100%;
-    margin-bottom: 1px;
+    margin-bottom: 5px;
 }
 
 /* For loading screen - pace.js */


### PR DESCRIPTION
Fixes #1219 

#### Describe the changes you have made in this PR -
I added width:100% attribute to '.objectPropertyAttributeChecked.btn'
Also added a margin-bottom to them so that they don't stick to each other.

### Screenshots of the changes (If any) -
**Before :**
![Screenshot from 2020-03-18 01-03-02](https://user-images.githubusercontent.com/54415525/76894486-4177e580-68b4-11ea-8815-8a52a945e22a.png)
**Now :**
![Screenshot from 2020-03-20 14-11-34](https://user-images.githubusercontent.com/54415525/77148051-c16c9e00-6ab4-11ea-85df-94a21fedb668.png)


