### PR TITLE
Fixed Min and Max Width Of Simulator Panel

### DIFF
--- a/app/assets/stylesheets/simulator.scss
+++ b/app/assets/stylesheets/simulator.scss
@@ -12,4 +12,6 @@
 .side {
   max-width: 350px;
   min-width: 250px;
+  overflow-x: hidden;
+  overflow-y: scroll;
 }

--- a/app/assets/stylesheets/simulator.scss
+++ b/app/assets/stylesheets/simulator.scss
@@ -9,9 +9,7 @@
   color: #fff;
 }
 
-#sideBar {
-  overflow-y: scroll;
-  overflow-x: hidden;
-  min-width: 250px;
+.side {
   max-width: 350px;
+  min-width: 250px;
 }

--- a/app/assets/stylesheets/simulator.scss
+++ b/app/assets/stylesheets/simulator.scss
@@ -8,3 +8,10 @@
 .moduleProperty input {
   color: #fff;
 }
+
+#sideBar {
+  overflow-y: scroll;
+  overflow-x: hidden;
+  min-width: 250px;
+  max-width: 350px;
+}

--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -69,7 +69,7 @@
   <!-- /.navbar-collapse -->
 </nav>
   <div>
-    <div class="side left" id="sideBar" style="overflow-y: scroll;overflow-x: hidden">
+    <div class="side left" id="sideBar">
       <div class="modules noSelect defaultCursor">
         <div id="modules-header">Circuit Elements</div>
         <div class="accordion" id="menu">


### PR DESCRIPTION
Fixes #1229 

#### Describe the changes you have made in this PR -
I have fixed the simulator panel min and max width . So now the panel works properly . Also I have moved the inline CSS to External CSS in Simulator.scss.
Without Min and Max Width , the elements in the Panel gets distorted . 

### Screenshots of the changes (If any) -
![patch-36](https://user-images.githubusercontent.com/42182955/76964658-14c1dd80-6949-11ea-9eaf-cf9deb0fa40f.gif)
