### PR TITLE
Added 'Show Assignment' button for Student User

### DIFF
--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -91,6 +91,7 @@
       <tr>
         <th>Name</th>
         <th>DeadLine</th>
+        <th>Preview</th>
         <th>Grading</th>
         <th>Actions</th>
         <% unless policy(@group).admin_access? %>
@@ -107,10 +108,10 @@
               <p> <strong>Time remaining: </strong><%= (( assignment.deadline.to_i - Time.now.to_i)/1.day) %> days,  <%= (( assignment.deadline.to_i- Time.now.to_i)/1.hour)%24 %> hours, <%= (( assignment.deadline.to_i- Time.now.to_i)/1.minute)%60 %> minutes</p>
               <% end %>
             </td>
+            <td><%= link_to 'Show', group_assignment_path(@group,assignment), class:"assignment-view" %></td>
             <td> <%= AssignmentDecorator.new(assignment).graded %> </td>
             <td>
               <% if policy(@group).admin_access? %>
-                <%= link_to 'Show', group_assignment_path(@group,assignment), class:"assignment-view" %>
                 <% if assignment.status!="closed" %>
                   <%= link_to 'Edit', edit_group_assignment_path(@group,assignment), class:"assignment-edit-reopen" %>
                 <% else %>


### PR DESCRIPTION
Fixes #1243 

#### Describe the changes you have made in this PR -
I have added an extra column for Preview and displayed the Show button for the Student User. It is same as the old UI. Will add appropriate styles to the buttons in a separate PR.

### Screenshots of the changes (If any) -
![Screenshot from 2020-03-20 00-12-46](https://user-images.githubusercontent.com/42511766/77102923-a1e75e00-6a3f-11ea-8629-98bc28976bef.png)

### Left - Mentor; Right - Student

