### PR TITLE
Replaces "Group member destroyed" with "Group member removed".

### DIFF
--- a/app/controllers/group_members_controller.rb
+++ b/app/controllers/group_members_controller.rb
@@ -93,7 +93,8 @@ class GroupMembersController < ApplicationController
 
     @group_member.destroy
     respond_to do |format|
-      format.html { redirect_to group_path(@group_member.group), notice: 'Group member was successfully destroyed.' }
+      format.html { redirect_to group_path(@group_member.group),
+      notice: "Group member was successfully removed." }
       format.json { head :no_content }
     end
   end

--- a/spec/system/group_spec.rb
+++ b/spec/system/group_spec.rb
@@ -53,7 +53,7 @@ describe "Group management", type: :system do
     click_on "Remove"
     accept_alert
 
-    expect(page).to have_text("Group member was successfully destroyed.")
+    expect(page).to have_text("Group member was successfully removed.")
   end
 
   it "should change the group name" do


### PR DESCRIPTION
Fixes #1227 

#### Describe the changes you have made in this PR -
Replaces "Group member destroyed" with "Group member removed".

### Screenshots of the changes (If any) -
![Screenshot from 2020-03-18 16-58-39](https://user-images.githubusercontent.com/50791000/77226959-2baf3c80-6ba2-11ea-859c-cd8cf431b33c.png)
