### PR TITLE
Prevent Collapsing Tabsbar and New Look

### DIFF
--- a/public/css/UX.css
+++ b/public/css/UX.css
@@ -351,7 +351,7 @@ select {
 
 #tabsDivTabEdit1{
     padding: 0em;
-    opacity: 0.5;
+    opacity: 0.3;
 }
 
 th,

--- a/public/css/UX.css
+++ b/public/css/UX.css
@@ -331,6 +331,29 @@ select {
     border: 1px solid #0099ff;
 }
 
+.tabsCloseButton:hover{
+    color:#fff;
+    font-family: 'Gill Sans', sans-serif;
+    padding-left: 1em;
+    opacity: 0.5;
+    display:inline;
+
+}
+
+.tabsCloseButton {
+    color:#111;
+    font-family: 'Gill Sans', sans-serif;
+    padding-left: 1em;
+    opacity: 1.0;
+    display: inline;
+
+}
+
+#tabsDivTabEdit1{
+    padding: 0em;
+    opacity: 0.5;
+}
+
 th,
 td {
     padding-left: 15px;

--- a/public/js/data.js
+++ b/public/js/data.js
@@ -11,7 +11,7 @@ function newCircuit(name, id) {
 
     $('.circuits').removeClass("current");
     if (name.length > 7) {
-        $('#tabsBar').append("<a href = '#' data-toggle ='tooltip' title = '" + name + "'><div class='circuits toolbarButton current' id='" + scope.id + "'> " + name.substr(0,6) + "<span id = 'tabsDivTabEdit1'>" +'...'+ "</span>" + "<span class ='tabsCloseButton' onclick='deleteCurrentCircuit()'  >x</span></div></a>");
+        $('#tabsBar').append("<a href = '#' data-toggle ='tooltip' title = '" + name + "'><div class='circuits toolbarButton current' id='" + scope.id + "'> " + name.substr(0,6) + "<span id = 'tabsDivTabEdit1'>" + '...' + "</span>" + "<span class ='tabsCloseButton' onclick = 'deleteCurrentCircuit()'  > x </span></div></a>");
     }
     else {
         $('#tabsBar').append("<div class='circuits toolbarButton current' id='" + scope.id + "'>" + name.substr(0,6) + "<span class ='tabsCloseButton' onclick='deleteCurrentCircuit()'  >x</span></div>");

--- a/public/js/data.js
+++ b/public/js/data.js
@@ -10,7 +10,12 @@ function newCircuit(name, id) {
     globalScope = scope;
 
     $('.circuits').removeClass("current");
-    $('#tabsBar').append("<div class='circuits toolbarButton current' id='" + scope.id + "'>" + name + "</div>");
+    if (name.length > 7) {
+        $('#tabsBar').append("<a href = '#' data-toggle ='tooltip' title = '" + name + "'><div class='circuits toolbarButton current' id='" + scope.id + "'> " + name.substr(0,6) + "<span id = 'tabsDivTabEdit1'>" +'...'+ "</span>" + "<span class ='tabsCloseButton' onclick='deleteCurrentCircuit()'  >x</span></div></a>");
+    }
+    else {
+        $('#tabsBar').append("<div class='circuits toolbarButton current' id='" + scope.id + "'>" + name.substr(0,6) + "<span class ='tabsCloseButton' onclick='deleteCurrentCircuit()'  >x</span></div>");
+    }
     $('.circuits').click(function() {
         switchCircuit(this.id)
     });

--- a/public/js/data.js
+++ b/public/js/data.js
@@ -11,9 +11,8 @@ function newCircuit(name, id) {
 
     $('.circuits').removeClass("current");
     if (name.length > 7) {
-        $('#tabsBar').append("<a href = '#' data-toggle ='tooltip' title = '" + name + "'><div class='circuits toolbarButton current' id='" + scope.id + "'> " + name.substr(0,6) + "<span id = 'tabsDivTabEdit1'>" + '...' + "</span>" + "<span class ='tabsCloseButton' onclick = 'deleteCurrentCircuit()'  > x </span></div></a>");
-    }
-    else {
+        $('#tabsBar').append("<a href = '#' data-toggle ='tooltip' title = '" + name + "'><div class='circuits toolbarButton current' id='" + scope.id + "'> " + name.substr(0,6) + "<span id = 'tabsDivTabEdit1'> ... </span><span class ='tabsCloseButton' onclick = 'deleteCurrentCircuit()' > x </span></div></a>");
+    } else {
         $('#tabsBar').append("<div class='circuits toolbarButton current' id='" + scope.id + "'>" + name.substr(0,6) + "<span class ='tabsCloseButton' onclick='deleteCurrentCircuit()'  >x</span></div>");
     }
     $('.circuits').click(function() {

--- a/public/js/data.js
+++ b/public/js/data.js
@@ -10,11 +10,7 @@ function newCircuit(name, id) {
     globalScope = scope;
 
     $('.circuits').removeClass("current");
-    if (name.length > 7) {
-        $('#tabsBar').append("<a href = '#' data-toggle ='tooltip' title = '" + name + "'><div class='circuits toolbarButton current' id='" + scope.id + "'> " + name.substr(0,6) + "<span id = 'tabsDivTabEdit1'> ... </span><span class ='tabsCloseButton' onclick = 'deleteCurrentCircuit()' > x </span></div></a>");
-    } else {
-        $('#tabsBar').append("<div class='circuits toolbarButton current' id='" + scope.id + "'>" + name.substr(0,6) + "<span class ='tabsCloseButton' onclick='deleteCurrentCircuit()'  >x</span></div>");
-    }
+    $('#tabsBar').append("<a href = '#' data-toggle ='tooltip' title = '" + name + "'><div class='circuits toolbarButton current' id='" + scope.id + "'> " + name.substr(0,6) + "<span id = 'tabsDivTabEdit1'>" + name.substr(6,3) + "</span><span class ='tabsCloseButton' onclick = 'deleteCurrentCircuit()' > x </span></div></a>");
     $('.circuits').click(function() {
         switchCircuit(this.id)
     });


### PR DESCRIPTION
Fixes # 1287

#### Describe the changes you have made in this PR -
To tackle issue of collapsing tabsbar/ simulator: 
 * added new way of circuit's name display (with ellipsis ie, ...)
 * made max_display_size 7 , eg:
 ckt name: 1234567      ckt_name: 12345678
 tab_ame : 1234567      tab_name: 123456... which displays full name on 
                                             hovering


### Screenshots of the changes (If any) -
![hutgif1](https://user-images.githubusercontent.com/56930593/77314548-db63e600-6d2b-11ea-865d-1508b145de2d.gif)
 
testing 2

![hutgif2](https://user-images.githubusercontent.com/56930593/77315055-dfdcce80-6d2c-11ea-88d7-f6a962d0cc7d.gif)

### Alternatives
there's another ui possible:

![hut1](https://user-images.githubusercontent.com/56930593/77314564-e28af400-6d2b-11ea-8dfb-258b11158930.png)

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 

