### PR TITLE
Fixes Empty circuit names 

### DIFF
--- a/public/js/data.js
+++ b/public/js/data.js
@@ -25,6 +25,7 @@ function newCircuit(name, id) {
 
 
 function changeCircuitName(name, id = globalScope.id) {
+    name = name || "Untitled";
     name = stripTags(name);
     $('#' + id).html(name);
     scopeList[id].name = name;


### PR DESCRIPTION
Fixes #851 

#### Describe the changes you have made in this PR -
Empty Circuit names is replaced with Untitled which fixes breaking bar height.


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
