### PR TITLE
Added helplinks to all the elements and a missing tooltip text

### DIFF
--- a/public/js/Counter.js
+++ b/public/js/Counter.js
@@ -28,6 +28,7 @@ function Counter(x, y, scope = globalScope, bitWidth = 8) {
 Counter.prototype = Object.create(CircuitElement.prototype);
 Counter.prototype.constructor = Counter;
 Counter.prototype.tooltipText = "Counter: a binary counter from zero to a given maximum value";
+Counter.prototype.helplink = "https://docs.circuitverse.org/#/inputElements?id=counter";
 Counter.prototype.customSave = function () {
     return {
         nodes: {

--- a/public/js/UX.js
+++ b/public/js/UX.js
@@ -203,31 +203,13 @@ function showProperties(obj) {
         }
     }
 
-    // Tooltip can be defined in the prototype or the object itself, in addition to help map.
-    var tooltipText = obj && (obj.tooltipText);
-    if (tooltipText) {
-        $('#moduleProperty-inner').append('<p><button id="toolTipButton" class="btn btn-primary btn-xs" type="button" >CircuitVerse Help &#9432</button></p>');
-        $('#toolTipButton').hover(function () {
-            $("#Help").addClass("show");
-            $("#Help").empty();
-            ////console.log("SHOWING")
-            $("#Help").append(tooltipText);
-        }); // code goes in document ready fn only
-        $('#toolTipButton').mouseleave(function () {
-            $("#Help").removeClass("show");
-        });
-        //redirects to obj's specific help page
-        $('#toolTipButton').click(function () {
-            var helplink = obj && (obj.helplink);
+    var helplink = obj && (obj.helplink);
+    if (helplink) {
+        $('#moduleProperty-inner').append('<p><button id="HelpButton" class="btn btn-primary btn-xs" type="button" >Help &#9432</button></p>');
+        $('#HelpButton').click(function () {
             window.open(helplink);
         });
     }
-
-
-
-
-
-
 
     $(".objectPropertyAttribute").on("change keyup paste click", function () {
         // return;

--- a/public/js/eeprom.js
+++ b/public/js/eeprom.js
@@ -20,6 +20,7 @@ EEPROM.prototype.tooltipText = "Electrically Erasable Programmable Read-Only Mem
 EEPROM.prototype.constructor = EEPROM;
 EEPROM.prototype.shortName = "EEPROM";
 EEPROM.prototype.maxAddressWidth = 10;
+EEPROM.prototype.helplink = "https://docs.circuitverse.org/#/memoryElements?id=eeprom";
 EEPROM.prototype.mutableProperties = {
     "addressWidth": {
         name: "Address Width",

--- a/public/js/modules.js
+++ b/public/js/modules.js
@@ -56,6 +56,7 @@ AndGate.prototype.tooltipText = "And Gate Tooltip : Implements logical conjuncti
 AndGate.prototype.alwaysResolve = true;
 AndGate.prototype.verilogType = "and";
 AndGate.prototype.changeInputSize = changeInputSize;
+AndGate.prototype.helplink = "https://docs.circuitverse.org/#/gates?id=and-gate";
 //fn to create save Json Data of object
 AndGate.prototype.customSave = function () {
     var data = {
@@ -149,6 +150,7 @@ NandGate.prototype.tooltipText = "Nand Gate ToolTip : Combination of AND and NOT
 NandGate.prototype.alwaysResolve = true;
 NandGate.prototype.changeInputSize = changeInputSize;
 NandGate.prototype.verilogType = "nand";
+NandGate.prototype.helplink = "https://docs.circuitverse.org/#/gates?id=nand-gate";
 //fn to create save Json Data of object
 NandGate.prototype.customSave = function () {
     var data = {
@@ -236,6 +238,7 @@ function Multiplexer(x, y, scope = globalScope, dir = "RIGHT", bitWidth = 1, con
 Multiplexer.prototype = Object.create(CircuitElement.prototype);
 Multiplexer.prototype.constructor = Multiplexer;
 Multiplexer.prototype.tooltipText = "Multiplexer ToolTip : Multiple inputs and a single line output.";
+Multiplexer.prototype.helplink = "https://docs.circuitverse.org/#/decodersandplexers?id=multiplexer";
 Multiplexer.prototype.changeControlSignalSize = function (size) {
     if (size == undefined || size < 1 || size > 32) return;
     if (this.controlSignalSize == size) return;
@@ -370,6 +373,7 @@ XorGate.prototype.alwaysResolve = true;
 
 XorGate.prototype.changeInputSize = changeInputSize;
 XorGate.prototype.verilogType = "xor";
+XorGate.prototype.helplink = "https://docs.circuitverse.org/#/gates?id=xor-gate";
 XorGate.prototype.customSave = function () {
     // //console.log(this.scope.allNodes);
     var data = {
@@ -457,6 +461,7 @@ XnorGate.prototype.alwaysResolve = true;
 XnorGate.prototype.tooltipText = "Xnor Gate ToolTip : Logical complement of the XOR gate";
 XnorGate.prototype.changeInputSize = changeInputSize;
 XnorGate.prototype.verilogType = "xnor";
+XnorGate.prototype.helplink = "https://docs.circuitverse.org/#/gates?id=xnor-gate";
 XnorGate.prototype.customSave = function () {
     var data = {
         constructorParamaters: [this.direction, this.inputSize, this.bitWidth],
@@ -830,6 +835,7 @@ OrGate.prototype.tooltipText = "Or Gate Tooltip : Implements logical disjunction
 OrGate.prototype.changeInputSize = changeInputSize;
 OrGate.prototype.alwaysResolve = true;
 OrGate.prototype.verilogType = "or";
+OrGate.prototype.helplink = "https://docs.circuitverse.org/#/gates?id=or-gate";
 OrGate.prototype.customSave = function () {
     var data = {
 
@@ -936,6 +942,7 @@ function NotGate(x, y, scope = globalScope, dir = "RIGHT", bitWidth = 1) {
 NotGate.prototype = Object.create(CircuitElement.prototype);
 NotGate.prototype.constructor = NotGate;
 NotGate.prototype.tooltipText = "Not Gate Tooltip : Inverts the input digital signal.";
+NotGate.prototype.helplink = "https://docs.circuitverse.org/#/gates?id=not-gate";
 NotGate.prototype.customSave = function () {
     var data = {
         constructorParamaters: [this.direction, this.bitWidth],
@@ -1145,6 +1152,7 @@ function TriState(x, y, scope = globalScope, dir = "RIGHT", bitWidth = 1) {
 TriState.prototype = Object.create(CircuitElement.prototype);
 TriState.prototype.constructor = TriState;
 TriState.prototype.tooltipText = "TriState ToolTip : Effectively removes the output from the circuit.";
+TriState.prototype.helplink = "https://docs.circuitverse.org/#/miscellaneous?id=tri-state-buffer"
 // TriState.prototype.propagationDelay=10000;
 TriState.prototype.customSave = function () {
     var data = {
@@ -1221,6 +1229,7 @@ function Buffer(x, y, scope = globalScope, dir = "RIGHT", bitWidth = 1) {
 Buffer.prototype = Object.create(CircuitElement.prototype);
 Buffer.prototype.constructor = Buffer;
 Buffer.prototype.tooltipText = "Buffer ToolTip : Isolate the input from the output.";
+Buffer.prototype.helplink = "https://docs.circuitverse.org/#/miscellaneous?id=buffer"
 Buffer.prototype.customSave = function () {
     var data = {
         constructorParamaters: [this.direction, this.bitWidth],
@@ -1354,6 +1363,7 @@ function Adder(x, y, scope = globalScope, dir = "RIGHT", bitWidth = 1) {
 Adder.prototype = Object.create(CircuitElement.prototype);
 Adder.prototype.constructor = Adder;
 Adder.prototype.tooltipText = "Adder ToolTip : Performs addition of numbers.";
+Adder.prototype.helplink = "https://docs.circuitverse.org/#/miscellaneous?id=adder"
 Adder.prototype.customSave = function () {
     var data = {
         constructorParamaters: [this.direction, this.bitWidth],
@@ -1412,6 +1422,7 @@ function Rom(x, y, scope = globalScope, data = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 Rom.prototype = Object.create(CircuitElement.prototype);
 Rom.prototype.constructor = Rom;
 Rom.prototype.tooltipText = "Read-only memory";
+Rom.prototype.helplink = "https://docs.circuitverse.org/#/memoryElements?id=rom";
 Rom.prototype.isResolvable = function () {
     if ((this.en.value == 1 || this.en.connections.length == 0) && this.memAddr.value != undefined) return true;
     return false;
@@ -2095,6 +2106,7 @@ function BitSelector(x, y, scope = globalScope, dir = "RIGHT", bitWidth = 2, sel
 BitSelector.prototype = Object.create(CircuitElement.prototype);
 BitSelector.prototype.constructor = BitSelector;
 BitSelector.prototype.tooltipText = "BitSelector ToolTip : Divides input bits into several equal-sized groups.";
+BitSelector.prototype.helplink = "https://docs.circuitverse.org/#/decodersandplexers?id=bit-selector";
 BitSelector.prototype.changeSelectorBitWidth = function (size) {
     if (size == undefined || size < 1 || size > 32) return;
     this.selectorBitWidth = size;
@@ -2291,6 +2303,7 @@ NorGate.prototype.tooltipText = "Nor Gate ToolTip : Combination of OR gate and N
 NorGate.prototype.alwaysResolve = true;
 NorGate.prototype.changeInputSize = changeInputSize;
 NorGate.prototype.verilogType = "nor";
+NorGate.prototype.helplink = "https://docs.circuitverse.org/#/gates?id=nor-gate";
 NorGate.prototype.customSave = function () {
     var data = {
         constructorParamaters: [this.direction, this.inputSize, this.bitWidth],
@@ -2779,6 +2792,7 @@ function Demultiplexer(x, y, scope = globalScope, dir = "LEFT", bitWidth = 1, co
 Demultiplexer.prototype = Object.create(CircuitElement.prototype);
 Demultiplexer.prototype.constructor = Demultiplexer;
 Demultiplexer.prototype.tooltipText = "DeMultiplexer ToolTip : Multiple outputs and a single line input.";
+Demultiplexer.prototype.helplink = "https://docs.circuitverse.org/#/decodersandplexers?id=demultiplexer";
 Demultiplexer.prototype.customSave = function () {
     var data = {
         constructorParamaters: [this.direction, this.bitWidth, this.controlSignalSize],
@@ -2906,6 +2920,7 @@ function Decoder(x, y, scope = globalScope, dir = "LEFT", bitWidth = 1) {
 Decoder.prototype = Object.create(CircuitElement.prototype);
 Decoder.prototype.constructor = Decoder;
 Decoder.prototype.tooltipText = "Decoder ToolTip : Converts coded inputs into coded outputs.";
+Decoder.prototype.helplink = "https://docs.circuitverse.org/#/decodersandplexers?id=decoder";
 Decoder.prototype.customSave = function () {
     var data = {
         constructorParamaters: [this.direction, this.bitWidth],
@@ -2986,7 +3001,7 @@ function Flag(x, y, scope = globalScope, dir = "RIGHT", bitWidth = 1, identifier
 Flag.prototype = Object.create(CircuitElement.prototype);
 Flag.prototype.constructor = Flag;
 Flag.prototype.tooltipText = "FLag ToolTip: Use this for debugging and plotting."
-Flag.prototype.helplink = "https://docs.circuitverse.org/#/miscellaneous?id=tunnel";
+Flag.prototype.helplink = "https://docs.circuitverse.org/#/timing_diagrams?id=using-flags";
 Flag.prototype.setPlotValue = function () {
     var time = plotArea.stopWatch.ElapsedMilliseconds;
 
@@ -3113,6 +3128,7 @@ function MSB(x, y, scope = globalScope, dir = "RIGHT", bitWidth = 1) {
 MSB.prototype = Object.create(CircuitElement.prototype);
 MSB.prototype.constructor = MSB;
 MSB.prototype.tooltipText = "MSB ToolTip : The most significant bit or the high-order bit.";
+MSB.prototype.helplink = "https://docs.circuitverse.org/#/decodersandplexers?id=most-significant-bit-msb-detector";
 MSB.prototype.customSave = function () {
     var data = {
 
@@ -3196,6 +3212,7 @@ function LSB(x, y, scope = globalScope, dir = "RIGHT", bitWidth = 1) {
 LSB.prototype = Object.create(CircuitElement.prototype);
 LSB.prototype.constructor = LSB;
 LSB.prototype.tooltipText = "LSB ToolTip : The least significant bit or the low-order bit.";
+LSB.prototype.helplink = "https://docs.circuitverse.org/#/decodersandplexers?id=least-significant-bit-lsb-detector";
 LSB.prototype.customSave = function () {
     var data = {
 
@@ -3300,6 +3317,7 @@ function PriorityEncoder(x, y, scope = globalScope, dir = "RIGHT", bitWidth = 1)
 PriorityEncoder.prototype = Object.create(CircuitElement.prototype);
 PriorityEncoder.prototype.constructor = PriorityEncoder;
 PriorityEncoder.prototype.tooltipText = "Priority Encoder ToolTip : Compresses binary inputs into a smaller number of outputs.";
+PriorityEncoder.prototype.helplink = "https://docs.circuitverse.org/#/decodersandplexers?id=priority-encoder";
 PriorityEncoder.prototype.customSave = function () {
     var data = {
 
@@ -3408,6 +3426,7 @@ function Tunnel(x, y, scope = globalScope, dir = "LEFT", bitWidth = 1, identifie
 Tunnel.prototype = Object.create(CircuitElement.prototype);
 Tunnel.prototype.constructor = Tunnel;
 Tunnel.prototype.tooltipText = "Tunnel ToolTip : Tunnel Selected.";
+Tunnel.prototype.helplink = "https://docs.circuitverse.org/#/miscellaneous?id=tunnel";
 Tunnel.prototype.newDirection = function (dir) {
     if (this.direction == dir) return;
     this.direction = dir;
@@ -3727,6 +3746,7 @@ function Rectangle(x, y, scope = globalScope, rows = 15, cols = 20) {
 Rectangle.prototype = Object.create(CircuitElement.prototype);
 Rectangle.prototype.constructor = Rectangle;
 Rectangle.prototype.tooltipText = "Rectangle ToolTip : Used to Box the Circuit or area you want to highlight.";
+Rectangle.prototype.helplink = "https://docs.circuitverse.org/#/annotation?id=rectangle";
 Rectangle.prototype.changeRowSize = function (size) {
     if (size == undefined || size < 5 || size > 1000) return;
     if (this.rows == size) return;
@@ -3815,6 +3835,7 @@ function Arrow(x, y, scope = globalScope, dir = "RIGHT") {
 Arrow.prototype = Object.create(CircuitElement.prototype);
 Arrow.prototype.constructor = Arrow;
 Arrow.prototype.tooltipText = "Arrow ToolTip : Arrow Selected.";
+Arrow.prototype.helplink = "https://docs.circuitverse.org/#/annotation?id=arrow";
 Arrow.prototype.customSave = function () {
     var data = {
         constructorParamaters: [this.direction],

--- a/public/js/ram.js
+++ b/public/js/ram.js
@@ -54,6 +54,7 @@ RAM.prototype.tooltipText = "Random Access Memory";
 RAM.prototype.shortName = "RAM";
 RAM.prototype.maxAddressWidth = 20;
 RAM.prototype.constructor = RAM;
+RAM.prototype.helplink = "https://docs.circuitverse.org/#/memoryElements?id=ram";
 RAM.prototype.mutableProperties = {
     "addressWidth": {
         name: "Address Width",

--- a/public/js/sequential.js
+++ b/public/js/sequential.js
@@ -45,6 +45,7 @@ function TflipFlop(x, y, scope = globalScope, dir = "RIGHT") {
 TflipFlop.prototype = Object.create(CircuitElement.prototype);
 TflipFlop.prototype.constructor = TflipFlop;
 TflipFlop.prototype.tooltipText = "T FlipFlop ToolTip :  Changes state / Toggles whenever the clock input is strobed.";
+TflipFlop.prototype.helplink = "https://docs.circuitverse.org/#/Sequential?id=t-flip-flop";
 TflipFlop.prototype.isResolvable = function() {
     if (this.reset.value == 1) return true;
     if (this.clockInp.value != undefined && this.dInp.value != undefined) return true;
@@ -153,6 +154,7 @@ function DflipFlop(x, y, scope = globalScope, dir = "RIGHT", bitWidth = 1) {
 DflipFlop.prototype = Object.create(CircuitElement.prototype);
 DflipFlop.prototype.constructor = DflipFlop;
 DflipFlop.prototype.tooltipText = "D FlipFlop ToolTip : Introduces delay in timing circuit.";
+DflipFlop.prototype.helplink = "https://docs.circuitverse.org/#/Sequential?id=d-flip-flop";
 DflipFlop.prototype.isResolvable = function() {
 	return true;
     if (this.reset.value == 1) return true;
@@ -261,6 +263,7 @@ function Dlatch(x, y, scope = globalScope, dir = "RIGHT", bitWidth = 1) {
 Dlatch.prototype = Object.create(CircuitElement.prototype);
 Dlatch.prototype.constructor = Dlatch;
 Dlatch.prototype.tooltipText = "D Latch : Single input Flip flop or D FlipFlop";
+Dlatch.prototype.helplink = "https://docs.circuitverse.org/#/Sequential?id=d-latch";
 Dlatch.prototype.isResolvable = function() {
     if (this.clockInp.value != undefined && this.dInp.value != undefined ) return true;
     return false;
@@ -347,6 +350,8 @@ function Random(x, y, scope = globalScope, dir = "RIGHT", bitWidth = 1) {
 }
 Random.prototype = Object.create(CircuitElement.prototype);
 Random.prototype.constructor = Random;
+Random.prototype.tooltipText = "Random ToolTip : Random Selected.";
+Random.prototype.helplink = "https://docs.circuitverse.org/#/inputElements?id=random";
 Random.prototype.isResolvable = function() {
     if (this.clockInp.value != undefined && ( this.maxValue.value != undefined || this.maxValue.connections.length == 0 ) )
         return true;
@@ -432,6 +437,7 @@ function SRflipFlop(x, y, scope = globalScope, dir = "RIGHT") {
 SRflipFlop.prototype = Object.create(CircuitElement.prototype);
 SRflipFlop.prototype.constructor = SRflipFlop;
 SRflipFlop.prototype.tooltipText = "SR FlipFlop ToolTip : SR FlipFlop Selected.";
+SRflipFlop.prototype.helplink = "https://docs.circuitverse.org/#/Sequential?id=sr-flip-flop";
 SRflipFlop.prototype.newBitWidth = function(bitWidth) {
     this.bitWidth = bitWidth;
     this.dInp.bitWidth = bitWidth;
@@ -535,6 +541,7 @@ function JKflipFlop(x, y, scope = globalScope, dir = "RIGHT") {
 JKflipFlop.prototype = Object.create(CircuitElement.prototype);
 JKflipFlop.prototype.constructor = JKflipFlop;
 JKflipFlop.prototype.tooltipText = "JK FlipFlop ToolTip : gated SR flip-flop with the addition of a clock input.";
+JKflipFlop.prototype.helplink = "https://docs.circuitverse.org/#/Sequential?id=jk-flip-flop";
 JKflipFlop.prototype.isResolvable = function() {
     if (this.reset.value == 1) return true;
     if (this.clockInp.value != undefined && this.J.value != undefined && this.K.value != undefined) return true;
@@ -662,6 +669,7 @@ function TTY(x, y, scope = globalScope, rows = 3, cols = 32) {
 TTY.prototype = Object.create(CircuitElement.prototype);
 TTY.prototype.constructor = TTY;
 TTY.prototype.tooltipText = "TTY ToolTip : Tele typewriter selected.";
+TTY.prototype.helplink = "https://docs.circuitverse.org/#/Sequential?id=tty";
 TTY.prototype.changeRowSize = function(size) {
     if (size == undefined || size < 1 || size > 10) return;
     if (this.rows == size) return;
@@ -801,6 +809,7 @@ function Keyboard(x, y, scope = globalScope, bufferSize = 32) {
 Keyboard.prototype = Object.create(CircuitElement.prototype);
 Keyboard.prototype.constructor = Keyboard;
 Keyboard.prototype.tooltipText = "Keyboard";
+Keyboard.prototype.helplink = "https://docs.circuitverse.org/#/Sequential?id=keyboard";
 Keyboard.prototype.changeBufferSize = function(size) {
     if (size == undefined || size < 20 || size > 100) return;
     if (this.bufferSize == size) return;

--- a/public/js/testBench.js
+++ b/public/js/testBench.js
@@ -23,6 +23,7 @@ TB_Input.prototype = Object.create(CircuitElement.prototype);
 TB_Input.prototype.constructor = TB_Input;
 TB_Input.prototype.tooltipText = "Test Bench Input Selected";
 TB_Input.prototype.centerElement = true;
+TB_Input.prototype.helplink = "https://docs.circuitverse.org/#/testbench";
 TB_Input.prototype.dblclick=function(){
     this.testData=JSON.parse(prompt("Enter TestBench Json"));
     this.setup();
@@ -293,6 +294,7 @@ function TB_Output(x, y, scope = globalScope, dir = "RIGHT",  identifier) {
 TB_Output.prototype = Object.create(CircuitElement.prototype);
 TB_Output.prototype.constructor = TB_Output;
 TB_Output.prototype.tooltipText = "Test Bench Output Selected";
+TB_Output.prototype.helplink = "https://docs.circuitverse.org/#/testbench";
 TB_Output.prototype.centerElement = true;
 // TB_Output.prototype.dblclick=function(){
 //     this.testData=JSON.parse(prompt("Enter TestBench Json"));


### PR DESCRIPTION
Fixes https://github.com/CircuitVerse/CircuitVerse/issues/1317

#### Describe the changes you have made in this PR -
- There are two buttons: 
1. CircuitVerse Tip - when hovered, the tooltip text of the element will be displayed.
2. CircuitVerse Help - when clicked, it redirects the user to the element's document page. If the element does not have documentation then this button will not be displayed.
- A tooltip text was missing for Random, added it.
### Screenshots of the changes (If any) -

#### Before:
![Screenshot (552)](https://user-images.githubusercontent.com/35162705/77930889-0e2c5200-72c9-11ea-9dd4-fc2cc1dc37dd.png)

#### After:
![Screenshot (557)](https://user-images.githubusercontent.com/35162705/78790021-90083380-79cb-11ea-84ee-8765c89c4c0e.png)


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
