### PR TITLE
Marquee effect for example title

### DIFF
--- a/app/views/logix/examples.html.erb
+++ b/app/views/logix/examples.html.erb
@@ -50,7 +50,7 @@
             <div class="card card-examplepage-example d-inline-block my-4 rounded-0">
               <%= image_tag example[:img], alt: example[:name], class: "card-img-top card-img-examplepage-example" %>
               <div class="card-footer card-footer-examplepage-example">
-                <p class="examplepage-example-p d-inline-block float-left mt-2 overflow-hidden text-left text-truncate"><%= example[:name] %></p>
+                <marquee class="examplepage-example-p d-inline-block float-left mt-2 overflow-hidden text-left text-truncate" onmouseover="this.stop();" onmouseout="this.start();"><%= example[:name] %></marquee>
                 <button type="button" class="btn btn-about examplepage-example-button float-right mb-3" onclick="window.location.href = 'https://circuitverse.org/<%= example[:id] %>';">View</button>
               </div>
             </div>


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -Added marquee effect for example title, it will stop when hovered, text is hidden when text stops on hovering




### Screenshots of the changes (If any) -

![20200402_175226](https://user-images.githubusercontent.com/51922630/78248957-2d1a2680-750b-11ea-919b-a89e458a87ab.gif)



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
