### PR TITLE
added truncate() method to project.name, partialzied project cards

### DIFF
--- a/app/views/featured_circuits/index.html.erb
+++ b/app/views/featured_circuits/index.html.erb
@@ -14,7 +14,7 @@
         <% @projects.each do |project| -%>
           <div class="row feature">
                  <div class="col-12 col-md-8">
-                     <h3 class="card-title"><%= project.name %></h4>
+                     <h3 class="card-title"><%= truncate( project.name, length: 18) %></h4>
                      <p class="card-text"></p>
                           <a class="btn btn-dark btn-lg" target="_blank" href="<%= user_project_url(project.author, project) %>" role="button">View Example &raquo;</a>
                  </div>

--- a/app/views/users/logix/_dashboard.html.erb
+++ b/app/views/users/logix/_dashboard.html.erb
@@ -1,27 +1,5 @@
 <% projects.each do |project| %>
-
   <% if policy(project).check_direct_view_access? %>
-    <div class="col-xs-12 col-sm-6 col-md-4 col-lg-4">
-      <div class="card text-center card-userprojects">
-        <div class="card-header card-header-userprojects rounded-0">
-          <h3 class="cardname"><%= project.name %></h3>
-            <% if !project.assignment_id.nil? %>
-              <span class="badge badge-dark">Assignment</span>
-            <% end %>
-              <span class="badge badge-dark"><%= project.project_access_type %></span>
-        </div>
-        <img class="card-img-top" src="<%= project.image_preview.url %>" alt="<%= project.name %>">
-        <div class="card-footer card-footer-userprojects">
-          <% if policy(project).user_access? %>
-            <a href="<%= simulator_edit_path(project) %>" class="btn btn-userprojects" target="_blank">Launch</a>
-          <% else %>
-            <a href="<%= create_fork_project_path(project) %>" class="btn btn-userprojects" target="_blank">Fork</a>
-          <% end %>
-            <a href="#" id="<%= project.id %>" class="previewButton btn btn-userprojects" data-toggle="modal" data-target="#myModal">View</a>
-            <a href="<%= user_project_path(@user,project) %>" class="btn btn-userprojects" target="_blank">More</a>
-        </div>
-      </div>
-    </div>
+    <%= render partial: 'project_card', :locals => {:project => project} %>
   <% end %>
-
 <% end %>

--- a/app/views/users/logix/_project_card.html.erb
+++ b/app/views/users/logix/_project_card.html.erb
@@ -1,0 +1,22 @@
+
+        <div class="col-xs-12 col-sm-6 col-md-4 col-lg-4">
+          <div class="card text-center card-userprojects">
+            <div class="card-header card-header-userprojects rounded-0">
+              <h3 class="cardname"><%= truncate( project.name, length: 18) %></h3>
+              <% if !project.assignment_id.nil? %>
+                <span class="badge badge-dark">Assignment</span>
+              <% end %>
+                <span class="badge badge-dark"><%= project.project_access_type %></span>
+            </div>
+            <img class="card-img-top" src="<%= project.image_preview.url %>" alt="<%= project.name %>">
+            <div class="card-footer card-footer-userprojects">
+              <% if policy(project).user_access? %>
+                <a href="<%= simulator_edit_path(project) %>" class="btn btn-about" target="_blank">Launch</a>
+              <% else %>
+                <a href="<%= create_fork_project_path(project) %>" class="btn btn-about" target="_blank">Fork</a>
+              <% end %>
+              <a href="#" id="<%= project.id %>" class="previewButton btn btn-about" data-toggle="modal" data-target="#myModal">View</a>
+              <a href="<%= user_project_path(@user,project) %>" class="btn btn-about" target="_blank">More</a>
+            </div>
+          </div>
+        </div>

--- a/app/views/users/logix/favourites.html.erb
+++ b/app/views/users/logix/favourites.html.erb
@@ -18,31 +18,11 @@
 
   <div class="row">
     <% @projects.each do |project| %>
-
       <% if policy(project).check_direct_view_access? %>
-        <div class="col-xs-12 col-sm-6 col-md-4 col-lg-4">
-          <div class="card text-center card-userprojects">
-            <div class="card-header card-header-userprojects rounded-0">
-              <h3 class="cardname"><%= project.name %></h3>
-              <% if !project.assignment_id.nil? %>
-                <span class="badge badge-dark">Assignment</span>
-              <% end %>
-                <span class="badge badge-dark"><%= project.project_access_type %></span>
-            </div>
-            <img class="card-img-top" src="<%= project.image_preview.url %>" alt="<%= project.name %>" >
-            <div class="card-footer card-footer-userprojects">
-              <% if policy(project).user_access? %>
-                <a href="<%= simulator_edit_path(project) %>" class="btn btn-about" target="_blank">Launch</a>
-              <% else %>
-                <a href="<%= create_fork_project_path(project) %>" class="btn btn-about" target="_blank">Fork</a>
-              <% end %>
-              <a href="#" id="<%= project.id %>" class="previewButton btn btn-about" data-toggle="modal" data-target="#myModal">View</a>
-              <a href="<%= user_project_path(@user,project) %>" class="btn btn-about" target="_blank">More</a>
-            </div>
-          </div>
-        </div>
+        <%= render partial: 'project_card', :locals => {:project => project} %>
       <% end %>
     <% end %>
+
   </div>
 </div>
 


### PR DESCRIPTION
A simple fix for un-even cards, title longer than 21 characters shall be truncated.
![Firefox_Screenshot_2020-04-02T18-17-32 869Z](https://user-images.githubusercontent.com/42478217/78284021-57380c80-753c-11ea-8ef7-a1a2e2b77886.png)
