### PR TITLE
Fix Bit Overflow by limiting input to 32

### DIFF
--- a/public/js/UX.js
+++ b/public/js/UX.js
@@ -223,17 +223,24 @@ function showProperties(obj) {
         });
     }
 
-
-
-
-
-
+    function checkValidBitWidth() {
+        const selector = $("[name='newBitWidth']");
+        if (selector == undefined
+            || selector.val() > 32
+            || selector.val() < 1
+            || !$.isNumeric(selector.val())) {
+            // fallback to previously saves state
+            selector.val(selector.attr("old-val"));
+        } else {
+            selector.attr("old-val", selector.val());
+        }
+    }
 
     $(".objectPropertyAttribute").on("change keyup paste click", function () {
         // return;
         //////console.log(this.name+":"+this.value);
 
-
+        checkValidBitWidth()
         scheduleUpdate();
         updateCanvas = true;
         wireToBeChecked = 1;


### PR DESCRIPTION
Fixes #910 : Input fields can no longer have more than 32 width


#### Describe the changes you have made in this PR -
A function to automatically set widths greater than 32 to 32.

### Screenshots of the changes (If any) -
See the changes tab.



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
