### PR TITLE
Fix bug user can't add himself as collaborator

### DIFF
--- a/app/controllers/collaborations_controller.rb
+++ b/app/controllers/collaborations_controller.rb
@@ -56,8 +56,14 @@ class CollaborationsController < ApplicationController
       end
     end
 
+    if is_himself
+      notice = Utils.mail_notice_report_is_current_user(collaboration_params[:emails], collaboration_emails, newly_added)
+    else
+      notice = Utils.mail_notice(collaboration_params[:emails], collaboration_emails, newly_added)
+    end
+
     respond_to do |format|
-      format.html { redirect_to user_project_path(@project.author_id,@project.id), notice: Utils.mail_notice_report_is_current_user(collaboration_params[:emails], collaboration_emails, newly_added, is_himself)}
+      format.html { redirect_to user_project_path(@project.author_id,@project.id), notice: notice }
     end
 
   end

--- a/app/controllers/collaborations_controller.rb
+++ b/app/controllers/collaborations_controller.rb
@@ -34,16 +34,12 @@ class CollaborationsController < ApplicationController
     # if(not @project.assignment_id.nil?)
     #   render plain: "Assignments cannot have collaborators. Please contact admin." and return
     # end
-    authorize @project, :author_access?   
-    if collaboration_params[:emails].include?(current_user.email)
-      is_himself = true
-    else
-      is_himself = false
-    end
+    authorize @project, :author_access?
+
     current = current_user
     already_present = User.where(id: @project.collaborations.pluck(:user_id)).pluck(:email)
     collaboration_emails = Utils.parse_mails_except_current_user(collaboration_params[:emails], current)
-    
+
     newly_added = collaboration_emails - already_present
 
     newly_added.each do |email|
@@ -56,7 +52,7 @@ class CollaborationsController < ApplicationController
       end
     end
 
-    if is_himself
+    if collaboration_params[:emails].include?(current_user.email)
       notice = Utils.mail_notice_report_is_current_user(collaboration_params[:emails], collaboration_emails, newly_added)
     else
       notice = Utils.mail_notice(collaboration_params[:emails], collaboration_emails, newly_added)

--- a/app/controllers/collaborations_controller.rb
+++ b/app/controllers/collaborations_controller.rb
@@ -52,7 +52,7 @@ class CollaborationsController < ApplicationController
       end
     end
 
-    notice =  Utils.mail_notice(collaboration_params[:emails], collaboration_emails, newly_added)
+    notice = Utils.mail_notice(collaboration_params[:emails], collaboration_emails, newly_added)
 
     if collaboration_params[:emails].include?(current_user.email)
       notice = notice.prepend("You cannot invite yourself. ")

--- a/app/controllers/collaborations_controller.rb
+++ b/app/controllers/collaborations_controller.rb
@@ -36,10 +36,9 @@ class CollaborationsController < ApplicationController
     # end
     authorize @project, :author_access?
 
-    current = current_user
     already_present = User.where(id: @project.collaborations.pluck(:user_id)).pluck(:email)
     collaboration_emails = Utils.parse_mails_except_current_user(collaboration_params[:emails],
-                                                                 current)
+                                                                 current_user)
 
     newly_added = collaboration_emails - already_present
 
@@ -56,7 +55,7 @@ class CollaborationsController < ApplicationController
     notice = Utils.mail_notice(collaboration_params[:emails], collaboration_emails, newly_added)
 
     if collaboration_params[:emails].include?(current_user.email)
-      notice = notice.prepend("You cannot invite yourself. ")
+      notice.prepend("You can't invite yourself. ")
     end
 
     respond_to do |format|

--- a/app/controllers/collaborations_controller.rb
+++ b/app/controllers/collaborations_controller.rb
@@ -52,10 +52,10 @@ class CollaborationsController < ApplicationController
       end
     end
 
+    notice =  Utils.mail_notice(collaboration_params[:emails], collaboration_emails, newly_added)
+
     if collaboration_params[:emails].include?(current_user.email)
-      notice = Utils.mail_notice_report_is_current_user(collaboration_params[:emails], collaboration_emails, newly_added)
-    else
-      notice = Utils.mail_notice(collaboration_params[:emails], collaboration_emails, newly_added)
+      notice = notice.prepend("You cannot invite yourself. ")
     end
 
     respond_to do |format|

--- a/app/controllers/collaborations_controller.rb
+++ b/app/controllers/collaborations_controller.rb
@@ -38,7 +38,8 @@ class CollaborationsController < ApplicationController
 
     current = current_user
     already_present = User.where(id: @project.collaborations.pluck(:user_id)).pluck(:email)
-    collaboration_emails = Utils.parse_mails_except_current_user(collaboration_params[:emails], current)
+    collaboration_emails = Utils.parse_mails_except_current_user(collaboration_params[:emails],
+                                                                 current)
 
     newly_added = collaboration_emails - already_present
 

--- a/app/helpers/utils.rb
+++ b/app/helpers/utils.rb
@@ -33,18 +33,4 @@ module Utils
                "No valid Email(s) entered."
              end
   end
-
-  def self.mail_notice_report_is_current_user(input_mails, parsed_mails, newly_added)
-    total = input_mails.split(/[\s,\,]/).select(&:present?).count
-    valid = parsed_mails.count
-    invalid = total - valid
-    already_present = (parsed_mails - newly_added).count
-
-    notice = if total != 0 && valid != 0
-              "You cannot add yourself. Out of #{total} Email(s), #{valid} #{valid != 1 ? 'were' : 'was'} valid and #{invalid} #{invalid != 1 ? 'were' : 'was'} invalid. #{newly_added.count} user(s) will be invited. " + \
-               (already_present == 0 ? "No users were already present." : "#{already_present} user(s) #{already_present!= 1 ? 'were' : 'was'} already present.")
-             else
-              "No valid email(s) entered. You cannot invite yourself"
-             end
-  end
 end

--- a/app/helpers/utils.rb
+++ b/app/helpers/utils.rb
@@ -9,6 +9,12 @@ module Utils
     end.uniq.map(&:downcase)
   end
 
+  def self.parse_mails_except_current_user(mails, current)
+    mails.split(/[\s,\,]/).select do |email|
+      email.present? && email != current.email && Devise.email_regexp.match?(email)
+    end.uniq.map(&:downcase)
+  end
+
   # Forms notice string for given email input
   # @param input_mails string of emails entered
   # @param parsed_mails array of valid emails
@@ -25,6 +31,25 @@ module Utils
                (already_present == 0 ? "No users were already present." : "#{already_present} user(s) #{already_present!= 1 ? 'were' : 'was'} already present.")
              else
                "No valid Email(s) entered."
+             end
+  end
+
+  def self.mail_notice_report_is_current_user(input_mails, parsed_mails, newly_added, is_himself)
+    total = input_mails.split(/[\s,\,]/).select(&:present?).count
+    valid = parsed_mails.count
+    invalid = total - valid
+    already_present = (parsed_mails - newly_added).count
+
+    notice = if total != 0 && valid != 0 && is_himself
+              "You cannot add yourself. Out of #{total} Email(s), #{valid} #{valid != 1 ? 'were' : 'was'} valid and #{invalid} #{invalid != 1 ? 'were' : 'was'} invalid. #{newly_added.count} user(s) will be invited. " + \
+               (already_present == 0 ? "No users were already present." : "#{already_present} user(s) #{already_present!= 1 ? 'were' : 'was'} already present.")
+             elsif total != 0 && valid != 0 && !is_himself
+              "Out of #{total} Email(s), #{valid} #{valid != 1 ? 'were' : 'was'} valid and #{invalid} #{invalid != 1 ? 'were' : 'was'} invalid. #{newly_added.count} user(s) will be invited. " + \
+               (already_present == 0 ? "No users were already present." : "#{already_present} user(s) #{already_present!= 1 ? 'were' : 'was'} already present.")
+             elsif total == 0 || valid == 0 && is_himself
+              "No valid email(s) entered. You cannot invite yourself"
+             else
+              "No valid email(s) entered"
              end
   end
 end

--- a/app/helpers/utils.rb
+++ b/app/helpers/utils.rb
@@ -42,7 +42,7 @@ module Utils
 
     notice = if total != 0 && valid != 0
               "You cannot add yourself. Out of #{total} Email(s), #{valid} #{valid != 1 ? 'were' : 'was'} valid and #{invalid} #{invalid != 1 ? 'were' : 'was'} invalid. #{newly_added.count} user(s) will be invited. " + \
-               (already_present == 0 ? "No users were already present." : "#{already_present} user(s) #{already_present!= 1 ? 'were' : 'was'} already present.")             
+               (already_present == 0 ? "No users were already present." : "#{already_present} user(s) #{already_present!= 1 ? 'were' : 'was'} already present.")
              else
               "No valid email(s) entered. You cannot invite yourself"
              end

--- a/app/helpers/utils.rb
+++ b/app/helpers/utils.rb
@@ -34,22 +34,17 @@ module Utils
              end
   end
 
-  def self.mail_notice_report_is_current_user(input_mails, parsed_mails, newly_added, is_himself)
+  def self.mail_notice_report_is_current_user(input_mails, parsed_mails, newly_added)
     total = input_mails.split(/[\s,\,]/).select(&:present?).count
     valid = parsed_mails.count
     invalid = total - valid
     already_present = (parsed_mails - newly_added).count
 
-    notice = if total != 0 && valid != 0 && is_himself
+    notice = if total != 0 && valid != 0
               "You cannot add yourself. Out of #{total} Email(s), #{valid} #{valid != 1 ? 'were' : 'was'} valid and #{invalid} #{invalid != 1 ? 'were' : 'was'} invalid. #{newly_added.count} user(s) will be invited. " + \
-               (already_present == 0 ? "No users were already present." : "#{already_present} user(s) #{already_present!= 1 ? 'were' : 'was'} already present.")
-             elsif total != 0 && valid != 0 && !is_himself
-              "Out of #{total} Email(s), #{valid} #{valid != 1 ? 'were' : 'was'} valid and #{invalid} #{invalid != 1 ? 'were' : 'was'} invalid. #{newly_added.count} user(s) will be invited. " + \
-               (already_present == 0 ? "No users were already present." : "#{already_present} user(s) #{already_present!= 1 ? 'were' : 'was'} already present.")
-             elsif total == 0 || valid == 0 && is_himself
-              "No valid email(s) entered. You cannot invite yourself"
+               (already_present == 0 ? "No users were already present." : "#{already_present} user(s) #{already_present!= 1 ? 'were' : 'was'} already present.")             
              else
-              "No valid email(s) entered"
+              "No valid email(s) entered. You cannot invite yourself"
              end
   end
 end

--- a/spec/controllers/collaborations_controller_spec.rb
+++ b/spec/controllers/collaborations_controller_spec.rb
@@ -27,7 +27,7 @@ describe CollaborationsController, type: :request do
       end
 
       it "creates collaboration" do
-        expect(Utils).to receive(:mail_notice)
+        expect(Utils).to receive(:mail_notice_report_is_current_user)
         expect {
           post collaborations_path, params: create_params
         }.to change { Collaboration.count }.by(1)

--- a/spec/controllers/collaborations_controller_spec.rb
+++ b/spec/controllers/collaborations_controller_spec.rb
@@ -27,7 +27,7 @@ describe CollaborationsController, type: :request do
       end
 
       it "creates collaboration" do
-        expect(Utils).to receive(:mail_notice_report_is_current_user)
+        expect(Utils).to receive(:mail_notice)
         expect {
           post collaborations_path, params: create_params
         }.to change { Collaboration.count }.by(1)


### PR DESCRIPTION
Fixes #1357

#### Describe the changes you have made in this PR - If user wants to add himself as collaborator then he will not be allowed to do so and error message will be displayed "You can't add yourself as collaborator" 
Note: The email of user himself is considered as invalid for input.

### Screenshots of the changes (If any) -
![Screenshot (261)](https://user-images.githubusercontent.com/51922630/78662729-907ecc80-78ee-11ea-81b8-3c92afbb80fd.png)
![Screenshot (262)](https://user-images.githubusercontent.com/51922630/78662733-92e12680-78ee-11ea-8114-bacdcd916afb.png)

harsh.g225566@gmail.com was the user and harsh19may@gmail.com was already added rest two were new


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
