### PR TITLE
Reset button updated

### DIFF
--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -174,7 +174,7 @@
               <div class="">
                 Reset all nodes:
                 <button type="button" class="btn zoomButton btn-lg" onclick="layoutResetNodes()">
-                  <span class="fa fa-refresh" aria-hidden="true" title="Reset"></span>
+                  <span class="fa fa-sync" aria-hidden="true" title="Reset"></span>
                 </button>
               </div>
               <div class="">


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -
The `Reset all nodes` icon is not present in the simulator edit layout option currently.
I have fixed this by updating the icon.

### Screenshots of the changes (If any) -
Before:
![2](https://user-images.githubusercontent.com/42182955/79223527-24b0dc80-7e77-11ea-90b5-3617f71bee87.PNG)

After:
![1](https://user-images.githubusercontent.com/42182955/79223544-2da1ae00-7e77-11ea-81e1-6ebd13cb68d9.PNG)






Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
