### PR TITLE
Changed "Learn Logic Design" hyperlink into a button

### DIFF
--- a/app/views/logix/index.html.erb
+++ b/app/views/logix/index.html.erb
@@ -42,7 +42,7 @@
           <h1>Dive into the world of Logic Circuits for free!</h1><br>
           <p>From simple gates to complex sequential circuits, plot timing diagrams, automatic circuit generation, explore standard ICs, and much more</p>
           <a class="btn btn-homepage btn-about" href='/simulator'>Launch Simulator</a>
-          <a href="https://learn.circuitverse.org/" class="a-homepage">Learn Logic Design</a>
+          <a class="btn btn-homepage btn-about" href="https://learn.circuitverse.org/">Learn Logic Design</a>
         </div>
         <div>
           <%= image_tag "homepage/new_homepage_sketch.png", alt: "HomepageSketch", :class => "homepage-cover" %>


### PR DESCRIPTION
Fixes #1439 

### Changes made:
in the index.html.erb file, changed the class of the "Learn Logic Design" element from `a-homepage ` to `btn btn-homepage btn-about` in order to present it on the landing page as a button instead of a plain hyperlink.

### Screenshots of the changes:
![LandingPage](https://user-images.githubusercontent.com/28871211/82478734-f87c2180-9aee-11ea-93a1-9f18d6b70bd1.JPG)

