### PR TITLE
Allow blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Have any issues to discuss regarding CircuitVerse?
     url: https://join.slack.com/t/circuitverse-team/shared_invite/enQtNjc4MzcyNDE5OTA3LTdjYTM5NjFiZWZlZGI2MmU1MmYzYzczNmZlZDg5MjYxYmQ4ODRjMjQxM2UyMWI5ODUzODQzMDU2ZDEzNjI4NmE


### PR DESCRIPTION
I think limiting possible issues to only two categories is a quite bad idea. I want to add an issue that is more like issue regarding code base and it doesn't fit a `bug` or `feature request`.