### PR TITLE
removed backspace to delete selection

### DIFF
--- a/public/js/listeners.js
+++ b/public/js/listeners.js
@@ -161,8 +161,8 @@ function startListeners() {
             }
         }
 
-        if (e.keyCode == 8 || e.key == "Delete") {
-            delete_selected();
+        if (e.key == "Delete") {
+            if (simulationArea.lastSelected) delete_selected();
         }
 
         if (simulationArea.controlDown && e.key.charCodeAt(0) == 122) { // detect the special CTRL-Z code


### PR DESCRIPTION
Fixes #

I have removed 'keyCode == 8'  condition from delete selected listener, keyCode 8 is backspace, but some browsers have default listener with backspace, making it useless on browsers such as firefox,
I also added a condition to fire delete selected only when something is selected.

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
