### PR TITLE
Add project preview image API

### DIFF
--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::ProjectsController < Api::V1::BaseController
   include ActionView::Helpers::SanitizeHelper
 
   before_action :authenticate_user, only: %i[index show]
-  before_action :authenticate_user!, except: %i[index show]
+  before_action :authenticate_user!, except: %i[index show image_preview]
   before_action :load_index_projects, only: %i[index]
   before_action :load_user_projects, only: %i[user_projects]
   before_action :load_featured_circuits, only: %i[featured_circuits]
@@ -32,6 +32,11 @@ class Api::V1::ProjectsController < Api::V1::BaseController
     authorize @project, :check_view_access?
     @project.increase_views(@current_user)
     render json: Api::V1::ProjectSerializer.new(@project, @options)
+  end
+
+  def image_preview
+    @project = Project.open.find(params[:id])
+    render json: { "project_preview": request.base_url + @project.image_preview.url }
   end
 
   # PATCH /api/v1/projects/:id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,6 +126,7 @@ Rails.application.routes.draw do
         member do
           get 'toggle-star', to: 'projects#toggle_star'
           get 'fork', to: 'projects#create_fork'
+          get 'image_preview', to: 'projects#image_preview'
         end
       end
       resources :users do

--- a/spec/requests/api/v1/projects_controller/image_preview_spec.rb
+++ b/spec/requests/api/v1/projects_controller/image_preview_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::ProjectsController, "#image_preview", type: :request do
+  describe "get project image preview" do
+    let!(:public_project) { FactoryBot.create(:project, project_access_type: "Public") }
+    let!(:private_project) { FactoryBot.create(:project) }
+
+    context "when private project image_preview is requested" do
+      before do
+        get "/api/v1/projects/#{private_project.id}/image_preview", as: :json
+      end
+
+      it "returns status :not_found" do
+        expect(response).to have_http_status(404)
+        expect(response.parsed_body).to have_jsonapi_errors
+      end
+    end
+
+    context "when public project image_preview is requested" do
+      before do
+        get "/api/v1/projects/#{public_project.id}/image_preview", as: :json
+      end
+
+      it "returns image preview" do
+        expect(response).to have_http_status(200)
+        expect(response.parsed_body["project_preview"]).to eq(
+          request.base_url + public_project.image_preview.url
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Describe the changes you have made in this PR -
Add `/api/v1/project/:id/image_preview` to GET public project's full image url

### Screenshots of the changes (If any) -
```
{
  "project_preview": "http://localhost:3000/img/default.png"
}
```


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
