### PR TITLE
Add Grading API 

### DIFF
--- a/app/controllers/api/v1/grades_controller.rb
+++ b/app/controllers/api/v1/grades_controller.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class Api::V1::GradesController < Api::V1::BaseController
+  include ActionView::Helpers::SanitizeHelper
+
+  before_action :authenticate_user!
+  before_action :load_create_resources, only: %i[create]
+  before_action :set_grade, only: %i[update destroy]
+  before_action :check_access
+
+  def create
+    @grade.user_id = @current_user.id
+    @grade.grade = grade_params[:grade]
+    @grade.remarks = sanitize grade_params[:remarks]
+
+    if @grade.save
+      render json: Api::V1::GradeSerializer.new(@grade), status: :created
+    else
+      api_error(status: 422, errors: @grade.errors)
+    end
+  end
+
+  def update
+    @grade.update!(grade_params)
+    render json: Api::V1::GradeSerializer.new(@grade), status: :accepted
+  end
+
+  def destroy
+    @grade.destroy!
+    render json: {}, status: :no_content
+  end
+
+  private
+
+    def load_create_resources
+      @grade = Grade.new(
+        assignment_id: params[:assignment_id], project_id: params[:project_id]
+      )
+    end
+
+    def set_grade
+      @grade = Grade.find(params[:id])
+    end
+
+    def check_access
+      authorize @grade, :mentor?
+    end
+
+    def grade_params
+      params.require(:grade).permit(:grade, :remarks)
+    end
+end

--- a/app/models/grade.rb
+++ b/app/models/grade.rb
@@ -47,7 +47,6 @@ class Grade < ApplicationRecord
         group_members.each do |member|
           submission = submissions.find do |s| (
 
-
                          s.author_id == member.id &&
             s.assignment_id == assignment_id)
           end

--- a/app/models/grade.rb
+++ b/app/models/grade.rb
@@ -10,6 +10,7 @@ class Grade < ApplicationRecord
 
   validates :grade, :user_id, :project_id, :assignment_id, presence: true
   validate :grading_scale, :assignment_project
+  validates :project_id, uniqueness: { scope: :assignment_id }
 
   private
 
@@ -46,7 +47,7 @@ class Grade < ApplicationRecord
         group_members.each do |member|
           submission = submissions.find do |s| (
 
-                         
+
                          s.author_id == member.id &&
             s.assignment_id == assignment_id)
           end

--- a/app/serializers/api/v1/grade_serializer.rb
+++ b/app/serializers/api/v1/grade_serializer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Api::V1::GradeSerializer
+  include FastJsonapi::ObjectSerializer
+
+  attributes :grade, :remarks, :created_at, :updated_at
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -132,6 +132,8 @@ Rails.application.routes.draw do
       resources :users do
         get 'projects', to: 'projects#user_projects', on: :member
       end
+      post '/assignments/:assignment_id/projects/:project_id/grades', to: 'grades#create'
+      resources :grades, only: [:update, :destroy]
     end
   end
 end

--- a/db/migrate/20200604034729_add_unique_grade_validation.rb
+++ b/db/migrate/20200604034729_add_unique_grade_validation.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUniqueGradeValidation < ActiveRecord::Migration[6.0]
+  def change
+    add_index :grades, %i[project_id assignment_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_04_034729) do
+ActiveRecord::Schema.define(version: 2020_06_22_174739) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_22_174739) do
+ActiveRecord::Schema.define(version: 2020_06_04_034729) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -155,6 +155,7 @@ ActiveRecord::Schema.define(version: 2020_06_22_174739) do
     t.bigint "assignment_id"
     t.string "remarks"
     t.index ["assignment_id"], name: "index_grades_on_assignment_id"
+    t.index ["project_id", "assignment_id"], name: "index_grades_on_project_id_and_assignment_id", unique: true
     t.index ["project_id"], name: "index_grades_on_project_id"
     t.index ["user_id"], name: "index_grades_on_user_id"
   end

--- a/spec/requests/api/v1/grades_controller/create_spec.rb
+++ b/spec/requests/api/v1/grades_controller/create_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::GradesController, "#create", type: :request do
+  describe "create a grade" do
+    let!(:mentor) { FactoryBot.create(:user) }
+    let!(:group) { FactoryBot.create(:group, mentor: mentor) }
+    let!(:assignment) { FactoryBot.create(:assignment, group: group, grading_scale: :letter) }
+    let!(:project) { FactoryBot.create(:project, assignment: assignment) }
+
+    context "when not authenticated" do
+      before do
+        post "/api/v1/assignments/#{assignment.id}/projects/#{project.id}/grades", as: :json
+      end
+
+      it "returns status unautheticated" do
+        expect(response).to have_http_status(401)
+        expect(response.parsed_body).to have_jsonapi_errors
+      end
+    end
+
+    context "when not authorized to grade assignment" do
+      before do
+        token = get_auth_token(FactoryBot.create(:user))
+        post "/api/v1/assignments/#{assignment.id}/projects/#{project.id}/grades",
+             headers: { "Authorization": "Token #{token}" },
+             params: create_params, as: :json
+      end
+
+      it "returns status unauthorized" do
+        expect(response).to have_http_status(403)
+        expect(response.parsed_body).to have_jsonapi_errors
+      end
+    end
+
+    context "when authorized but tries to create grade with invalid params" do
+      before do
+        token = get_auth_token(mentor)
+        post "/api/v1/assignments/#{assignment.id}/projects/#{project.id}/grades",
+             headers: { "Authorization": "Token #{token}" },
+             params: { "invalid": "invalid" }, as: :json
+      end
+
+      it "returns status bad_request" do
+        expect(response).to have_http_status(400)
+        expect(response.parsed_body).to have_jsonapi_errors
+      end
+    end
+
+    context "when authorized but tries to create duplicate grade" do
+      before do
+        FactoryBot.create(
+          :grade, project: project, assignment: assignment, \
+                  user_id: mentor.id, grade: "A", remarks: "Good"
+        )
+        token = get_auth_token(mentor)
+        post "/api/v1/assignments/#{assignment.id}/projects/#{project.id}/grades",
+             headers: { "Authorization": "Token #{token}" },
+             params: create_params, as: :json
+      end
+
+      it "returns status unprocessable_identity" do
+        expect(response).to have_http_status(422)
+        expect(response.parsed_body).to have_jsonapi_errors
+      end
+    end
+
+    context "when authorized but tries to create grade with different grading scale" do
+      before do
+        token = get_auth_token(mentor)
+        post "/api/v1/assignments/#{assignment.id}/projects/#{project.id}/grades",
+             headers: { "Authorization": "Token #{token}" },
+             params: invalid_grading_scale_params, as: :json
+      end
+
+      it "returns status unprocessable_identity" do
+        expect(response).to have_http_status(422)
+        expect(response.parsed_body).to have_jsonapi_errors
+      end
+    end
+
+    context "when authorized to grade an assignment" do
+      before do
+        token = get_auth_token(mentor)
+        post "/api/v1/assignments/#{assignment.id}/projects/#{project.id}/grades",
+             headers: { "Authorization": "Token #{token}" },
+             params: create_params, as: :json
+      end
+
+      it "returns status created & grade details" do
+        expect(response).to have_http_status(201)
+        expect(response).to match_response_schema("grade")
+        expect(response.parsed_body["data"]["attributes"]["grade"]).to eq("A")
+      end
+    end
+
+    def create_params
+      {
+        "grade": {
+          "grade": "A",
+          "remarks": "Nice Work"
+        }
+      }
+    end
+
+    def invalid_grading_scale_params
+      {
+        "grade": {
+          "grade": 100,
+          "remarks": "Nice Work"
+        }
+      }
+    end
+  end
+end

--- a/spec/requests/api/v1/grades_controller/create_spec.rb
+++ b/spec/requests/api/v1/grades_controller/create_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Api::V1::GradesController, "#create", type: :request do
         post "/api/v1/assignments/#{assignment.id}/projects/#{project.id}/grades", as: :json
       end
 
-      it "returns status unautheticated" do
+      it "returns status unauthenticated" do
         expect(response).to have_http_status(401)
         expect(response.parsed_body).to have_jsonapi_errors
       end

--- a/spec/requests/api/v1/grades_controller/destroy_spec.rb
+++ b/spec/requests/api/v1/grades_controller/destroy_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::GradesController, "#destroy", type: :request do
+  describe "delete specific grade" do
+    let!(:mentor) { FactoryBot.create(:user) }
+    let!(:group) { FactoryBot.create(:group, mentor: mentor) }
+    let!(:assignment) { FactoryBot.create(:assignment, group: group, grading_scale: :letter) }
+    let!(:project) { FactoryBot.create(:project, assignment: assignment) }
+    let!(:grade) do
+      FactoryBot.create(
+        :grade, project: project, assignment: assignment, \
+                user_id: mentor.id, grade: "A", remarks: "Good"
+      )
+    end
+
+    context "when not authenticated" do
+      before do
+        delete "/api/v1/grades/#{grade.id}", as: :json
+      end
+
+      it "returns status unauthenticated" do
+        expect(response).to have_http_status(401)
+        expect(response.parsed_body).to have_jsonapi_errors
+      end
+    end
+
+    context "when authenticated as random user and don't have delete access" do
+      before do
+        token = get_auth_token(FactoryBot.create(:user))
+        delete "/api/v1/grades/#{grade.id}",
+               headers: { "Authorization": "Token #{token}" }, as: :json
+      end
+
+      it "returns status unauthorized" do
+        expect(response).to have_http_status(403)
+        expect(response.parsed_body).to have_jsonapi_errors
+      end
+    end
+
+    context "when authorized but tries to delete non existent grade" do
+      before do
+        token = get_auth_token(mentor)
+        delete "/api/v1/grades/0",
+               headers: { "Authorization": "Token #{token}" }, as: :json
+      end
+
+      it "returns status not_found" do
+        expect(response).to have_http_status(404)
+        expect(response.parsed_body).to have_jsonapi_errors
+      end
+    end
+
+    context "when authorized to delete grade" do
+      before do
+        token = get_auth_token(mentor)
+        delete "/api/v1/grades/#{grade.id}",
+               headers: { "Authorization": "Token #{token}" }, as: :json
+      end
+
+      it "delete group & return status no_content" do
+        expect { Grade.find(grade.id) }.to raise_exception(
+          ActiveRecord::RecordNotFound
+        )
+        expect(response).to have_http_status(204)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/grades_controller/update_spec.rb
+++ b/spec/requests/api/v1/grades_controller/update_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::GradesController, "#update", type: :request do
+  describe "create a grade" do
+    let!(:mentor) { FactoryBot.create(:user) }
+    let!(:group) { FactoryBot.create(:group, mentor: mentor) }
+    let!(:assignment) { FactoryBot.create(:assignment, group: group, grading_scale: :letter) }
+    let!(:project) { FactoryBot.create(:project, assignment: assignment) }
+    let!(:grade) do
+      FactoryBot.create(
+        :grade, project: project, assignment: assignment, \
+                user_id: mentor.id, grade: "A", remarks: "Good"
+      )
+    end
+
+    context "when not authenticated" do
+      before do
+        patch "/api/v1/grades/#{grade.id}", as: :json
+      end
+
+      it "returns status unautheticated" do
+        expect(response).to have_http_status(401)
+        expect(response.parsed_body).to have_jsonapi_errors
+      end
+    end
+
+    context "when not authorized to update assignment's grade" do
+      before do
+        token = get_auth_token(FactoryBot.create(:user))
+        patch "/api/v1/grades/#{grade.id}",
+              headers: { "Authorization": "Token #{token}" },
+              params: update_params, as: :json
+      end
+
+      it "returns status unauthorized" do
+        expect(response).to have_http_status(403)
+        expect(response.parsed_body).to have_jsonapi_errors
+      end
+    end
+
+    context "when authorized but tries to update non existent grade" do
+      before do
+        token = get_auth_token(mentor)
+        patch "/api/v1/grades/0",
+              headers: { "Authorization": "Token #{token}" },
+              params: update_params, as: :json
+      end
+
+      it "returns status not_found" do
+        expect(response).to have_http_status(404)
+        expect(response.parsed_body).to have_jsonapi_errors
+      end
+    end
+
+    context "when authorized but tries to update grade with invalid params" do
+      before do
+        token = get_auth_token(mentor)
+        patch "/api/v1/grades/#{grade.id}",
+              headers: { "Authorization": "Token #{token}" },
+              params: { "invalid": "invalid" }, as: :json
+      end
+
+      it "returns status bad_request" do
+        expect(response).to have_http_status(400)
+        expect(response.parsed_body).to have_jsonapi_errors
+      end
+    end
+
+    context "when authorized but tries to update grade with different grading scale" do
+      before do
+        token = get_auth_token(mentor)
+        patch "/api/v1/grades/#{grade.id}",
+              headers: { "Authorization": "Token #{token}" },
+              params: invalid_grading_scale_params, as: :json
+      end
+
+      it "returns status unprocessable_identity" do
+        expect(response).to have_http_status(422)
+        expect(response.parsed_body).to have_jsonapi_errors
+      end
+    end
+
+    context "when authorized to update assignment's grade" do
+      before do
+        token = get_auth_token(mentor)
+        patch "/api/v1/grades/#{grade.id}",
+              headers: { "Authorization": "Token #{token}" },
+              params: update_params, as: :json
+      end
+
+      it "returns status accepted & grade details" do
+        expect(response).to have_http_status(202)
+        expect(response).to match_response_schema("grade")
+        expect(response.parsed_body["data"]["attributes"]["grade"]).to eq("B")
+      end
+    end
+
+    def update_params
+      {
+        "grade": {
+          "grade": "B"
+        }
+      }
+    end
+
+    def invalid_grading_scale_params
+      {
+        "grade": {
+          "grade": 100
+        }
+      }
+    end
+  end
+end

--- a/spec/requests/api/v1/grades_controller/update_spec.rb
+++ b/spec/requests/api/v1/grades_controller/update_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Api::V1::GradesController, "#update", type: :request do
         patch "/api/v1/grades/#{grade.id}", as: :json
       end
 
-      it "returns status unautheticated" do
+      it "returns status unauthenticated" do
         expect(response).to have_http_status(401)
         expect(response.parsed_body).to have_jsonapi_errors
       end

--- a/spec/support/api/schemas/grade.json
+++ b/spec/support/api/schemas/grade.json
@@ -1,0 +1,24 @@
+{
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "type": { "type": "string" },
+        "attributes": {
+          "type": "object",
+          "properties": {
+            "grade": { "type": "string" },
+            "remarks": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" }
+          },
+          "required": ["grade", "remarks", "created_at", "updated_at"]
+        }
+      },
+      "required": ["id", "type", "attributes"]
+    }
+  },
+  "required": ["data"]
+}


### PR DESCRIPTION
#### Describe the changes you have made in this PR -

1. Adds the following grading endpoints
    - `api/v1/assignments/:assignment_id/projects/:project_id/grades` to grade assignment.
    - `api/v1/grade/:id` to update & destroy grade.

2. Adds validation to `project_id` & `assignment_id` in grades.

3. Adds grades schema & specs

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
