### PR TITLE
removed hex-dec-bin.js

### DIFF
--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -273,7 +273,6 @@
     <link rel="stylesheet" type="text/css" href="/css/restrictedElements.css">
     <!-- <script src="./SAP_DATA.js"></script> -->
     <script src="/js/utils.js"></script>
-    <script src="/js/dec-bin-hex-converter.js"></script>
     <script src="/js/engine.js"></script>
     <script src="/js/logix.js"></script>
     <script src="/js/Plot.js"></script>


### PR DESCRIPTION

#### Describe the changes you have made in this PR -
removed Hec-dec-bin.js from the simulator/edit.html.erb which was creating error in hec-dec-bin tool





Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
