### PR TITLE
Add Favourite Projects API

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -122,6 +122,7 @@ Rails.application.routes.draw do
       get '/me', to: 'users#me'
       resources :users, only: [:index, :show, :update]
       get '/projects/featured', to: 'projects#featured_circuits'
+      get '/projects/favourites', to: 'projects#favourite_projects'
       resources :projects do
         member do
           get 'toggle-star', to: 'projects#toggle_star'

--- a/spec/requests/api/v1/projects_controller/favourite_projects_spec.rb
+++ b/spec/requests/api/v1/projects_controller/favourite_projects_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::ProjectsController, "#favourite_projects", type: :request do
+  describe "list all starred projects" do
+    let!(:user) { FactoryBot.create(:user) }
+
+    context "when not authenticated" do
+      before do
+        get "/api/v1/projects/favourites", as: :json
+      end
+
+      it "returns status :not_authorized" do
+        expect(response).to have_http_status(401)
+        expect(response.parsed_body).to have_jsonapi_errors
+      end
+    end
+
+    context "when authenticated" do
+      before do
+        # creates 3 project starred by user..
+        FactoryBot.create_list(:project, 3, project_access_type: "Public").each do |p|
+          FactoryBot.create(:star, user: user, project: p)
+        end
+        # creates 2 projects starred by some other user..
+        FactoryBot.create_list(:project, 2, project_access_type: "Public").each do |p|
+          FactoryBot.create(:star, user: FactoryBot.create(:user), project: p)
+        end
+        token = get_auth_token(user)
+        get "/api/v1/projects/favourites",
+            headers: { "Authorization": "Token #{token}" }, as: :json
+      end
+
+      it "returns all projects starred by user" do
+        expect(response).to have_http_status(200)
+        expect(response).to match_response_schema("projects")
+        expect(response.parsed_body["data"].length).to eq(3)
+      end
+    end
+
+    context "when authenticated and includes author details" do
+      before do
+        # creates 3 project starred by user..
+        FactoryBot.create_list(:project, 3, project_access_type: "Public").each do |p|
+          FactoryBot.create(:star, user: user, project: p)
+        end
+        # creates 2 projects starred by some other user..
+        FactoryBot.create_list(:project, 2, project_access_type: "Public").each do |p|
+          FactoryBot.create(:star, user: FactoryBot.create(:user), project: p)
+        end
+        token = get_auth_token(user)
+        get "/api/v1/projects/favourites?include=author",
+            headers: { "Authorization": "Token #{token}" }, as: :json
+      end
+
+      it "returns all projects starred by user including author details" do
+        expect(response).to have_http_status(200)
+        expect(response).to match_response_schema("projects_with_author")
+        expect(response.parsed_body["data"].length).to eq(3)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### Describe the changes you have made in this PR -
1. Adds the following favourite projects endpoints
    - `api/v1/projects/favourites` to GET starred projects

2. Adds specs for the above enpoint..

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
