### PR TITLE
links open in new tab now

### DIFF
--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -14,12 +14,12 @@
         </div>
         <div class="row row-about">
           <div class="col-xs col-sm col-md col-lg">
-            <div class="contact" onclick="window.location.href='mailto:support@circuitverse.org';">
+            <div class="contact" onclick="window.open('mailto:support@circuitverse.org', '_blank');">
               <%= image_tag "SVGs/email.svg", height: '60', width: '60', alt: "", class: 'about-card-image' %>
               <h6>Email us at</h6>
               <p id="tab">support@circuitverse.org</p>
             </div>
-            <div class="contact" onclick="window.location.href='<%= Rails.configuration.slack_url %>';">
+            <div class="contact" onclick="window.open('<%= Rails.configuration.slack_url %>', '_blank');">
               <%= image_tag "SVGs/slack.svg", height: '60', width: '60', alt: "", class: 'about-card-image' %>
               <h6>Join and chat with us at</h6>
               <p id="tab">Slack Channel</p>

--- a/app/views/logix/contribute.html.erb
+++ b/app/views/logix/contribute.html.erb
@@ -12,17 +12,17 @@
 
         <div class="row row-about">
           <div class="col-xs col-sm col-md col-lg">
-            <div class="contact" onclick="window.location.href='mailto:support@circuitverse.org';">
+            <div class="contact" onclick="window.open('mailto:support@circuitverse.org', '_blank');">
               <%= image_tag "SVGs/email.svg", alt: "", height: '60', width: '60', class: 'about-card-image' %>
               <h6>Email us at</h6>
               <p id="tab">support@circuitverse.org</p>
             </div>
-            <div class="contact" onclick="window.location.href='<%= Rails.configuration.slack_url %>';">
+            <div class="contact" onclick="window.open('<%= Rails.configuration.slack_url %>', '_blank');">
               <%= image_tag "SVGs/slack.svg", alt: "", height: '60', width: '60', class: 'about-card-image' %>
               <h6>Join and chat with us at</h6>
               <p id="tab">Slack Channel</p>
             </div>
-            <div class="contact" onclick="window.location.href='https://github.com/CircuitVerse';">
+            <div class="contact" onclick="window.open('https://github.com/CircuitVerse', '_blank');">
               <%= image_tag "SVGs/github.svg", alt: "", height: '60', width: '60', class: 'about-card-image' %>
               <h6>Contribute to Open Source</h6>
               <p id="tab">Github</p>


### PR DESCRIPTION
Fixes #1515 

#### Describe the changes you have made in this PR -
Links of slack, Github and mail on Contribute and About page open in a new tab now
### Screenshots of the changes (If any) -



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
