### PR TITLE
Include Project collaborators & starred status

### DIFF
--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -138,7 +138,10 @@ class Api::V1::ProjectsController < Api::V1::BaseController
     def set_options
       @options = {}
       @options[:include] = include_resource if params.key?(:include)
-      @options[:params] = { only_name: true }
+      @options[:params] = {
+        current_user: @current_user,
+        only_name: true
+      }
     end
 
     def filter

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -11,12 +11,12 @@ class Api::V1::ProjectsController < Api::V1::BaseController
   before_action :load_featured_circuits, only: %i[featured_circuits]
   before_action :load_favourites, only: %i[favourite_projects]
   before_action :set_project, only: %i[show update destroy toggle_star create_fork]
-  before_action :set_options, except: %i[destroy toggle_star]
+  before_action :set_options, except: %i[destroy toggle_star image_preview]
   before_action :filter, only: %i[index user_projects featured_circuits favourite_projects]
   before_action :sort, only: %i[index user_projects featured_circuits favourite_projects]
 
   SORTABLE_FIELDS = %i[view created_at].freeze
-  WHITELISTED_INCLUDE_ATTRIBUTES = %i[author].freeze
+  WHITELISTED_INCLUDE_ATTRIBUTES = %i[author collaborators].freeze
 
   # GET /api/v1/projects
   def index
@@ -138,6 +138,7 @@ class Api::V1::ProjectsController < Api::V1::BaseController
     def set_options
       @options = {}
       @options[:include] = include_resource if params.key?(:include)
+      @options[:params] = { only_name: true }
     end
 
     def filter

--- a/app/serializers/api/v1/project_serializer.rb
+++ b/app/serializers/api/v1/project_serializer.rb
@@ -11,7 +11,7 @@ class Api::V1::ProjectSerializer
     if params[:current_user].nil?
       nil
     else
-      Star.find_by(user_id: params[:current_user].id, project_id: project.id).nil? ? false : true
+      Star.exists?(user_id: params[:current_user].id, project_id: project.id)
     end
   end
 

--- a/app/serializers/api/v1/project_serializer.rb
+++ b/app/serializers/api/v1/project_serializer.rb
@@ -7,6 +7,14 @@ class Api::V1::ProjectSerializer
              :updated_at, :image_preview, :description,
              :view, :tags
 
+  attributes :is_starred do |project, params|
+    if params[:current_user].nil?
+      nil
+    else
+      Star.find_by(user_id: params[:current_user].id, project_id: project.id).nil? ? false : true
+    end
+  end
+
   attributes :author_name do |project|
     project.author.name
   end

--- a/app/serializers/api/v1/project_serializer.rb
+++ b/app/serializers/api/v1/project_serializer.rb
@@ -16,4 +16,5 @@ class Api::V1::ProjectSerializer
   end
 
   belongs_to :author
+  has_many :collaborators, serializer: Api::V1::UserSerializer
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -212,6 +212,7 @@ ActiveRecord::Schema.define(version: 2020_07_10_140442) do
     t.bigint "mentor_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "group_members_count"
     t.index ["mentor_id"], name: "index_groups_on_mentor_id"
   end
 

--- a/spec/requests/api/v1/projects_controller/create_fork_spec.rb
+++ b/spec/requests/api/v1/projects_controller/create_fork_spec.rb
@@ -70,5 +70,18 @@ RSpec.describe Api::V1::ProjectsController, "#create_fork", type: :request do
         expect(response).to match_response_schema("project_with_author")
       end
     end
+
+    context "when forks other user's project and includes collaborators" do
+      before do
+        token = get_auth_token(random_user)
+        get "/api/v1/projects/#{project.id}/fork?include=collaborators",
+            headers: { "Authorization": "Token #{token}" }, as: :json
+      end
+
+      it "returns status :ok & return forked project including collaborators" do
+        expect(response).to have_http_status(200)
+        expect(response).to match_response_schema("project_with_collaborators")
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/projects_controller/show_spec.rb
+++ b/spec/requests/api/v1/projects_controller/show_spec.rb
@@ -33,6 +33,19 @@ RSpec.describe Api::V1::ProjectsController, "#show", type: :request do
       end
     end
 
+    context "when unauthenticated user fetches public project with collaborators" do
+      before do
+        # Adds random user as a collaborator to public_project
+        FactoryBot.create(:collaboration, user: FactoryBot.create(:user), project: public_project)
+        get "/api/v1/projects/#{public_project.id}?include=collaborators", as: :json
+      end
+
+      it "returns project details including collaborators" do
+        expect(response).to have_http_status(200)
+        expect(response).to match_response_schema("project_with_collaborators")
+      end
+    end
+
     context "when unauthenticated user fetches private project details" do
       before do
         get "/api/v1/projects/#{private_project.id}", as: :json

--- a/spec/support/api/schemas/project.json
+++ b/spec/support/api/schemas/project.json
@@ -22,6 +22,7 @@
             },
             "description": { "type": "string" },
             "view": { "type": "integer" },
+            "is_starred": { "type": ["boolean", "null"] },
             "author_name": { "type": "string" },
             "stars_count": { "type": "integer" },
             "tags": {
@@ -46,6 +47,7 @@
             "image_preview",
             "description",
             "view",
+            "is_starred",
             "author_name",
             "stars_count",
             "tags"

--- a/spec/support/api/schemas/project.json
+++ b/spec/support/api/schemas/project.json
@@ -67,9 +67,26 @@
                 }
               },
               "required": ["data"]
+            },
+            "collaborators": {
+              "type": "object",
+              "properties": {
+                "data": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": { "type": "string" },
+                      "type": { "type": "string" }
+                    },
+                    "required": ["id", "type"]
+                  }
+                }
+              },
+              "required": ["data"]
             }
           },
-          "required": ["author"]
+          "required": ["author", "collaborators"]
         }
       },
       "required": ["id", "type", "attributes"]

--- a/spec/support/api/schemas/project_with_author.json
+++ b/spec/support/api/schemas/project_with_author.json
@@ -22,6 +22,7 @@
             },
             "description": { "type": "string" },
             "view": { "type": "integer" },
+            "is_starred": { "type": ["boolean", "null"] },
             "author_name": { "type": "string" },
             "stars_count": { "type": "integer" },
             "tags": {
@@ -46,6 +47,7 @@
             "image_preview",
             "description",
             "view",
+            "is_starred",
             "author_name",
             "stars_count",
             "tags"

--- a/spec/support/api/schemas/project_with_collaborators.json
+++ b/spec/support/api/schemas/project_with_collaborators.json
@@ -22,6 +22,7 @@
             },
             "description": { "type": "string" },
             "view": { "type": "integer" },
+            "is_starred": { "type": ["boolean", "null"] },
             "author_name": { "type": "string" },
             "stars_count": { "type": "integer" },
             "tags": {
@@ -46,6 +47,7 @@
             "image_preview",
             "description",
             "view",
+            "is_starred",
             "author_name",
             "stars_count",
             "tags"

--- a/spec/support/api/schemas/project_with_collaborators.json
+++ b/spec/support/api/schemas/project_with_collaborators.json
@@ -101,10 +101,9 @@
           "attributes": {
             "type": "object",
             "properties": {
-              "name": { "type": "string" },
-              "email": { "type": "string" }
+              "name": { "type": "string" }
             },
-            "required": ["name", "email"]
+            "required": ["name"]
           }
         },
         "required": ["id", "type", "attributes"]

--- a/spec/support/api/schemas/projects.json
+++ b/spec/support/api/schemas/projects.json
@@ -24,6 +24,7 @@
               },
               "description": { "type": "string" },
               "view": { "type": "integer" },
+              "is_starred": { "type": ["boolean", "null"] },
               "author_name": { "type": "string" },
               "stars_count": { "type": "integer" },
               "tags": {
@@ -48,6 +49,7 @@
               "image_preview",
               "description",
               "view",
+              "is_starred",
               "author_name",
               "stars_count",
               "tags"

--- a/spec/support/api/schemas/projects_with_author.json
+++ b/spec/support/api/schemas/projects_with_author.json
@@ -69,15 +69,32 @@
                   }
                 },
                 "required": ["data"]
+              },
+              "collaborators": {
+                "type": "object",
+                "properties": {
+                  "data": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": { "type": "string" },
+                        "type": { "type": "string" }
+                      },
+                      "required": ["id", "type"]
+                    }
+                  }
+                },
+                "required": ["data"]
               }
             },
-            "required": ["author"]
+            "required": ["author", "collaborators"]
           }
         },
         "required": ["id", "type", "attributes"]
       }
     },
-        "included": {
+    "included": {
       "type": "array",
       "items": {
         "type": "object",

--- a/spec/support/api/schemas/projects_with_author.json
+++ b/spec/support/api/schemas/projects_with_author.json
@@ -24,6 +24,7 @@
               },
               "description": { "type": "string" },
               "view": { "type": "integer" },
+              "is_starred": { "type": ["boolean", "null"] },
               "author_name": { "type": "string" },
               "stars_count": { "type": "integer" },
               "tags": {
@@ -48,6 +49,7 @@
               "image_preview",
               "description",
               "view",
+              "is_starred",
               "author_name",
               "stars_count",
               "tags"

--- a/spec/support/api/schemas/projects_with_collaborators.json
+++ b/spec/support/api/schemas/projects_with_collaborators.json
@@ -94,6 +94,24 @@
         "required": ["id", "type", "attributes"]
       }
     },
+    "included": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "type": { "type": "string" },
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" }
+            },
+            "required": ["name"]
+          }
+        },
+        "required": ["id", "type", "attributes"]
+      }
+    },
     "links": {
       "type": "object",
       "properties": {
@@ -106,5 +124,5 @@
       "required": ["self", "first", "prev", "next", "last"]
     }
   },
-  "required": ["data", "links"]
+  "required": ["data", "included", "links"]
 }

--- a/spec/support/api/schemas/projects_with_collaborators.json
+++ b/spec/support/api/schemas/projects_with_collaborators.json
@@ -24,6 +24,7 @@
               },
               "description": { "type": "string" },
               "view": { "type": "integer" },
+              "is_starred": { "type": ["boolean", "null"] },
               "author_name": { "type": "string" },
               "stars_count": { "type": "integer" },
               "tags": {
@@ -48,6 +49,7 @@
               "image_preview",
               "description",
               "view",
+              "is_starred",
               "author_name",
               "stars_count",
               "tags"


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -
- Project collaborators are now available in project API endpoints with `include=collaborators`.
- Added is_starred project attribute.
- Updated json schema and added relevant new ones in view of above.
- Added specs for the changes mentioned.

### Screenshots of the changes (If any) -



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
