### PR TITLE
Change-tab-close-button

### DIFF
--- a/public/css/UX.css
+++ b/public/css/UX.css
@@ -337,13 +337,13 @@ select {
 .tabsCloseButton:hover{
     color:#fff;
     font-family: 'Gill Sans', sans-serif;
-    padding-left: 1em;
+    margin-left: 1em;
     opacity: 0.5;
 }
 .tabsCloseButton {
     color:#111;
     font-family: 'Gill Sans', sans-serif;
-    padding-left: 1em;
+    margin-left: 1em;
     opacity: 1.0;
     position: absolute;
     top: 5px;


### PR DESCRIPTION
Fixes #

Describe the changes you have made in this PR -
ISSUE #1532
the close button after the hover is still active until the middle of the tab sometimes when the name of the tab is very small therefore i have changed the css rule from padding to margin inorder to remove this issue


Screenshots of the changes (If any) -
Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.