### PR TITLE
Changed a typo to fix the teachers page link in footer

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -34,7 +34,7 @@
             <h6>Info</h6>
             <a href="/docs" target="_blank"><h6>Documentation</h6></a>
             <a href="/contribute"><h6>Contribute</h6></a>
-            <a href="/Teachers"><h6>Teachers</h6></a>
+            <a href="/teachers"><h6>Teachers</h6></a>
             <a href="/about"><h6>About</h6></a>
             <% if Flipper.enabled?(:forum) %>
               <%= link_to "Forum", simple_discussion_path %>


### PR DESCRIPTION
Fixes # Minor Fix

#### Describe the changes you have made in this PR -
Changed a typo to fix the teachers page link in footer

### Screenshots of the changes (If any) -



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
