### PR TITLE
Add FCM Notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,4 @@ SLACK_ISSUE_HOOK_URL=<Slack-hook-url>
 BUGSNAG_API_KEY=''
 RECAPTCHA_SITE_KEY=<google-recaptcha-site-key>
 RECAPTCHA_SECRET_KEY=<google-recaptcha-secret-key>
+FCM_SERVER_KEY=<fcm-server-key>

--- a/Gemfile
+++ b/Gemfile
@@ -104,6 +104,7 @@ gem 'simple_discussion', '~> 1.2'
 gem 'inline_svg'
 gem 'disposable_mail', '~> 0.1'
 gem 'recaptcha'
+gem 'fcm'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,6 +177,8 @@ GEM
       multipart-post (>= 1.2, < 3)
     fast_jsonapi (1.5)
       activesupport (>= 4.2)
+    fcm (0.0.6)
+      httparty (~> 0.10, >= 0.10.0)
     ffi (1.13.1)
     ffi (1.13.1-x64-mingw32)
     ffi-compiler (1.0.1)
@@ -219,6 +221,10 @@ GEM
     http-parser (1.2.1)
       ffi-compiler (>= 1.0, < 2.0)
     i18n (1.8.5)
+    httparty (0.18.1)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
+    i18n (1.7.1)
       concurrent-ruby (~> 1.0)
     i18n_data (0.8.0)
     image_processing (1.11.0)
@@ -609,6 +615,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   fast_jsonapi
+  fcm
   flipper-redis
   flipper-ui
   font-awesome-sass (~> 5.13.0)

--- a/app/controllers/api/v1/fcm_controller.rb
+++ b/app/controllers/api/v1/fcm_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Api::V1::FcmController < Api::V1::BaseController
+  before_action :authenticate_user!
+
+  # POST /api/v1/fcm/token
+  def save_token
+    # fetches or create FCM for current_user
+    @token = Fcm.find_by(user_id: current_user.id)
+    @token ||= Fcm.new(user_id: current_user.id)
+    @token.token = params[:token]
+
+    if @token.save
+      render json: { "message": "token saved" }
+    else
+      api_error(status: 422, errors: @token.errors)
+    end
+  end
+end

--- a/app/lib/fcm_notification.rb
+++ b/app/lib/fcm_notification.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class FcmNotification
+  def self.send(registration_tokens, title, body, data = {})
+    fcm = FCM.new(ENV["FCM_SERVER_KEY"])
+    options = {
+      "notification": {
+        "title": title,
+        "body": body
+      },
+      "data": data
+    }
+
+    fcm.send(registration_tokens, options)
+  end
+end

--- a/app/models/collaboration.rb
+++ b/app/models/collaboration.rb
@@ -3,4 +3,16 @@
 class Collaboration < ApplicationRecord
   belongs_to :user
   belongs_to :project
+
+  after_create :send_new_collaboration_notif
+
+  def send_new_collaboration_notif
+    return if user.fcm.nil?
+
+    FcmNotification.send(
+      user.fcm.token,
+      "Added as Collaborator",
+      "#{project.author.name} added you as a collaborator in #{project.name}"
+    )
+  end
 end

--- a/app/models/fcm.rb
+++ b/app/models/fcm.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal:true
+
+class Fcm < ApplicationRecord
+  belongs_to :user
+
+  validates :token, presence: true
+  validates :user_id, uniqueness: true
+end

--- a/app/models/featured_circuit.rb
+++ b/app/models/featured_circuit.rb
@@ -3,18 +3,28 @@
 class FeaturedCircuit < ApplicationRecord
   belongs_to :project
 
-  after_create :featured_circuit_email
+  after_create :featured_circuit_email, :send_featured_circuit_notif
   validate :project_public
 
   private
 
     def project_public
-      if project.project_access_type != "Public"
-        errors.add(:project, "Featured projects have to be public")
-      end
+      return unless project.project_access_type != "Public"
+
+      errors.add(:project, "Featured projects have to be public")
     end
 
     def featured_circuit_email
       UserMailer.featured_circuit_email(project.author, project).deliver_later
+    end
+
+    def send_featured_circuit_notif
+      return if project.author.fcm.nil?
+
+      FcmNotification.send(
+        project.author.fcm.token,
+        "Project Featured",
+        "Your project #{project.name} is now featured"
+      )
     end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,6 +29,8 @@ class User < ApplicationRecord
   # Multiple push_subscriptions over many devices
   has_many :push_subscriptions, dependent: :destroy
 
+  has_one :fcm, dependent: :destroy
+
   after_commit :send_welcome_mail, on: :create
   after_commit :create_members_from_invitations, on: :create
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -124,14 +124,15 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      post "/auth/login", to: "authentication#login"
-      post "/auth/signup", to: "authentication#signup"
-      post "/oauth/login", to: "authentication#oauth_login"
-      post "/oauth/signup", to: "authentication#oauth_signup"
-      get  "/public_key.pem", to: "authentication#public_key"
-      post "/password/forgot", to: "authentication#forgot_password"
-      get "/me", to: "users#me"
-      post "/forgot_password", to: "users#forgot_password"
+      post '/auth/login', to: 'authentication#login'
+      post '/auth/signup', to: 'authentication#signup'
+      post '/oauth/login', to: 'authentication#oauth_login'
+      post '/oauth/signup', to: 'authentication#oauth_signup'
+      get '/public_key.pem', to: "authentication#public_key"
+      post '/password/forgot', to: 'authentication#forgot_password'
+      get '/me', to: 'users#me'
+      post '/fcm/token', to: 'fcm#save_token'
+      post '/forgot_password', to: 'users#forgot_password'
       resources :users, only: %i[index show update]
       get "/projects/featured", to: "projects#featured_circuits"
       resources :projects do

--- a/db/migrate/20200807171203_create_fcms.rb
+++ b/db/migrate/20200807171203_create_fcms.rb
@@ -1,0 +1,10 @@
+class CreateFcms < ActiveRecord::Migration[6.0]
+  def change
+    create_table :fcms do |t|
+      t.string :token, null: false
+      t.references :user, foreign_key: true, unique: true, on_delete: :cascade
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -128,6 +128,14 @@ ActiveRecord::Schema.define(version: 2020_09_30_135954) do
     t.index ["user_id"], name: "index_custom_mails_on_user_id"
   end
 
+  create_table "fcms", force: :cascade do |t|
+    t.string "token", null: false
+    t.bigint "user_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_fcms_on_user_id"
+  end
+
   create_table "featured_circuits", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -367,6 +375,7 @@ ActiveRecord::Schema.define(version: 2020_09_30_135954) do
   add_foreign_key "collaborations", "users"
   add_foreign_key "commontator_comments", "commontator_comments", column: "parent_id", on_update: :restrict, on_delete: :cascade
   add_foreign_key "custom_mails", "users"
+  add_foreign_key "fcms", "users"
   add_foreign_key "featured_circuits", "projects"
   add_foreign_key "forum_posts", "forum_threads"
   add_foreign_key "forum_posts", "users"

--- a/spec/factories/fcm.rb
+++ b/spec/factories/fcm.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :fcm do
+  end
+end

--- a/spec/models/fcm_spec.rb
+++ b/spec/models/fcm_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Fcm, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:user) }
+  end
+
+  describe "validations" do
+    let(:user) { FactoryBot.create(:user) }
+
+    context "when token is null" do
+      let(:fcm) { FactoryBot.build(:fcm, token: nil, user: user) }
+
+      it "invalidates fcm" do
+        expect(fcm).to be_invalid
+      end
+    end
+
+    context "when token is empty string" do
+      let(:fcm) { FactoryBot.build(:fcm, token: "", user: user) }
+
+      it "invalidates fcm" do
+        expect(fcm).to be_invalid
+      end
+    end
+
+    context "when user_id is not unique" do
+      let(:fcm) { FactoryBot.create(:fcm, token: "token", user: user) }
+
+      it "validates uniqueness of :user_id in fcm" do
+        expect(fcm).to validate_uniqueness_of(:user_id)
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,14 +4,15 @@ require "rails_helper"
 
 RSpec.describe User, type: :model do
   describe "associations" do
-    it { should have_many(:projects) }
-    it { should have_many(:stars) }
-    it { should have_many(:rated_projects) }
-    it { should have_many(:groups_mentored) }
-    it { should have_many(:group_members) }
-    it { should have_many(:groups) }
-    it { should have_many(:collaborations) }
-    it { should have_many(:collaborated_projects) }
+    it { is_expected.to have_many(:projects) }
+    it { is_expected.to have_many(:stars) }
+    it { is_expected.to have_many(:rated_projects) }
+    it { is_expected.to have_many(:groups_mentored) }
+    it { is_expected.to have_many(:group_members) }
+    it { is_expected.to have_many(:groups) }
+    it { is_expected.to have_many(:collaborations) }
+    it { is_expected.to have_many(:collaborated_projects) }
+    it { is_expected.to have_one(:fcm) }
   end
 
   describe "callbacks" do

--- a/spec/requests/api/v1/fcm_controller/save_token_spec.rb
+++ b/spec/requests/api/v1/fcm_controller/save_token_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::FcmController, "#save_token", type: :request do
+  describe "create or update a user's token" do
+    let(:user) { FactoryBot.create(:user) }
+
+    context "when not authenticated" do
+      before do
+        post "/api/v1/fcm/token", as: :json
+      end
+
+      it "returns status unauthenticated" do
+        expect(response).to have_http_status(401)
+        expect(response.parsed_body).to have_jsonapi_errors
+      end
+    end
+
+    context "when authenticated but token body is null" do
+      before do
+        token = get_auth_token(user)
+        post "/api/v1/fcm/token",
+             headers: { "Authorization": "Token #{token}" },
+             params: { "token": nil }, as: :json
+      end
+
+      it "returns status unprocessable_identity" do
+        expect(response).to have_http_status(422)
+        expect(response.parsed_body).to have_jsonapi_errors
+      end
+    end
+
+    context "when authenticated but token body is empty string" do
+      before do
+        token = get_auth_token(user)
+        post "/api/v1/fcm/token",
+             headers: { "Authorization": "Token #{token}" },
+             params: { "token": "" }, as: :json
+      end
+
+      it "returns status unprocessable_identity" do
+        expect(response).to have_http_status(422)
+        expect(response.parsed_body).to have_jsonapi_errors
+      end
+    end
+
+    context "when authenticated and user's token does not exists" do
+      before do
+        token = get_auth_token(user)
+        post "/api/v1/fcm/token",
+             headers: { "Authorization": "Token #{token}" },
+             params: { "token": "token" }, as: :json
+
+        # reloads user and associations
+        user.reload
+      end
+
+      it "creates new token & returns 'token saved' message" do
+        expect(response).to have_http_status(200)
+        expect(response.parsed_body["message"]).to eq("token saved")
+        expect(user.fcm.token).to eq("token")
+      end
+    end
+
+    context "when authenticated and user's token already exists" do
+      before do
+        FactoryBot.create(:fcm, token: "token", user: user)
+
+        token = get_auth_token(user)
+        post "/api/v1/fcm/token",
+             headers: { "Authorization": "Token #{token}" },
+             params: { "token": "updated_token" }, as: :json
+
+        # reloads user and associations
+        user.reload
+      end
+
+      it "updates existing token & returns 'token saved' message" do
+        expect(response).to have_http_status(200)
+        expect(response.parsed_body["message"]).to eq("token saved")
+        expect(user.fcm.token).to eq("updated_token")
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -87,6 +87,18 @@ RSpec.configure do |config|
         "error": "invalid_request",
         "error_description": "Invalid Credentials"
       }.to_json, headers: {})
+
+    # To stub fcm send notifications with irrespective of request body
+    stub_request(:post, "https://fcm.googleapis.com/fcm/send")
+      .with(
+        headers: {
+          "Accept" => "*/*",
+          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "Content-Type" => "application/json",
+          "User-Agent" => "Ruby"
+        }
+      )
+      .to_return(status: 200, body: "", headers: {})
   end
 
   config.after do


### PR DESCRIPTION
#### Describe the changes you have made in this PR -
- Add `Fcm` model with appropriate migrations and bindings.
- Add `fcm` gem implementation to send fcm notifs in `app/lib/fcm_notification.rb`.
- Add send notifications hooks `on_create`, `on_update` in relevant models.
- Add `rubocop` recommendations in model classes.

### Screenshots of the changes (If any) -

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
