### PR TITLE
fixed bug of referenced .bundle and node_modules folder

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.1'
+version: "3.1"
 services:
   db:
     image: postgres
@@ -12,6 +12,8 @@ services:
     build: .
     command: bundle exec sidekiq -q default -q mailers
     volumes:
+      - /circuitverse/.bundle
+      - /circuitverse/node_modules
       - .:/circuitverse
       - ./config/database.docker.yml:/circuitverse/config/database.yml
     environment:
@@ -20,6 +22,8 @@ services:
     build: .
     entrypoint: /circuitverse/bin/docker_run
     volumes:
+      - /circuitverse/.bundle
+      - /circuitverse/node_modules
       - .:/circuitverse
       - ./config/database.docker.yml:/circuitverse/config/database.yml
     ports:
@@ -34,5 +38,5 @@ services:
   redis:
     image: redis
 # volumes:
-  # app:
-  # public:
+# app:
+# public:


### PR DESCRIPTION
Fixes # fixed bug of referenced .bundle and node_modules folder

#### Describe the changes you have made in this PR -
changed docker-compose file
earlier we needed to run yarn install and bundle install --without production in our folder before using docker-compose up as these folders were refrenced and were not in repo
but now I have removed referencing of these folders and it will get data from docker container itself
thus our yarn install --checkfiles error is removed completely


### Screenshots of the changes (If any) -



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
