### PR TITLE
Sendgrid configuration

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -86,16 +86,15 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.default_url_options = { host: "https://circuitverse.org/" }
 
-    config.action_mailer.smtp_settings = {
-     :address              => 'smtp.yandex.com',
-     :port                 => 465,
-     :domain               => 'yandex.com',
-     :user_name            => ENV["CIRCUITVERSE_EMAIL_ID"],
-     :password             => ENV["CIRCUITVERSE_EMAIL_PASSWORD"],
-     :ssl                  => true,
-     :authentication       => :login,
-     :enable_starttls_auto => true,
- }
+  config.action_mailer.smtp_settings = {
+    :user_name => 'apikey',
+    :password => ENV["CIRCUITVERSE_EMAIL_PASSWORD"],
+    :domain => 'circuitverse.org',
+    :address => 'smtp.sendgrid.net',
+    :port => 587,
+    :authentication => :plain,
+    :enable_starttls_auto => true
+  }
 
   config.vapid_public_key = ENV["VAPID_PUBLIC_KEY"]
   config.vapid_private_key = ENV["VAPID_PRIVATE_KEY"]


### PR DESCRIPTION
Fixes Failing mails by migrating mail provider from yandex to Sendgrid. 

Following instructions from https://sendgrid.com/docs/for-developers/sending-email/rubyonrails/ 


