### PR TITLE
add name validation to avoid blank name submissions and special chara…

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,7 +31,12 @@ class User < ApplicationRecord
   after_commit :create_members_from_invitations, on: :create
 
   has_attached_file :profile_picture, styles: { medium: "205X240#", thumb: "100x100>" }, default_url: ":style/Default.jpg"
+
+  #validations for user
+
   validates_attachment_content_type :profile_picture, content_type: %r{\Aimage/.*\z}
+  validates :name, presence: true
+  validates_format_of :name, :with => /\A[^0-9`!@#\$%\^&*+_=]+\z/
 
   scope :subscribed, -> { where(subscribed: true) }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,11 +32,10 @@ class User < ApplicationRecord
 
   has_attached_file :profile_picture, styles: { medium: "205X240#", thumb: "100x100>" }, default_url: ":style/Default.jpg"
 
-  #validations for user
+  # validations for user
 
   validates_attachment_content_type :profile_picture, content_type: %r{\Aimage/.*\z}
-  validates :name, presence: true
-  validates_format_of :name, :with => /\A[^0-9`!@#\$%\^&*+_=]+\z/
+  validates :name, presence: true, format: { with: /\A[^0-9`!@#\$%\^&*+_=]+\z/ }
 
   scope :subscribed, -> { where(subscribed: true) }
 

--- a/spec/system/signup_spec.rb
+++ b/spec/system/signup_spec.rb
@@ -14,7 +14,7 @@ describe "Sign up", type: :system do
   it "should not sign-up when no credentials" do
     click_button "Sign up"
 
-    expect(page).to have_text("2 errors prohibited this user from being saved:")
+    expect(page).to have_text("4 errors prohibited this user from being saved:")
   end
 
   it "should not sign-up when password is empty" do
@@ -43,7 +43,7 @@ describe "Sign up", type: :system do
 
 
   it "should sign-up when valid credentials" do
-    fill_in "Name", with: "user1"
+    fill_in "Name", with: "userone"
     fill_in "Email", with: "user1@example.com"
     fill_in "Password", with: "secret"
     click_button "Sign up"


### PR DESCRIPTION
…cters in name

Fixes:
Fixed user being able to submit the name field as blank while signing up.
Made exceptions for a set of characters a user can submit through the name field.

#### Describe the changes you have made in this PR -

validates :name, presence: true, format
checks if the name is present and allows only certain characters to be present in the name. i.e avoids name field being blank and names containing, %^$*# etc..

Found out that the tests in signup_spec.rb restricted these validations. updated tests to pass the validations tests made In this PR.