### PR TITLE
Validates email#1633

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,7 +31,12 @@ class User < ApplicationRecord
   after_commit :create_members_from_invitations, on: :create
 
   has_attached_file :profile_picture, styles: { medium: "205X240#", thumb: "100x100>" }, default_url: ":style/Default.jpg"
+
+  #validations for user
+
   validates_attachment_content_type :profile_picture, content_type: %r{\Aimage/.*\z}
+  validates :name, presence: true
+  validates_format_of :name, :with => /\A[^0-9`!@#\$%\^&*+_=]+\z/
 
   scope :subscribed, -> { where(subscribed: true) }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,7 +35,7 @@ class User < ApplicationRecord
   # validations for user
 
   validates_attachment_content_type :profile_picture, content_type: %r{\Aimage/.*\z}
-  validates :name, presence: true, format: { with: /\A[^0-9`!@#\$%\^&*+_=]+\z/ }
+  validates :email, presence: true, format: /\A[^@,\s]+@[^@,\s]+\.[^@,\s]+\z/
 
   scope :subscribed, -> { where(subscribed: true) }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,11 +32,10 @@ class User < ApplicationRecord
 
   has_attached_file :profile_picture, styles: { medium: "205X240#", thumb: "100x100>" }, default_url: ":style/Default.jpg"
 
-  #validations for user
+  # validations for user
 
   validates_attachment_content_type :profile_picture, content_type: %r{\Aimage/.*\z}
-  validates :name, presence: true
-  validates_format_of :name, :with => /\A[^0-9`!@#\$%\^&*+_=]+\z/
+  validates :name, presence: true, format: { with: /\A[^0-9`!@#\$%\^&*+_=]+\z/ }
 
   scope :subscribed, -> { where(subscribed: true) }
 

--- a/spec/system/signup_spec.rb
+++ b/spec/system/signup_spec.rb
@@ -14,7 +14,7 @@ describe "Sign up", type: :system do
   it "should not sign-up when no credentials" do
     click_button "Sign up"
 
-    expect(page).to have_text("2 errors prohibited this user from being saved:")
+    expect(page).to have_text("4 errors prohibited this user from being saved:")
   end
 
   it "should not sign-up when password is empty" do
@@ -43,7 +43,7 @@ describe "Sign up", type: :system do
 
 
   it "should sign-up when valid credentials" do
-    fill_in "Name", with: "user1"
+    fill_in "Name", with: "userone"
     fill_in "Email", with: "user1@example.com"
     fill_in "Password", with: "secret"
     click_button "Sign up"


### PR DESCRIPTION
Fixes: Email validation. Checks for domain name after @ in email field when user signing up.

Describe the changes you have made in this PR:
added validation for email field, which checks if there is a domain name present after @, while user signs up.

