### PR TITLE
Configure Recaptcha

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,5 @@ GITHUB_CLIENT_ID=<github-client-id>
 GITHUB_CLIENT_SECRET=<github-client-secret>
 SLACK_ISSUE_HOOK_URL=<Slack-hook-url>
 BUGSNAG_API_KEY=''
+RECAPTCHA_SITE_KEY_V3=<google-recaptcha-site-key>
+RECAPTCHA_SECRET_KEY_V3=<google-recaptcha-secret-key>

--- a/Gemfile
+++ b/Gemfile
@@ -103,6 +103,7 @@ gem 'friendly_id', '~> 5.3.0'
 gem 'simple_discussion', '~> 1.2'
 gem 'inline_svg'
 gem 'disposable_mail', '~> 0.1'
+gem 'recaptcha'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -401,6 +401,8 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    recaptcha (5.5.0)
+      json
     redis (4.1.3)
     regexp_parser (1.7.1)
     remotipart (1.4.4)
@@ -634,6 +636,7 @@ DEPENDENCIES
   rails (~> 6.0)
   rails-erd
   rails_admin (~> 2.0)
+  recaptcha
   rspec-rails (~> 4.0)
   rspec_junit_formatter
   rubocop

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Users::RegistrationsController < Devise::RegistrationsController
+  prepend_before_action :check_captcha, only: [:create]
   before_action :configure_sign_up_params, only: [:create]
   invisible_captcha only: [:create, :update], honeypot: :subtitle unless Rails.env.test?
   # before_action :configure_account_update_params, only: [:update]
@@ -45,6 +46,17 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def configure_sign_up_params
     devise_parameter_sanitizer.permit(:sign_up, keys: %i[name age])
   end
+
+  private
+
+    def check_captcha
+      if Flipper.enabled?(:recaptcha) && !verify_recaptcha
+        self.resource = resource_class.new sign_up_params
+        resource.validate # Look for any other validation errors besides reCAPTCHA
+        set_minimum_password_length
+        respond_with_navigational(resource) { render :new }
+      end
+    end
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_account_update_params

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Users::SessionsController < Devise::SessionsController
+  prepend_before_action :check_captcha, only: [:create]
+
   # before_action :configure_sign_in_params, only: [:create]
 
   # GET /resource/sign_in
@@ -24,4 +26,13 @@ class Users::SessionsController < Devise::SessionsController
   # def configure_sign_in_params
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
   # end
+
+  private
+
+    def check_captcha
+      if Flipper.enabled?(:recaptcha) && !verify_recaptcha
+        self.resource = resource_class.new sign_in_params
+        respond_with_navigational(resource) { render :new }
+      end
+    end
 end

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -48,6 +48,10 @@
         <div class="field form-group">
           <div class="field form-group">
             <div class="input-group">
+              <% if Flipper.enabled?(:recaptcha) %>
+                <%= flash[:recaptcha_error] %>
+                <%= recaptcha_tags %>
+              <% end %>
               <%= f.submit "Sign up" ,class:"btn primary-button users-login-primary-button" %>
               <div class="users-text-container">
                 <span class="users-text">Already Registered?</span>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -44,6 +44,9 @@
         <% end -%>
         <div class="field form-group">
           <div class="input-group">
+            <% if Flipper.enabled?(:recaptcha) %>
+              <%= recaptcha_tags %>
+            <% end %>
             <%= f.submit "Log in" ,class:"btn primary-button users-login-primary-button" %>
             <div class="users-text-container">
               <span class="users-text">New User?</span>

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 require "flipper/adapters/redis"
+
+# default flipper configuration
+default_flipper_features = {
+  'recaptcha': false,
+  'forum': false,
+  'project_comments': true
+}
+
 Flipper.configure do |config|
   config.default do
     if Rails.env.test?
@@ -15,7 +23,18 @@ Flipper.configure do |config|
   end
 end
 
-Flipper.enable(:project_comments)
+# set default flipper configuration
+if !Rails.env.test? then
+  enabled_features = Flipper.features.map { |feature| feature.name }
+  default_flipper_features.each do |key, enabled|
+    # If feature not set already then set to default
+    unless enabled_features.include?(key.to_s)
+      Flipper.enable(key) if enabled
+      Flipper.disable(key) if !enabled
+    end
+  end
+end
+
 Flipper::UI.configure do |config|
   config.fun = false
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,7 +50,8 @@ Rails.application.routes.draw do
 
   get "/users/edit", to: redirect('/')
   devise_for :users, controllers: {
-    registrations: "users/registrations", omniauth_callbacks: "users/omniauth_callbacks"
+    registrations: "users/registrations", omniauth_callbacks: "users/omniauth_callbacks",
+    sessions: "users/sessions"
   }
 
   # Logix web pages resources


### PR DESCRIPTION
Add's Google Recaptcha for signup and login pages. Configured Recaptcha V2

1. Added flipper configuration
1. Added default flipper variables

Documentation: https://github.com/heartcombo/devise/wiki/How-To:-Use-Recaptcha-with-Devise

![image](https://user-images.githubusercontent.com/2092958/93665734-96302f00-fa96-11ea-9741-e11d92440dda.png)

