### PR TITLE
[fixed]Indicate that 'circuit' and 'info' in footer are not links

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -20,7 +20,6 @@
       <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4 footer-column">
         <div class="row text-left">
           <div class="col-5 footer-links">
-            ​​<h5><span style="background-color:#42b983; padding:0px; padding-left: 2px; padding-right:2px;">Circuits</span></h5>
             <a href="/simulator"><h6>Simulator</h6></a>
             <a href="/learn" target="_blank"><h6>Learn</h6></a>
             <a href="/examples"><h6>Examples</h6></a>
@@ -31,7 +30,6 @@
             <% end %>
           </div>
           <div class="col-6 footer-links">
-            <h5><span style="background-color:#42b983; padding:0px; padding-left: 2px; padding-right:2px;">Info</span></h5>
             <a href="/docs" target="_blank"><h6>Documentation</h6></a>
             <a href="/contribute"><h6>Contribute</h6></a>
             <a href="/teachers"><h6>Teachers</h6></a>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -20,7 +20,7 @@
       <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4 footer-column">
         <div class="row text-left">
           <div class="col-5 footer-links">
-            <h6>Circuits</h6>
+            ​​<h5><span style="background-color:#42b983; padding:0px; padding-left: 2px; padding-right:2px;">Circuits</span></h5>
             <a href="/simulator"><h6>Simulator</h6></a>
             <a href="/learn" target="_blank"><h6>Learn</h6></a>
             <a href="/examples"><h6>Examples</h6></a>
@@ -31,7 +31,7 @@
             <% end %>
           </div>
           <div class="col-6 footer-links">
-            <h6>Info</h6>
+            <h5><span style="background-color:#42b983; padding:0px; padding-left: 2px; padding-right:2px;">Info</span></h5>
             <a href="/docs" target="_blank"><h6>Documentation</h6></a>
             <a href="/contribute"><h6>Contribute</h6></a>
             <a href="/teachers"><h6>Teachers</h6></a>


### PR DESCRIPTION
Fixes #
Indicate that 'circuit' and 'info' in footer are not link

#### Describe the changes you have made in this PR -
changed the background color(matching to CircuitVerse logo) of the text **_Circuits_** and **_Info_** in footer to indicate that those are not links.

### Screenshots of the changes (If any) -
before:
![bug](https://user-images.githubusercontent.com/64456160/93668005-6dfcfc00-faa7-11ea-8d60-b65060de9551.png)

after:
![bug-fix](https://user-images.githubusercontent.com/64456160/93668753-5a07c900-faac-11ea-8f73-d89905f0c683.png)


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
