### PR TITLE
Disable invisible captcha in Test Env

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -2,7 +2,7 @@
 
 class Users::RegistrationsController < Devise::RegistrationsController
   before_action :configure_sign_up_params, only: [:create]
-  invisible_captcha only: [:create, :update], honeypot: :subtitle
+  invisible_captcha only: [:create, :update], honeypot: :subtitle unless Rails.env.test?
   # before_action :configure_account_update_params, only: [:update]
 
   # GET /resource/sign_up


### PR DESCRIPTION
Fixes Failing tests due to invisible_captcha. I think the captcha worked so well that it could identify the test bot was a bot :P 
