### PR TITLE
Show element description instead of classname

### DIFF
--- a/public/js/logix.js
+++ b/public/js/logix.js
@@ -56,10 +56,10 @@ function setupElementLists() {
     window.renderOrder = [...(moduleList.slice().reverse()), "wires", "allNodes"]; // Order of render
 
 
-    function createIcon(element) {
+    function createIcon(element, description) {
         return `<div class="icon logixModules pointerCursor" id="${element}" >
             <img src= "/img/${element}.svg" >
-            <p class="img__description">${element}</p>
+            <p class="img__description">${description}</p>
         </div>`;
     }
 
@@ -69,9 +69,8 @@ function setupElementLists() {
 
         let categoryData = elementHierarchy[category];
 
-        for (let i = 0; i < categoryData.length; i++) {
-            let element = categoryData[i];
-            htmlIcons += createIcon(element);
+        for (element in categoryData) {
+            htmlIcons += createIcon(element, categoryData[element]);
         }
 
         let accordionData = `<div class="panelHeader">${category}</div>

--- a/public/js/metadata.json
+++ b/public/js/metadata.json
@@ -5,84 +5,83 @@ var metadata = {
         "JKflipFlop", "SRflipFlop", "DflipFlop", "TTY", "Keyboard", "Clock", "DigitalLed", "Stepper", "VariableLed", "RGBLed", "SquareRGBLed", "RGBLedMatrix", "Button", "Demultiplexer",
         "Buffer", "SubCircuit", "Flag", "MSB", "LSB", "PriorityEncoder", "Tunnel", "ALU", "Decoder", "Random", "Counter", "Dlatch", "TB_Input", "TB_Output", "ForceGate",
     ],
-    
+
     "annotationList" : ["Text", "Rectangle", "Arrow"],
     "inputList" : ["Random", "Dlatch", "JKflipFlop", "TflipFlop", "SRflipFlop", "DflipFlop", "Buffer", "Stepper", "Ground", "Power", "ConstantVal", "Input", "Clock", "Button", "Counter"],
     "subCircuitInputList" : ["Random", "Dlatch", "JKflipFlop", "TflipFlop", "SRflipFlop", "DflipFlop", "Buffer", "Stepper", "Ground", "Power", "ConstantVal", "Clock", "Button", "Counter"],
-    "elementHierarchy": {  
-       "Input":[  
-          "Input",
-          "Button",
-          "Power",
-          "Ground",
-          "ConstantVal",
-          "Stepper",
-          "Random",
-          "Counter"
-       ],
-       "Output":[  
-          "Output",
-          "RGBLed",
-          "DigitalLed",
-          "VariableLed",
-          "HexDisplay",
-          "SevenSegDisplay",
-          "SixteenSegDisplay",
-          "SquareRGBLed",
-          "RGBLedMatrix"
- 
-       ],
-       "Gates":[  
-          "AndGate",
-          "OrGate",
-          "NotGate",
-          "XorGate",
-          "NandGate",
-          "NorGate",
-          "XnorGate"
-       ],
-       "Decoders & Plexers":[  
-          "Multiplexer",
-          "Demultiplexer",
-          "BitSelector",
-          "MSB",
-          "LSB",
-          "PriorityEncoder",
-          "Decoder"
-       ],
-       "Sequential Elements":[  
-          "DflipFlop",
-          "Dlatch",
-          "TflipFlop",
-          "JKflipFlop",
-          "SRflipFlop",
-          "TTY",
-          "Keyboard",
-          "Clock",
-       ],
-       "Memory Elements":[
-          "Rom",
-          "RAM",
-          "EEPROM"
-       ],
-       "Test Bench":[  
-          "TB_Input",
-          "TB_Output",
-          "ForceGate"
-       ],
-       "Misc":[  
-          "Flag",
-          "Splitter",
-          "Adder",
-          "TriState",
-          "Buffer",
-          "ControlledInverter",
-          "ALU",
-          "Rectangle",
-          "Arrow",
-          "Text",
-		  "Tunnel",
-		  "TwoComplement"
-       ]
+    "elementHierarchy": {
+       "Input": {
+          "Input": "Input",
+          "Button": "Button",
+          "Power": "Power",
+          "Ground": "Ground",
+          "ConstantVal": "Constant Value",
+          "Stepper": "Stepper",
+          "Random": "Random",
+          "Counter": "Counter"
+       },
+       "Output": {
+          "Output": "Output",
+          "RGBLed": "RGB LED",
+          "DigitalLed": "Digital LED",
+          "VariableLed": "Variable LED",
+          "HexDisplay": "HEX Display",
+          "SevenSegDisplay": "Seven Segment Display",
+          "SixteenSegDisplay": "Sixteen Segment Display",
+          "SquareRGBLed": "Square RGB LED",
+          "RGBLedMatrix": "RGB LED Matrix"
+       },
+       "Gates": {
+          "AndGate": "AND Gate",
+          "OrGate": "OR Gate",
+          "NotGate": "NOT Gate",
+          "XorGate": "XOR Gate",
+          "NandGate": "NAND Gate",
+          "NorGate": "NOR Gate",
+          "XnorGate": "XNOR Gate"
+       },
+       "Decoders & Plexers": {
+          "Multiplexer": "Mux",
+          "Demultiplexer": "Demux",
+          "BitSelector": "Bit Selector",
+          "MSB": "MSB",
+          "LSB": "LSB",
+          "PriorityEncoder": "Priority Encoder",
+          "Decoder": "Decoder"
+       },
+       "Sequential Elements": {
+          "DflipFlop": "D Flip Flop",
+          "Dlatch": "D Latch",
+          "TflipFlop": "T Flip Flop",
+          "JKflipFlop": "JK Flip Flop",
+          "SRflipFlop": "SR Flip Flop",
+          "TTY": "TTY",
+          "Keyboard": "Keyboard",
+          "Clock": "Clock",
+       },
+       "Memory Elements": {
+          "Rom": "ROM",
+          "RAM": "RAM",
+          "EEPROM": "EEPROM"
+       },
+       "Test Bench": {
+          "TB_Input": "TB Input",
+          "TB_Output": "TB Output",
+          "ForceGate": "Force Gate"
+       },
+       "Misc": {
+          "Flag": "Flag",
+          "Splitter": "Splitter",
+          "Adder": "Adder",
+          "TriState": "TriState",
+          "Buffer": "Buffer",
+          "ControlledInverter": "Controlled Inverter",
+          "ALU": "ALU",
+          "Rectangle": "Rectangle",
+          "Arrow": "Arrow",
+          "Text": "Text",
+          "Tunnel": "Tunnel",
+          "TwoComplement": "Two Complement"
+       }
     }
  }


### PR DESCRIPTION
To make it more clear, add a description to each element (dict instead of list). Display this description instead of the element's classname.

### Screenshots of the changes (If any) -

![image](https://user-images.githubusercontent.com/299017/93764282-1f6c7080-fc13-11ea-8750-77d83e3ccfbd.png)
