### PR TITLE
adding tooltips to display full project names 

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -131,7 +131,7 @@
 }
 
 .tooltiptext {
-  background-color: $primary-green;
+  background-color: $navbar-dark-grey;
   border-radius: .3rem;
   bottom: 100%;
   color: $white;
@@ -147,7 +147,7 @@
   z-index: 1;
 
   &::after {
-    border-color: $primary-green transparent transparent;
+    border-color: $navbar-dark-grey transparent transparent;
     border-style: solid;
     border-width: .3rem;
     content: '';

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -128,10 +128,10 @@
   }
 
   .tooltiptext {
-    background-color: #42b983;
+    background-color: var(--green);
     border-radius: 6px;
     bottom: 100%;
-    color: #fff;
+    color: var(--white);
     left: 50%;
     margin-left: -60px;
     opacity: 0;

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -115,15 +115,52 @@
 }
 
 .circuit-card-name {
-  display: inline-block;
   float: left;
   font-weight: 600;
   margin-top: 5px;
-  max-height: 50px;
-  max-width: 150px;
-  overflow: hidden;
+  position: relative;
   text-align: left;
-  text-overflow: ellipsis;
+
+  p {
+    max-height: 50px;
+    max-width: 150px;
+    overflow: hidden;
+  }
+
+  .tooltiptext {
+    background-color: #42b983;
+    border-radius: 6px;
+    bottom: 100%;
+    color: #fff;
+    left: 50%;
+    margin-left: -60px;
+    opacity: 0;
+    padding: 5px 0;
+    position: absolute;
+    text-align: center;
+    transition: opacity .5s;
+    visibility: hidden;
+    width: 120px;
+    z-index: 1;
+  }
+
+
+  .tooltiptext::after {
+    border-color: var(--green) transparent transparent;
+    border-style: solid;
+    border-width: 5px;
+    content: '';
+    left: 50%;
+    margin-left: -5px;
+    position: absolute;
+    top: 100%;
+  }
+
+}
+
+.circuit-card-name:hover .tooltiptext {
+  opacity: 1;
+  visibility: visible;
 }
 
 .circuit-card-primary-button {

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -117,36 +117,36 @@
 .circuit-card-name {
   float: left;
   font-weight: 600;
-  margin-top: 5px;
+  margin-top: 10px;
   position: relative;
   text-align: left;
 
   p {
-    max-height: 50px;
+    max-height: 30px;
     max-width: 150px;
     overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .tooltiptext {
-    background-color: var(--green);
+    background-color: $primary-green;
     border-radius: 6px;
     bottom: 100%;
-    color: var(--white);
-    left: 50%;
-    margin-left: -60px;
+    color: $white;
+    font-size: .8rem;
+    max-width: 160px;
     opacity: 0;
     padding: 5px 0;
     position: absolute;
     text-align: center;
     transition: opacity .5s;
     visibility: hidden;
-    width: 120px;
     z-index: 1;
   }
 
-
   .tooltiptext::after {
-    border-color: var(--green) transparent transparent;
+    border-color: $primary-green transparent transparent;
     border-style: solid;
     border-width: 5px;
     content: '';

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -123,39 +123,39 @@
 
   p {
     max-height: 30px;
-    max-width: 150px;
+    max-width: 160px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
+}
 
-  .tooltiptext {
-    background-color: $primary-green;
-    border-radius: 6px;
-    bottom: 100%;
-    color: $white;
-    font-size: .8rem;
-    max-width: 160px;
-    opacity: 0;
-    padding: 5px 0;
-    position: absolute;
-    text-align: center;
-    transition: opacity .5s;
-    visibility: hidden;
-    z-index: 1;
-  }
+.tooltiptext {
+  background-color: $primary-green;
+  border-radius: .3rem;
+  bottom: 100%;
+  color: $white;
+  font-size: .8rem;
+  left: 0%;
+  max-width: 100%;
+  opacity: 0;
+  padding: .3rem;
+  position: absolute;
+  text-align: center;
+  transition: opacity .5s;
+  visibility: hidden;
+  z-index: 1;
 
-  .tooltiptext::after {
+  &::after {
     border-color: $primary-green transparent transparent;
     border-style: solid;
-    border-width: 5px;
+    border-width: .3rem;
     content: '';
     left: 50%;
-    margin-left: -5px;
+    margin-left: -.3rem;
     position: absolute;
     top: 100%;
   }
-
 }
 
 .circuit-card-name:hover .tooltiptext {

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -118,8 +118,8 @@
   display: inline-block;
   float: left;
   font-weight: 600;
-  margin-top: 10px;
-  max-height: 30px;
+  margin-top: 5px;
+  max-height: 50px;
   max-width: 150px;
   overflow: hidden;
   text-align: left;

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -214,23 +214,29 @@
 }
 
 .users-card-name {
-  display: block;
+  display: inline-block;
   font-size: 18px;
   font-weight: 600;
-  max-height: 30px;
-  max-width: 340px;
   padding-bottom: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  position: relative;
 
   p {
     margin-bottom: 0;
+    max-height: 30px;
+    max-width: 340px;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 }
 
+.users-card-name:hover .tooltiptext {
+  opacity: 1;
+  visibility: visible;
+}
+
 .users-tag-container {
-  display: inline-block;
-  margin-top: 0;
+  display: block;
+  margin-top: -.5rem;
 }
 
 .users-card-body {

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -214,7 +214,7 @@
 }
 
 .users-card-name {
-  display: inline-block;
+  display: block;
   font-size: 18px;
   font-weight: 600;
   padding-bottom: 0;
@@ -236,8 +236,8 @@
 }
 
 .users-tag-container {
-  display: block;
-  margin-top: -.5rem;
+  display: inline-block;
+  margin-top: 0;
 }
 
 .users-card-body {

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -223,9 +223,10 @@
   p {
     margin-bottom: 0;
     max-height: 30px;
-    max-width: 340px;
+    max-width: 300px;
     overflow: hidden;
     text-overflow: ellipsis;
+    white-space: nowrap;
   }
 }
 

--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -12,7 +12,7 @@
         </p>
     </div>
   </div>
-  <div class="col-xs col-sm col-md col-lg d-flex justify-content-center">
+  <div class="col-xs col-sm col-md col-lg">
     <a class="btn primary-button" href="/tos" target="_blank">Terms of Service</a>
     <a class="btn primary-button" href="/privacy" target="_blank">Privacy Policy</a>
   </div>

--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -12,7 +12,7 @@
         </p>
     </div>
   </div>
-  <div class="col-xs col-sm col-md col-lg">
+  <div class="col-xs col-sm col-md col-lg d-flex justify-content-center">
     <a class="btn primary-button" href="/tos" target="_blank">Terms of Service</a>
     <a class="btn primary-button" href="/privacy" target="_blank">Privacy Policy</a>
   </div>

--- a/app/views/featured_circuits/index.html.erb
+++ b/app/views/featured_circuits/index.html.erb
@@ -15,6 +15,7 @@
           <div class="card-footer circuit-card-footer">
             <div class="circuit-card-name">
               <p><%= project.name %></p>
+              <span class="tooltiptext"><%= project.name %></span>
             </div>
             <a class="btn primary-button circuit-card-primary-button" target="_blank" href="<%= user_project_url(project.author, project) %>">View</a>
           </div>

--- a/app/views/logix/examples.html.erb
+++ b/app/views/logix/examples.html.erb
@@ -14,6 +14,7 @@
           <div class="card-footer circuit-card-footer">
             <div class="circuit-card-name">
               <p><%= example[:name] %></p>
+              <span class="tooltiptext"><%= example[:name] %></span>
             </div>
             <a class="btn primary-button circuit-card-primary-button" target="_blank" href="https://circuitverse.org/<%= example[:id] %>">View</a>
           </div>

--- a/app/views/logix/index.html.erb
+++ b/app/views/logix/index.html.erb
@@ -121,6 +121,7 @@
             <div class="card-footer circuit-card-footer">
               <div class="circuit-card-name">
                 <p>16-bit Ripple Carry Adder</p>
+                <span class="tooltiptext">16-bit Ripple Carry Adder</span>
               </div>
               <a class="btn primary-button circuit-card-primary-button" target="_blank" href="https://circuitverse.org/users/3/projects/248">View</a>
             </div>
@@ -132,6 +133,7 @@
             <div class="card-footer circuit-card-footer">
               <div class="circuit-card-name">
                 <p>SAP-1</p>
+                <span class="tooltiptext">SAP-1</span>
               </div>
               <a class="btn primary-button circuit-card-primary-button" target="_blank" href="https://circuitverse.org/users/3/projects/67">View</a>
             </div>
@@ -143,6 +145,7 @@
             <div class="card-footer circuit-card-footer">
               <div class="circuit-card-name">
                 <p>Full Adder from 2 Half Adders</p>
+                <span class="tooltiptext">Full Adder from 2 Half Adders</span>
               </div>
               <a class="btn primary-button circuit-card-primary-button" target="_blank" href="https://circuitverse.org/users/3/projects/247">View</a>
             </div>
@@ -171,6 +174,7 @@
                 <div class="card-footer circuit-card-footer">
                   <div class="circuit-card-name">
                     <p><%= circuit.name %></p>
+                    <span class="tooltiptext"><%= circuit.name %></span>
                   </div>
                   <a class="btn primary-button circuit-card-primary-button" target="_blank" href="<%= user_project_url(circuit.author, circuit) %>">View</a>
                 </div>
@@ -200,6 +204,7 @@
               <div class="card-footer circuit-card-footer">
                 <div class="circuit-card-name">
                   <p><%= project.name %></p>
+                  <span class="tooltiptext"><%= project.name %></span>
                 </div>
                 <a class="btn primary-button circuit-card-primary-button" target="_blank" href="<%= user_project_url(project.author, project) %>">View</a>
               </div>

--- a/app/views/users/logix/_dashboard.html.erb
+++ b/app/views/users/logix/_dashboard.html.erb
@@ -5,7 +5,7 @@
       <div class="card text-center users-card">
         <div class="card-header users-card-header">
           <div class="users-card-name">
-            <p title="<%= project.name %>"><%= project.name %></p>
+            <p><%= project.name %></p>
             <span class="tooltiptext"><%= project.name %></span>
           </div>
           <div class="users-tag-container">

--- a/app/views/users/logix/_dashboard.html.erb
+++ b/app/views/users/logix/_dashboard.html.erb
@@ -6,6 +6,7 @@
         <div class="card-header users-card-header">
           <div class="users-card-name">
             <p title="<%= project.name %>"><%= project.name %></p>
+            <span class="tooltiptext"><%= project.name %></span>
           </div>
           <div class="users-tag-container">
             <% if !project.assignment_id.nil? %>


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -

### Screenshots of the changes (If any) -
before::
   problem1:
![1](https://user-images.githubusercontent.com/55848322/93782651-73de1300-fc48-11ea-9006-9068e5c1739f.png)
![x](https://user-images.githubusercontent.com/55848322/93842571-03211000-fcb5-11ea-8422-a3da9c7c4b83.png)   
hidden words are getting partially displayed

problem2:
there is no way to see full project name (adding tooltip required)


fix :: final commit will implement some fine tuning to the circuit card names and responsive  tooltips to all circuit cards on homepage as well as dashboard cards to represent full  circuit name

![Screenshot from 2020-10-24 15-13-24](https://user-images.githubusercontent.com/55848322/97078760-e78a8b80-160b-11eb-91ea-dcfbabec3932.png)




Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 

