### PR TITLE
Support multiple mentors per group

### DIFF
--- a/app/assets/stylesheets/groups.scss
+++ b/app/assets/stylesheets/groups.scss
@@ -3,7 +3,7 @@
   margin-bottom: 20px;
 }
 
-.group-mentor-heading {
+.group-owner-heading {
   font-weight: normal;
 }
 

--- a/app/controllers/api/v1/group_mentors_controller.rb
+++ b/app/controllers/api/v1/group_mentors_controller.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+class Api::V1::GroupMentorsController < Api::V1::BaseController
+  before_action :authenticate_user!
+  before_action :set_group, only: %i[index create]
+  before_action :set_group_member, only: %i[destroy]
+  before_action :check_show_access, only: %i[index]
+  before_action :check_edit_access, only: %i[create]
+  before_action :check_mentor_access, only: %i[destroy]
+
+  # GET /api/v1/groups/:group_id/mentors/
+  def index
+    @group_mentors = paginate(@group.group_mentors)
+    @options = { links: link_attrs(@group_mentors, api_v1_group_mentors_url(@group.id)) }
+    render json: Api::V1::GroupMentorSerializer.new(@group_mentors, @options)
+  end
+
+  # POST /api/v1/groups/:group_id/mentors/
+  def create
+    mails_handler = MailsHandler.new(params[:emails], @group, current_user)
+    # parse mails as valid or invalid
+    mails_handler.parse
+    # create invitation or group member
+    mails_handler.create_invitation_or_group_member
+
+    render json: {
+      added: mails_handler.added_mails,
+      pending: mails_handler.pending_mails,
+      invalid: mails_handler.invalid_mails
+    }
+  end
+
+  # DELETE /api/v1/group/mentors/:id
+  def destroy
+    @group_member.destroy!
+    render json: {}, status: :no_content
+  end
+
+  private
+
+    def set_group
+      @group = Group.find(params[:group_id])
+    end
+
+    def set_group_member
+      @group_member = GroupMember.find(params[:id])
+    end
+
+    def check_show_access
+      # checks if current_user has access to get group mentors
+      authorize @group, :show_access?
+    end
+
+    def check_mentor_access
+      # check mentor access?
+      authorize @group_member, :mentor?
+    end
+
+    def check_edit_access
+      # check if current user has admin/mentor rights to create group mentors
+      authorize @group, :admin_access?
+    end
+end

--- a/app/controllers/api/v1/groups_controller.rb
+++ b/app/controllers/api/v1/groups_controller.rb
@@ -2,17 +2,24 @@
 
 class Api::V1::GroupsController < Api::V1::BaseController
   before_action :authenticate_user!
-  before_action :set_group, except: %i[index groups_mentored create]
-  before_action :set_options, only: %i[index groups_mentored create show update]
+  before_action :set_group, except: %i[index groups_owned groups_mentored create]
+  before_action :set_options, only: %i[index groups_owned groups_mentored create show update]
   before_action :check_show_access, only: [:show]
   before_action :check_edit_access, only: %i[update destroy]
 
-  WHITELISTED_INCLUDE_ATTRIBUTES = %i[group_members assignments].freeze
+  WHITELISTED_INCLUDE_ATTRIBUTES = %i[group_members group_mentors assignments].freeze
 
   # GET /api/v1/groups
   def index
     @groups = paginate(current_user.groups)
     @options[:links] = link_attrs(@groups, api_v1_groups_url)
+    render json: Api::V1::GroupSerializer.new(@groups, @options)
+  end
+
+  # GET /api/v1/groups/owned
+  def groups_owned
+    @groups = paginate(current_user.groups_owned)
+    @options[:links] = link_attrs(@groups, api_v1_groups_owned_url)
     render json: Api::V1::GroupSerializer.new(@groups, @options)
   end
 
@@ -25,6 +32,7 @@ class Api::V1::GroupsController < Api::V1::BaseController
 
   # POST /api/v1/groups/
   def create
+    @group = current_user.groups_owned.new(group_params)
     @group = current_user.groups_mentored.new(group_params)
     @group.save!
     if @group.save
@@ -75,7 +83,7 @@ class Api::V1::GroupsController < Api::V1::BaseController
     end
 
     def group_params
-      params.require(:group).permit(:name, :mentor_id)
+      params.require(:group).permit(:name, :owner_id)
     end
 
     def check_show_access

--- a/app/controllers/group_members_controller.rb
+++ b/app/controllers/group_members_controller.rb
@@ -30,7 +30,7 @@ class GroupMembersController < ApplicationController
   def create
     dummy = GroupMember.new
     dummy.group_id = group_member_params[:group_id]
-    authorize dummy, :mentor?
+    authorize dummy, :owner?
 
     @group = Group.find(group_member_params[:group_id])
 
@@ -115,6 +115,6 @@ class GroupMembersController < ApplicationController
     end
 
     def check_access
-      authorize @group_member, :mentor?
+      authorize @group_member, :owner?
     end
 end

--- a/app/controllers/group_mentors_controller.rb
+++ b/app/controllers/group_mentors_controller.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+class GroupMentorsController < ApplicationController
+  before_action :set_group_mentor, only: %i[show edit update destroy]
+  before_action :check_access, only: %i[edit update destroy]
+  before_action :authenticate_user!
+
+  # GET /group_mentors
+  # GET /group_mentors.json
+  # def index
+  #   @group_mentors = GroupMentor.all
+  # end
+  #
+  # # GET /group_mentors/1
+  # # GET /group_mentors/1.json
+  # def show
+  # end
+  #
+  # # GET /group_mentors/new
+  # def new
+  #   @group_member = GroupMentor.new
+  # end
+
+  # GET /group_mentors/1/edit
+  # def edit
+  # end
+
+  # POST /group_mentors
+  # POST /group_mentors.json
+  def create
+    dummy = GroupMentor.new
+    dummy.group_id = group_mentor_params[:group_id]
+    authorize dummy, :owner?
+
+    @group = Group.find(group_mentor_params[:group_id])
+
+    group_mentor_emails = Utils.parse_mails(group_mentor_params[:emails])
+
+    present_mentors = User.where(id: @group.group_mentors.pluck(:user_id)).pluck(:email)
+    newly_added = group_mentor_emails - present_mentors
+
+    newly_added.each do |email|
+      email = email.strip
+      user = User.find_by(email: email)
+      if user.nil?
+        PendingInvitation.where(group_id: @group.id, email: email).first_or_create
+      else
+        GroupMentor.where(group_id: @group.id, user_id: user.id).first_or_create
+      end
+    end
+
+    notice = Utils.mail_notice(group_mentor_params[:emails], group_mentor_emails, newly_added)
+
+    respond_to do |format|
+      format.html do
+        redirect_to group_path(@group), notice: Utils.mail_notice(group_mentor_params[:emails], group_mentor_emails, newly_added)
+      end
+    end
+  end
+
+  # DELETE /group_mentors/1
+  # DELETE /group_mentors/1.json
+  def destroy
+    @group_mentor.destroy
+    respond_to do |format|
+      format.html do
+        redirect_to group_path(@group_mentor.group),
+                    notice: "Group mentor was successfully removed."
+      end
+      format.json { head :no_content }
+    end
+  end
+
+  private
+
+    # Use callbacks to share common setup or constraints between actions.
+    def set_group_mentor
+      @group_mentor = GroupMentor.find(params[:id])
+    end
+
+    # Never trust parameters from the scary internet, only allow the white list through.
+    def group_mentor_params
+      params.require(:group_mentor).permit(:group_id, :user_id, :emails)
+    end
+
+    def check_access
+      authorize @group_mentor, :owner?
+    end
+end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -10,6 +10,7 @@ class GroupsController < ApplicationController
   # GET /groups/1.json
   def show
     @group_member = @group.group_members.new
+    @group_mentor = @group.group_mentors.new
     @group.assignments.each do |assignment|
       if (assignment.status == "reopening") && (assignment.deadline < Time.zone.now)
         assignment.status = "closed"
@@ -29,6 +30,7 @@ class GroupsController < ApplicationController
   # POST /groups
   # POST /groups.json
   def create
+    @group = current_user.groups_owned.new(group_params)
     @group = current_user.groups_mentored.new(group_params)
 
     respond_to do |format|
@@ -75,7 +77,7 @@ class GroupsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def group_params
-      params.require(:group).permit(:name, :mentor_id)
+      params.require(:group).permit(:name, :owner_id)
     end
 
     def check_show_access

--- a/app/controllers/users/logix_controller.rb
+++ b/app/controllers/users/logix_controller.rb
@@ -35,7 +35,12 @@ class Users::LogixController < ApplicationController
 
   def groups
     @user = authorize @user
-    @groups_mentored = Group.where(id: Group.joins(:mentor).where(mentor: @user))
+    @groups_owned = Group.where(id: Group.joins(:owner).where(owner: @user))
+                            .select("groups.*, COUNT(group_members.id) as group_member_count")
+                            .joins("left outer join group_members on \
+                              (group_members.group_id = groups.id)")
+                            .group("groups.id")
+    @groups_mentored = Group.where(id: Group.joins(:group_mentors).where(group_mentors: { user: @user }))
                             .select("groups.*, COUNT(group_members.id) as group_member_count")
                             .joins("left outer join group_members on \
                               (group_members.group_id = groups.id)")

--- a/app/mailers/group_mailer.rb
+++ b/app/mailers/group_mailer.rb
@@ -12,4 +12,10 @@ class GroupMailer < ApplicationMailer
     @group = group
     mail(to: @user.email, subject: "Added to a New group")
   end
+
+  def new_mentor_email(user, group)
+    @user = user
+    @group = group
+    mail(to: @user.email, subject: "Added as mentor a New group")
+  end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -2,9 +2,11 @@
 
 class Group < ApplicationRecord
   validates :name, length: { minimum: 1 }
-  belongs_to :mentor, class_name: "User"
+  belongs_to :owner, class_name: "User"
   has_many :group_members, dependent: :destroy
-  has_many :users, through: :group_members
+  has_many :group_mentors, dependent: :destroy
+  has_many :members, through: :group_members, source: :user
+  has_many :mentors, through: :group_mentors, source: :user
 
   has_many :assignments, dependent: :destroy
   has_many :pending_invitations, dependent: :destroy
@@ -12,6 +14,6 @@ class Group < ApplicationRecord
   after_commit :send_creation_mail, on: :create
 
   def send_creation_mail
-    GroupMailer.new_group_email(mentor, self).deliver_later
+    GroupMailer.new_group_email(owner, self).deliver_later
   end
 end

--- a/app/models/group_mentor.rb
+++ b/app/models/group_mentor.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class GroupMentor < ApplicationRecord
+  belongs_to :group
+  belongs_to :user
+  has_many :assignments, through: :group
+
+  after_commit :send_welcome_email, on: :create
+
+  def send_welcome_email
+    GroupMailer.new_mentor_email(user, group).deliver_later
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,11 +11,13 @@ class User < ApplicationRecord
   has_many :projects, foreign_key: "author_id", dependent: :destroy
   has_many :stars
   has_many :rated_projects, through: :stars, dependent: :destroy, source: "project"
-  has_many :groups_mentored, class_name: "Group",  foreign_key: "mentor_id", dependent: :destroy
+  has_many :groups_owned, class_name: "Group",  foreign_key: "owner_id", dependent: :destroy
+  has_many :group_mentor, dependent: :destroy
+  has_many :groups_mentored, through: :group_mentor, :source => :group
   devise :database_authenticatable, :registerable, :recoverable, :rememberable, :trackable,
          :validatable, :omniauthable, omniauth_providers: %i[google_oauth2 facebook github]
 
-  # has_many :assignments, foreign_key: 'mentor_id', dependent: :destroy
+  # has_many :assignments, foreign_key: 'owner_id', dependent: :destroy
   has_many :group_members, dependent: :destroy
   has_many :groups, through: :group_members
   has_many :grades

--- a/app/policies/assignment_policy.rb
+++ b/app/policies/assignment_policy.rb
@@ -9,12 +9,16 @@ class AssignmentPolicy < ApplicationPolicy
   end
 
   def show?
-    assignment.group.mentor_id == user.id || user.groups.where(id: assignment.group.id).exists? \
-    || user.admin?
+    assignment.group.owner_id == user.id || user.groups.where(id: assignment.group.id).exists? \
+    || mentor? || user.admin?
+  end
+
+  def mentor?
+    assignment.group.group_mentors.where(user: user.id).exists?
   end
 
   def admin_access?
-    (assignment.group&.mentor_id == user.id) || user.admin?
+    (assignment.group&.owner_id == user.id) || mentor? || user.admin?
   end
 
   def start?

--- a/app/policies/grade_policy.rb
+++ b/app/policies/grade_policy.rb
@@ -9,6 +9,6 @@ class GradePolicy < ApplicationPolicy
   end
 
   def mentor?
-    grade.assignment&.group&.mentor_id == user.id
+    grade.assignment&.group&.owner_id == user.id || grade.assignment&.group&.group_mentors.exists?(user_id: user.id)
   end
 end

--- a/app/policies/group_member_policy.rb
+++ b/app/policies/group_member_policy.rb
@@ -8,7 +8,7 @@ class GroupMemberPolicy < ApplicationPolicy
     @group_member = group_member
   end
 
-  def mentor?
-    (group_member.group.mentor_id == user.id || user.admin?)
+  def owner?
+    (group_member.group.owner_id == user.id || user.admin?)
   end
 end

--- a/app/policies/group_mentor_policy.rb
+++ b/app/policies/group_mentor_policy.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class GroupMentorPolicy < ApplicationPolicy
+  attr_reader :user, :group_mentor
+
+  def initialize(user, group_mentor)
+    @user = user
+    @group_mentor = group_mentor
+  end
+
+  def owner?
+    (group_mentor.group.owner_id == user.id || user.admin?)
+  end
+end

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -6,14 +6,19 @@ class GroupPolicy < ApplicationPolicy
   def initialize(user, group)
     @user = user
     @group = group
-    @admin_access = ((group.mentor_id == user.id) || user.admin?)
+    @admin_access = ((group.owner_id == user.id) || user.admin?)
+    @mentor_access = (group.group_mentors.exists?(user_id: user.id))
   end
 
   def show_access?
-    @admin_access || group.group_members.exists?(user_id: user.id)
+    @admin_access || group.group_members.exists?(user_id: user.id) || group.group_mentors.exists?(user_id: user.id)
   end
 
   def admin_access?
     @admin_access
+  end
+
+  def mentor_access?
+    @mentor_access
   end
 end

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -28,7 +28,7 @@ class ProjectPolicy < ApplicationPolicy
     (project.project_access_type != "Private" \
     || (!user.nil? && project.author_id == user.id) \
     || (!user.nil? && !project.assignment_id.nil? \
-      && project.assignment.group.mentor_id == user.id) \
+      && ((project.assignment.group.owner_id == user.id) || (project.assignment.group.group_mentors.exists?(user_id: user.id)))) \
     || (!user.nil? && Collaboration.exists?(project_id: project.id, user_id: user.id)) \
     || (!user.nil? && user.admin))
   end

--- a/app/serializers/api/v1/assignment_serializer.rb
+++ b/app/serializers/api/v1/assignment_serializer.rb
@@ -6,7 +6,7 @@ class Api::V1::AssignmentSerializer
   attributes :name, :deadline, :description, :status, :restrictions
 
   attributes :has_mentor_access do |assignment, params|
-    (assignment.group.mentor_id == params[:current_user].id) || params[:current_user].admin?
+    (assignment.group.owner_id == params[:current_user].id) || params[:current_user].admin?
   end
 
   attributes :current_user_project_id do |assignment, params|

--- a/app/serializers/api/v1/group_mentor_serializer.rb
+++ b/app/serializers/api/v1/group_mentor_serializer.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Api::V1::GroupMentorSerializer
+  include FastJsonapi::ObjectSerializer
+
+  attributes :group_id, :user_id, :created_at, :updated_at
+
+  attribute :name do |object|
+    object.user.name
+  end
+
+  attribute :email do |object|
+    object.user.email
+  end
+end

--- a/app/serializers/api/v1/group_serializer.rb
+++ b/app/serializers/api/v1/group_serializer.rb
@@ -7,12 +7,13 @@ class Api::V1::GroupSerializer
     group.group_members.size
   end
 
-  attributes :mentor_name do |group|
-    group.mentor.name
+  attributes :owner_name do |group|
+    group.owner.name
   end
 
-  attributes :name, :mentor_id, :created_at, :updated_at
+  attributes :name, :owner_id, :created_at, :updated_at
 
   has_many :group_members
+  has_many :group_mentors
   has_many :assignments
 end

--- a/app/views/assignment_mailer/new_assignment_email.html.erb
+++ b/app/views/assignment_mailer/new_assignment_email.html.erb
@@ -3,7 +3,7 @@
   <%= inline_svg_tag "SVGs/newAssignment.svg", alt: "New Assignment", class: "mailer-assignment-image" %>
   <p class="mailer-text">
     A new assignment named <span class="mailer-highlighted-text"><%= @assignment.name %> (<%= @assignment.deadline %>)</span> has been assigned in <span class="mailer-highlighted-text"><%= Group.find_by(id:@assignment.group_id).name %></span>. <br>
-    Assignment is mentored by <span class="mailer-highlighted-text"><%= User.find_by(id:Group.find_by(id:@assignment.group_id).mentor_id).name %></span>
+    Assignment is mentored by <span class="mailer-highlighted-text"><%= User.find_by(id:Group.find_by(id:@assignment.group_id).owner_id).name %></span>
   </p>
   <a href="<%= group_assignment_url(Group.find_by(id:@assignment.group_id), @assignment) %>" class="mailer-button">View Assignment</a>
   <p class="mailer-text">Keep building!</p>

--- a/app/views/assignment_mailer/update_assignment_email.html.erb
+++ b/app/views/assignment_mailer/update_assignment_email.html.erb
@@ -3,7 +3,7 @@
   <%= inline_svg_tag "SVGs/newAssignment.svg", alt: "New Assignment", class: "mailer-assignment-image" %>
   <p class="mailer-text">
     The assignment <span class="mailer-highlighted-text"><%= @assignment.name %> (<%= @assignment.deadline %>)</span> has been updated. <br>
-    Assignment is mentored by <span class="mailer-highlighted-text"><%= User.find_by(id:Group.find_by(id:@assignment.group_id).mentor_id).name %></span>
+    Assignment is mentored by <span class="mailer-highlighted-text"><%= User.find_by(id:Group.find_by(id:@assignment.group_id).owner_id).name %></span>
   </p>
   <a href="<%= group_assignment_url(Group.find_by(id:@assignment.group_id), @assignment) %>" class="mailer-button">View Assignment</a>
   <p class="mailer-text">Keep building!</p>

--- a/app/views/group_mailer/new_member_email.html.erb
+++ b/app/views/group_mailer/new_member_email.html.erb
@@ -3,7 +3,7 @@
   <%= inline_svg_tag "PNGs/newGroup.png", alt: "New Group", class: "mailer-group-image" %>
   <p class="mailer-text">
     You have been added to a new group named <span class="mailer-highlighted-text"><%= @group.name %></span>. <br>
-    The group is mentored by <span class="mailer-highlighted-text"><%= User.find_by(id:@group.mentor_id).name %></span>.
+    The group is mentored by <span class="mailer-highlighted-text"><%= User.find_by(id:@group.owner_id).name %></span>.
   </p>
   <a href="<%= group_url(@group) %>" class="mailer-button">View Group</a>
   <p class="mailer-text">Keep building!</p>

--- a/app/views/groups/_add_mentor_modal.html.erb
+++ b/app/views/groups/_add_mentor_modal.html.erb
@@ -1,0 +1,34 @@
+<div id="addmentorModal" class="modal fade" role="dialog">
+  <div class="modal-dialog primary-modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header primary-modal-header">
+        <h4 class="modal-title">Add Mentors</h4>
+        <button type="button" class="close" data-dismiss="modal">&times;</button>
+      </div>
+      <div class="modal-body">
+        <p>Enter Email IDs separated by commas/spaces or in separate lines. If users are not registered, an email ID will be sent requesting them to sign up.</p>
+        <%= form_with(model: group_mentor, local: true) do |form| %>
+          <% if group_mentor.errors.any? %>
+            <div id="error-message">
+              <ul>
+                <% group_mentor.errors.full_messages.each do |message| %>
+                    <li><%= message %></li>
+                <% end %>
+              </ul>
+            </div>
+          <% end %>
+          <div class="field">
+            <%= form.hidden_field :group_id, id: :group_mentor_group_id %>
+          </div>
+          <div class="form-group">
+            <label for="emails">Email IDs:</label>
+            <textarea class="form-control form-input" rows="5" id="emails" name="group_mentor[emails]"></textarea>
+          </div>
+          <div class="modal-footer">
+            <%= form.submit "Add mentors", class: 'btn primary-button' %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/groups/_delete_mentor_confirmation_modal.html.erb
+++ b/app/views/groups/_delete_mentor_confirmation_modal.html.erb
@@ -1,0 +1,18 @@
+<div id="deletementorModal" class="modal fade" role="dialog">
+  <div class="modal-dialog primary-modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header secondary-modal-header">
+        <h4 class="modal-title">Delete</h4>
+        <button type="button" class="close" data-dismiss="modal">&times;</button>
+      </div>
+      <div class="modal-body">
+        <p>Are you sure you want to remove this mentor?</p>
+      </div>
+      <div class="modal-footer">
+        <%= link_to '#', method: :delete, class: "btn primary-delete-button", id: "groups-member-delete-button" do %>
+          Delete
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/groups/_group.json.jbuilder
+++ b/app/views/groups/_group.json.jbuilder
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-json.extract! group, :id, :name, :mentor_id, :created_at, :updated_at
+json.extract! group, :id, :name, :owner_id, :created_at, :updated_at
 json.url group_url(group, format: :json)

--- a/app/views/groups/_group_mentors.html.erb
+++ b/app/views/groups/_group_mentors.html.erb
@@ -1,4 +1,4 @@
-<% group.members.each do |user| %>
+<% group.mentors.each do |user| %>
   <div class="col-xs-12 col-sm-12 col-md-6 col-lg-4 groups-members-card-container">
     <div class="groups-members-card">
       <div class="row">
@@ -10,9 +10,9 @@
           <p class="groups-members-card-email"><%= user.email %></p>
         </div>
         <div class="col-5 groups-members-card-button">
-          <% if (policy(group).admin_access? || policy(group).mentor_access?) %>
-            <%= link_to '#', data: {toggle: "modal", target: "#deletememberModal", currentgroupmember: GroupMember.find_by(user_id:user.id,group_id:group.id).id}, class:"mini-button groups-delete-mini-button" do %>
-              <%= image_tag("SVGs/deleteGroup.svg", alt: "Remove Member") %>
+          <% if policy(group).admin_access? %>
+            <%= link_to '#', data: {toggle: "modal", target: "#deletementorModal", currentgroupmember: GroupMentor.find_by(user_id:user.id,group_id:group.id).id}, class:"mini-button groups-delete-mini-button" do %>
+              <%= image_tag("SVGs/deleteGroup.svg", alt: "Remove Mentir") %>
               <span>Remove</span>
             <% end %>
           <% end %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -20,11 +20,21 @@
           <% end %>
         <% end %>
       </h1>
-      <h4 class="group-mentor-heading">
-        <strong>Mentor:</strong>
-        <%= @group.mentor.name %>
+      <h4 class="group-owner-heading">
+        <strong>Owner:</strong>
+        <%= @group.owner.name %>
       </h4>
     </div>
+  </div>
+  <div class="row center-row groups-row">
+    <h3>MENTORS</h3>
+    <% if policy(@group).admin_access? %>
+      <button type="button" class="btn primary-button groups-primary-button" data-toggle="modal" data-target="#addmentorModal">+ Add Mentors</button>
+    <% end %>
+  </div>
+  <hr>
+  <div class="row center-row groups-members-scroll-row">
+    <%= render partial: "group_mentors", locals: {group: @group} %>
   </div>
   <div class="row center-row groups-row">
     <h3>MEMBERS</h3>
@@ -306,7 +316,9 @@
     </div>
   </div>
   <%= render partial: "delete_member_confirmation_modal" %>
+  <%= render partial: "delete_mentor_confirmation_modal" %>
   <%= render partial: "delete_assignment_confirmation_modal" %>
+  <%= render partial: "add_mentor_modal", locals: {group_mentor: @group_mentor} %>
   <%= render partial: "add_member_modal", locals: {group_member: @group_member} %>
 </div>
 
@@ -329,6 +341,11 @@
         let groupmember = $(e.relatedTarget).data('currentgroupmember');
         $(e.currentTarget).find('#groups-member-delete-button').attr("href",
         "/group_members/" + groupmember.toString());
+    });
+    $("#deletementorModal").on("show.bs.modal", function(e) {
+        let groupmember = $(e.relatedTarget).data('currentgroupmember');
+        $(e.currentTarget).find('#groups-member-delete-button').attr("href",
+        "/group_mentors/" + groupmember.toString());
     });
   });
 </script>

--- a/app/views/pending_invitation_mailer/new_pending_email.html.erb
+++ b/app/views/pending_invitation_mailer/new_pending_email.html.erb
@@ -6,7 +6,7 @@
   <body>
     <h1>Welcome to CircuitVerse></h1>
     <p>
-      You have been added to a new group named <%= @group.name %> by <%= User.find_by(id:@group.mentor_id).name%>.<br><br>
+      You have been added to a new group named <%= @group.name %> by <%= User.find_by(id:@group.owner_id).name%>.<br><br>
       Sign up with CircuitVerse to explore the digital world. You can use the group once you have signed up with CircuitVerse.
     </p>
     <br>

--- a/app/views/users/logix/groups.html.erb
+++ b/app/views/users/logix/groups.html.erb
@@ -21,6 +21,35 @@
     </div>
   </div>
   <br>
+  <% if @groups_owned.present? %>
+    <h4 class="submain-heading">GROUPS YOU OWN:</h4>
+    <div class="row center-row">
+      <% @groups_owned.each do |group| %>
+        <div class="col-xs-12 col-sm-12 col-md-6 col-lg-4">
+          <div class="groups-card groups-mentor-card">
+            <div class="groups-mentor-card-name"><%= group.name %></div>
+            <div>
+              <p>Total Members: <%= group.group_member_count %></p>
+            </div>
+            <div class="groups-mentor-card-mini-buttons">
+              <%= link_to group, class: "mini-button groups-mentor-card-view-mini-button" do %>
+                <%= image_tag("SVGs/viewGroup.svg", alt: "View Group") %>
+                <span>View</span>
+              <% end %>
+              <%= link_to edit_group_path(group), class: "mini-button groups-mentor-card-edit-mini-button" do %>
+                <%= image_tag("SVGs/editGroup.svg", alt: "Edit Group") %>
+                <span>Edit</span>
+              <% end %>
+              <%= link_to '#', class: "mini-button groups-mentor-card-delete-mini-button", data: {toggle: "modal", target: "#deletegroupModal", currentgroup: group.id} do %>
+                <%= image_tag("SVGs/deleteGroup.svg", alt: "Delete Group") %>
+                <span>Delete</span>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
   <% if @groups_mentored.present? %>
     <h4 class="submain-heading">GROUPS YOU MENTOR:</h4>
     <div class="row center-row">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
 
   # resources :assignment_submissions
   resources :group_members, only: %i[create destroy]
+  resources :group_mentors, only: %i[create destroy]
   resources :groups, except: %i[index] do
     resources :assignments
   end
@@ -148,11 +149,14 @@ Rails.application.routes.draw do
       end
       post "/assignments/:assignment_id/projects/:project_id/grades", to: "grades#create"
       resources :grades, only: %i[update destroy]
+      get "/groups/owned", to: "groups#groups_owned"
       get "/groups/mentored", to: "groups#groups_mentored"
       resources :groups, only: %i[index show update destroy]
       delete "/group/members/:id", to: "group_members#destroy"
+      delete "/group/mentors/:id", to: "group_mentors#destroy"
       resources :groups do
         resources :members, controller: "group_members", shallow: true, only: %i[index create]
+        resources :mentors, controller: "group_mentors", shallow: true, only: %i[index create]
         resources :assignments, shallow: true
       end
       resources :assignments do

--- a/db/migrate/20200920120825_multiple_mentors_per_group.rb
+++ b/db/migrate/20200920120825_multiple_mentors_per_group.rb
@@ -1,0 +1,12 @@
+class MultipleMentorsPerGroup < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :groups, :mentor_id, :owner_id
+
+    create_table :group_mentors do |t|
+      t.references :group, foreign_key: true
+      t.references :user, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_10_140442) do
+ActiveRecord::Schema.define(version: 2020_09_20_120825) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -207,13 +207,22 @@ ActiveRecord::Schema.define(version: 2020_07_10_140442) do
     t.index ["user_id"], name: "index_group_members_on_user_id"
   end
 
+  create_table "group_mentors", force: :cascade do |t|
+    t.bigint "group_id"
+    t.bigint "user_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["group_id"], name: "index_group_mentors_on_group_id"
+    t.index ["user_id"], name: "index_group_mentors_on_user_id"
+  end
+
   create_table "groups", force: :cascade do |t|
     t.string "name"
-    t.bigint "mentor_id"
+    t.bigint "owner_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "group_members_count"
-    t.index ["mentor_id"], name: "index_groups_on_mentor_id"
+    t.index ["owner_id"], name: "index_groups_on_owner_id"
   end
 
   create_table "notifications", force: :cascade do |t|
@@ -379,7 +388,9 @@ ActiveRecord::Schema.define(version: 2020_07_10_140442) do
   add_foreign_key "grades", "users"
   add_foreign_key "group_members", "groups"
   add_foreign_key "group_members", "users"
-  add_foreign_key "groups", "users", column: "mentor_id"
+  add_foreign_key "group_mentors", "groups"
+  add_foreign_key "group_mentors", "users"
+  add_foreign_key "groups", "users", column: "owner_id"
   add_foreign_key "pending_invitations", "groups"
   add_foreign_key "projects", "assignments"
   add_foreign_key "projects", "projects", column: "forked_project_id"

--- a/spec/controllers/group_mentors_controller_spec.rb
+++ b/spec/controllers/group_mentors_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe GroupMembersController, type: :request do
+describe GroupMentorsController, type: :request do
   before do
     @owner = FactoryBot.create(:user)
     @group = FactoryBot.create(:group, owner: @owner)
@@ -26,9 +26,9 @@ describe GroupMembersController, type: :request do
     end
 
     context "owner is logged in" do
-      it "creates members that are not present and pending invitations for others" do
+      it "creates mentors that are not present and pending invitations for others" do
         expect {
-          post group_members_path, params: create_params
+          post group_mentors_path, params: create_params
         }.to change { GroupMember.count }.by(1)
          .and change { PendingInvitation.count }.by(1)
       end
@@ -37,7 +37,7 @@ describe GroupMembersController, type: :request do
     context "user other than owner is logged in" do
       it "throws unauthorized error" do
         sign_in_random_user
-        post group_members_path, params: create_params
+        post group_mentors_path, params: create_params
         check_not_authorized(response)
       end
     end

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -11,7 +11,7 @@ describe GroupsController, type: :request do
     it "creates a group" do
       sign_in @mentor
       expect {
-        post groups_path, params: { group: { name: "test group", mentor_id: @mentor.id } }
+        post groups_path, params: { group: { name: "test group", owner_id: @mentor.id } }
       }.to change { Group.count }.by(1)
     end
   end

--- a/spec/models/group_mentor_spec.rb
+++ b/spec/models/group_mentor_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe GroupMember, type: :model do
+RSpec.describe GroupMentor, type: :model do
   before do
     @user = FactoryBot.create(:user)
     @group = FactoryBot.create(:group, owner: @user)
@@ -15,16 +15,16 @@ RSpec.describe GroupMember, type: :model do
 
   describe "callbacks" do
     it "should call respective callbacks" do
-      expect_any_instance_of(GroupMember).to receive(:send_welcome_email)
-      FactoryBot.create(:group_member, user: @user, group: @group)
+      expect_any_instance_of(GroupMentor).to receive(:send_welcome_email)
+      FactoryBot.create(:group_mentor, user: @user, group: @group)
     end
   end
 
   describe "public methods" do
     it "sends welcome email" do
-      group_member = FactoryBot.create(:group_member, user: @user, group: @group)
+      group_mentor = FactoryBot.create(:group_mentor, user: @user, group: @group)
       expect {
-        group_member.send_welcome_email
+        group_mentor.send_welcome_email
       }.to have_enqueued_job.on_queue("mailers")
     end
   end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -4,13 +4,14 @@ require "rails_helper"
 
 RSpec.describe Group, type: :model do
   before do
-    @mentor = FactoryBot.create(:user)
+    @owner = FactoryBot.create(:user)
   end
 
   describe "associations" do
-    it { should belong_to(:mentor) }
+    it { should belong_to(:owner) }
     it { should have_many(:users) }
     it { should have_many(:group_members) }
+    it { should have_many(:group_mentor) }
     it { should have_many(:assignments) }
     it { should have_many(:pending_invitations) }
   end
@@ -24,7 +25,7 @@ RSpec.describe Group, type: :model do
 
   describe "public methods" do
     it "should send group creation mail" do
-      group = FactoryBot.create(:group, mentor: @mentor)
+      group = FactoryBot.create(:group, mentor: @owner)
       expect {
         group.send_creation_mail
       }.to have_enqueued_job.on_queue("mailers")

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe User, type: :model do
     it { should have_many(:projects) }
     it { should have_many(:stars) }
     it { should have_many(:rated_projects) }
+    it { should have_many(:groups_owned) }
     it { should have_many(:groups_mentored) }
     it { should have_many(:group_members) }
     it { should have_many(:groups) }

--- a/spec/policies/group_member_policy_spec.rb
+++ b/spec/policies/group_member_policy_spec.rb
@@ -7,19 +7,19 @@ describe GroupMemberPolicy do
   let(:group_member) { @group_member }
 
   before do
-    @mentor = FactoryBot.create(:user)
-    group = FactoryBot.create(:group, mentor: @mentor)
+    @owner = FactoryBot.create(:user)
+    group = FactoryBot.create(:group, owner: @owner)
     @user = FactoryBot.create(:user)
     @group_member = FactoryBot.create(:group_member, group: group, user: @user)
   end
 
-  context "user is mentor" do
-    let(:user) { @mentor }
-    it { should permit(:mentor) }
+  context "user is owner" do
+    let(:user) { @owner }
+    it { should permit(:owner) }
   end
 
   context "user is group member" do
     let(:user) { @user }
-    it { should_not permit(:mentor) }
+    it { should_not permit(:owner) }
   end
 end

--- a/spec/requests/api/v1/group_members_controller/create_spec.rb
+++ b/spec/requests/api/v1/group_members_controller/create_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Api::V1::GroupMembersController, "#create", type: :request do
   describe "create/add group members" do
     let!(:existing_user) { FactoryBot.create(:user, email: "test@test.com") }
-    let!(:mentor) { FactoryBot.create(:user) }
-    let!(:group) { FactoryBot.create(:group, mentor: mentor) }
+    let!(:owner) { FactoryBot.create(:user) }
+    let!(:group) { FactoryBot.create(:group, owner: owner) }
 
     context "when not authenticated" do
       before do
@@ -35,7 +35,7 @@ RSpec.describe Api::V1::GroupMembersController, "#create", type: :request do
 
     context "when authorized but tries to add members to non existent group" do
       before do
-        token = get_auth_token(mentor)
+        token = get_auth_token(owner)
         post "/api/v1/groups/0/members",
              headers: { "Authorization": "Token #{token}" },
              params: create_params, as: :json
@@ -49,7 +49,7 @@ RSpec.describe Api::V1::GroupMembersController, "#create", type: :request do
 
     context "when authorized and has access to add group members" do
       before do
-        token = get_auth_token(mentor)
+        token = get_auth_token(owner)
         post "/api/v1/groups/#{group.id}/members",
              headers: { "Authorization": "Token #{token}" },
              params: create_params, as: :json

--- a/spec/requests/api/v1/groups_controller/groups_owned_spec.rb
+++ b/spec/requests/api/v1/groups_controller/groups_owned_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::GroupsController, "#groups_owned", type: :request do
+  describe "list all groups owned" do
+    let!(:mentor) { FactoryBot.create(:user) }
+
+    context "when not authenticated" do
+      before do
+        get "/api/v1/groups/owned", as: :json
+      end
+
+      it "returns status unauthorized" do
+        expect(response).to have_http_status(401)
+        expect(response.parsed_body).to have_jsonapi_errors
+      end
+    end
+
+    context "when authenticated as mentor and including assignments" do
+      before do
+        # create 3 groups with assignments and group_members for each
+        FactoryBot.create_list(:group, 3, mentor: mentor).each do |g|
+          FactoryBot.create(:assignment, group: g)
+        end
+        token = get_auth_token(mentor)
+        get "/api/v1/groups/owned?include=assignments",
+            headers: { "Authorization": "Token #{token}" }, as: :json
+      end
+
+      it "returns all groups including assignments signed in user mentors" do
+        expect(response).to have_http_status(200)
+        expect(response).to match_response_schema("groups_with_assignments")
+        expect(response.parsed_body["data"].length).to eq(3)
+      end
+    end
+
+    context "when authenticated as mentor and including group_members" do
+      before do
+        # create 3 groups with 4 group_members for each
+        FactoryBot.create_list(:group, 3, mentor: mentor).each do |g|
+          # creates three random group members
+          # rubocop:disable FactoryBot/CreateList
+          3.times do
+            FactoryBot.create(:group_member, group: g, user: FactoryBot.create(:user))
+          end
+          # rubocop:enable FactoryBot/CreateList
+        end
+        token = get_auth_token(mentor)
+        get "/api/v1/groups/owned?include=group_members",
+            headers: { "Authorization": "Token #{token}" }, as: :json
+      end
+
+      it "returns all groups including group_members signed in user mentors" do
+        expect(response).to have_http_status(200)
+        expect(response).to match_response_schema("groups_with_members")
+        expect(response.parsed_body["data"].length).to eq(3)
+      end
+    end
+  end
+end

--- a/spec/support/api/schemas/group.json
+++ b/spec/support/api/schemas/group.json
@@ -12,7 +12,7 @@
             "member_count": { "type": "integer" },
             "mentor_name": { "type": "string" },
             "name": { "type": "string" },
-            "mentor_id": { "type": "integer" },
+            "owner_id": { "type": "integer" },
             "created_at": { "type": "string" },
             "updated_at": { "type": "string" }
           },
@@ -20,7 +20,7 @@
             "member_count",
             "mentor_name",
             "name",
-            "mentor_id",
+            "owner_id",
             "created_at",
             "updated_at"
           ]

--- a/spec/support/api/schemas/groups.json
+++ b/spec/support/api/schemas/groups.json
@@ -14,7 +14,7 @@
               "member_count": { "type": "integer" },
               "mentor_name": { "type": "string" },
               "name": { "type": "string" },
-              "mentor_id": { "type": "integer" },
+              "owner_id": { "type": "integer" },
               "created_at": { "type": "string" },
               "updated_at": { "type": "string" }
             },
@@ -22,7 +22,7 @@
               "member_count",
               "mentor_name",
               "name",
-              "mentor_id",
+              "owner_id",
               "created_at",
               "updated_at"
             ]

--- a/spec/support/api/schemas/groups_with_assignments.json
+++ b/spec/support/api/schemas/groups_with_assignments.json
@@ -14,7 +14,7 @@
               "member_count": { "type": "integer" },
               "mentor_name": { "type": "string" },
               "name": { "type": "string" },
-              "mentor_id": { "type": "integer" },
+              "owner_id": { "type": "integer" },
               "created_at": { "type": "string" },
               "updated_at": { "type": "string" }
             },
@@ -22,7 +22,7 @@
               "member_count",
               "mentor_name",
               "name",
-              "mentor_id",
+              "owner_id",
               "created_at",
               "updated_at"
             ]

--- a/spec/support/api/schemas/groups_with_members.json
+++ b/spec/support/api/schemas/groups_with_members.json
@@ -14,7 +14,7 @@
               "member_count": { "type": "integer" },
               "mentor_name": { "type": "string" },
               "name": { "type": "string" },
-              "mentor_id": { "type": "integer" },
+              "owner_id": { "type": "integer" },
               "created_at": { "type": "string" },
               "updated_at": { "type": "string" }
             },
@@ -22,7 +22,7 @@
               "member_count",
               "mentor_name",
               "name",
-              "mentor_id",
+              "owner_id",
               "created_at",
               "updated_at"
             ]


### PR DESCRIPTION
#### Describe the changes you have made in this PR -

The owner (formerly mentor) creates a group and can add and remove mentors now. The mentors have the same rights on members and assignements, but cannot add and remove mentors themselves.

### Screenshots of the changes (If any) -

![image](https://user-images.githubusercontent.com/299017/93784265-18eaf280-fc2d-11ea-8daa-cedee66a3a24.png)
