### PR TITLE
[FIXED] After search results of user the category of search should still remain 'Users' and not projects

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -20,7 +20,6 @@
       <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4 footer-column">
         <div class="row text-left">
           <div class="col-5 footer-links">
-            ​​<h5><span style="background-color:#42b983; padding:0px; padding-left: 2px; padding-right:2px;">Circuits</span></h5>
             <a href="/simulator"><h6>Simulator</h6></a>
             <a href="/learn" target="_blank"><h6>Learn</h6></a>
             <a href="/examples"><h6>Examples</h6></a>
@@ -31,7 +30,6 @@
             <% end %>
           </div>
           <div class="col-6 footer-links">
-            <h5><span style="background-color:#42b983; padding:0px; padding-left: 2px; padding-right:2px;">Info</span></h5>
             <a href="/docs" target="_blank"><h6>Documentation</h6></a>
             <a href="/contribute"><h6>Contribute</h6></a>
             <a href="/teachers"><h6>Teachers</h6></a>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -20,7 +20,7 @@
       <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4 footer-column">
         <div class="row text-left">
           <div class="col-5 footer-links">
-            <h6>Circuits</h6>
+            ​​<h5><span style="background-color:#42b983; padding:0px; padding-left: 2px; padding-right:2px;">Circuits</span></h5>
             <a href="/simulator"><h6>Simulator</h6></a>
             <a href="/learn" target="_blank"><h6>Learn</h6></a>
             <a href="/examples"><h6>Examples</h6></a>
@@ -31,7 +31,7 @@
             <% end %>
           </div>
           <div class="col-6 footer-links">
-            <h6>Info</h6>
+            <h5><span style="background-color:#42b983; padding:0px; padding-left: 2px; padding-right:2px;">Info</span></h5>
             <a href="/docs" target="_blank"><h6>Documentation</h6></a>
             <a href="/contribute"><h6>Contribute</h6></a>
             <a href="/teachers"><h6>Teachers</h6></a>


### PR DESCRIPTION
Fixes #1667 

#### Describe the changes you have made in this PR -
Added a script which retains the search filter applied to the search from **_select tag_**.

### Screenshots of the changes (If any) -
before:
if  **Users** filter is selected from **options** (_select tag_) and a name is searched, the **option** (_select tag_)  in the results page reverts to default value rather than staying **Users**.
![bug](https://user-images.githubusercontent.com/64456160/94045201-c22c1700-fdec-11ea-9359-12088d371627.png)

after:
after fixing it looks like so:
![fix](https://user-images.githubusercontent.com/64456160/94045244-d3752380-fdec-11ea-918b-237eed927ac3.png)

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 