### PR TITLE
[FIXED] After search results of user the category of search should still remain 'Users' and not projects #1697

### DIFF
--- a/app/views/logix_assets/_search_bar.html.erb
+++ b/app/views/logix_assets/_search_bar.html.erb
@@ -1,7 +1,7 @@
 <div class="container navbar-search-container">
   <div class="row center-row">
   <%= form_tag("/search", method: "get", id: 'search-box', class: 'navbar-search-bar-form') do %>
-    <%= select_tag "resource", options_for_select([ "Users", "Projects" ], "resource" == "Users" ? "Users" : "Projects"), class: "navbar-search-bar-select", id: "search_type" %>
+    <%= select_tag :resource , options_for_select([ "Users", "Projects" ],selected: params[:resource]), class: "navbar-search-bar-select", id: "search_type" %>
     <%= text_field_tag :q,params[:q], placeholder: "Search for projects or users", autocomplete:"off", class: "form-control form-input navbar-search-bar-input" %>
     <button class="btn primary-button navbar-search-bar-button" type="submit" name="button" value="Submit">Search</button>
   <% end %>


### PR DESCRIPTION

Fixes #1667

#### Describe the changes you have made in this PR -
Made changes to the _**select_tag**_ inside _**form**_  to fix this issue.

### Screenshots of the changes (If any) -
before:
if  **Users** filter is selected from **options** (_select tag_) and a name is searched, the **option** (_select tag_)  in the results page reverts to default value rather than staying **Users**.
![bug](https://user-images.githubusercontent.com/64456160/94045201-c22c1700-fdec-11ea-9359-12088d371627.png)

after:
after fixing it looks like so:
![fix](https://user-images.githubusercontent.com/64456160/94045244-d3752380-fdec-11ea-918b-237eed927ac3.png)


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
