### PR TITLE
XSS on Combinational Analysis Fix ( Issue #1720 )

### DIFF
--- a/public/js/combinationalAnalysis.js
+++ b/public/js/combinationalAnalysis.js
@@ -41,6 +41,15 @@ createCombinationalAnalysisPrompt=function(scope=globalScope){
 function createBooleanPrompt(inputListNames,outputListNames,scope=globalScope){
     inputListNames=inputListNames||(prompt("Enter inputs separated by commas").split(','));
     outputListNames=outputListNames||(prompt("Enter outputs separated by commas").split(','));
+    
+    //Strip tags from inputListNames
+    for(int i=0; i<inputListNames.length; i++)
+        inputListNames[i] = stripTags(inputListNames[i]);
+
+    //Strip tags from outputListNames
+    for(int i=0; i<outputListNames.length; i++)
+        outputListNames[i] = stripTags(outputListNames[i]);
+
     outputListNamesInteger=[];
     for (var i = 0; i < outputListNames.length; i++)
         outputListNamesInteger[i] = 7*i + 13;//assigning an integer to the value, 7*i + 13 is random


### PR DESCRIPTION
XSS fix on Combinational Analysis by stripping tags from `inputListNames`and `outputListNames` before reflecting it to DOM.