### PR TITLE
changed export result link from anchor text to btn

### DIFF
--- a/app/views/assignments/show.html.erb
+++ b/app/views/assignments/show.html.erb
@@ -32,7 +32,7 @@
           <% end %>
           <% if policy(@assignment).can_be_graded? %>
             &nbsp;
-            <%= link_to 'Export Results', grades_to_csv_path(@assignment, format: "csv"), class: "anchor-text" %>
+            <%= link_to 'Export Grades', grades_to_csv_path(@assignment, format: "csv"), class: "btn primary-button" %>
           <% end %>
           &nbsp;
           <%= link_to 'Back', group_path(@group), class: "anchor-text" %>


### PR DESCRIPTION
Fixes #1768 

#### Describe the changes you have made in this PR -
Changed export link in the assignment page into button and renamed "Export Results" to "Export Grades"
### Screenshots of the changes (If any) -
Before:
![before](https://user-images.githubusercontent.com/53009722/94990467-f8f6ef80-0599-11eb-85a4-aa972acaceff.png)

After:
![after2](https://user-images.githubusercontent.com/53009722/94990474-01e7c100-059a-11eb-8195-cb91e98d41a2.png)



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
