### PR TITLE
Docker: Start webpack dev server with web container

### DIFF
--- a/bin/docker_run
+++ b/bin/docker_run
@@ -18,5 +18,6 @@ bundle exec rails db:seed
 
 rm -f /circuitverse/tmp/pids/server.pid
 
+/circuitverse/bin/webpack-dev-server &
 echo "Starting on 127.0.0.1:3000"
 bundle exec rails s -p 3000 -b '0.0.0.0'


### PR DESCRIPTION
#### Describe the changes you have made in this PR -
Starts webpack-dev-server when the web container boots instead of having to start it manually from within the container
