### PR TITLE
fix home page ui on clicking search icon 

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -90,4 +90,6 @@
   if (window.location.href.includes('search')) {
       searchBar.style.display = "block";
   }
+  let searchElement = document.getElementsByClassName("navbar-search-icon-container");
+  window["search"] = searchElement[1];  
 </script>

--- a/app/views/logix/index.html.erb
+++ b/app/views/logix/index.html.erb
@@ -244,6 +244,19 @@
     }
   }
 </script>
+<script>
+let centerRow = $(".center-row")[3];
+let search = window["search"];
+$(search).on('click', function () {
+  if ($(centerRow).attr('data-click-state') == 1) {
+    $(centerRow).attr('data-click-state', 0);
+    $(centerRow).css('padding-top', '0px');
+  } else {
+    $(centerRow).attr('data-click-state', 1);
+    $(centerRow).css('padding-top', '73px');
+  }
+});
+</script>
 
     <!-- Bootstrap core JavaScript
     ================================================== -->


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -
Now, on clicking the search icon home-main-content & home-image-cover doesn't hide under search form container.
### Screenshots of the changes (If any) -
Before :
![Screenshot from 2020-10-04 22-21-34](https://user-images.githubusercontent.com/46301590/95021825-135fc480-0691-11eb-8d16-8dcda7520d84.png)
Now :
![Screenshot from 2020-10-04 22-30-54](https://user-images.githubusercontent.com/46301590/95021910-7b160f80-0691-11eb-8c3c-e20f713604fa.png)

@satu0king @tachyons please review.

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
