### PR TITLE
Stories/circuit2verilog: Attempt to merge changes with PR#1814

### DIFF
--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -41,7 +41,7 @@
           <li><a type="button" class="dropdown-item" id="bitconverter" >Hex-Bin-Dec-Converter</a></li>
           <li><a class="dropdown-item logixButton" id="startPlot">Start Plot</a></li>
           <li><a class="dropdown-item logixButton" id="createSaveAsImgPrompt">Download Image</a>
-          <li><a class="dropdown-item logixButton" id="convertVerilog">Convert Verilog</a>
+          <li><a class="dropdown-item logixButton" id="generateVerilog">Convert Verilog</a>
         </ul>
       </li>
       <li class="">

--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -41,6 +41,7 @@
           <li><a type="button" class="dropdown-item" id="bitconverter" >Hex-Bin-Dec-Converter</a></li>
           <li><a class="dropdown-item logixButton" id="startPlot">Start Plot</a></li>
           <li><a class="dropdown-item logixButton" id="createSaveAsImgPrompt">Download Image</a>
+          <li><a class="dropdown-item logixButton" id="convertVerilog">Convert Verilog</a>
         </ul>
       </li>
       <li class="">

--- a/public/js/Counter.js
+++ b/public/js/Counter.js
@@ -100,3 +100,27 @@ Counter.prototype.customDraw = function () {
     lineTo(ctx, -20, 15, xx, yy, this.direction);
     ctx.stroke();
 }
+
+Counter.moduleVerilog = function () {
+    return `module Counter(val, zero, max, clk, rst);
+    parameter WIDTH = 1;
+    output reg [WIDTH-1:0] val;
+    output reg zero;
+    input [WIDTH-1:0] max;
+    input clk, rst;
+  
+    always @ (posedge clk or posedge rst)
+      if (rst)
+        val <= 'b0;
+      else begin
+        if (val < max) begin
+          val <= val + 1;
+          zero <= 0;
+        end 
+        else begin
+          val <= 0;
+          zero <= 1;
+        end
+      end
+  endmodule`;
+}

--- a/public/js/Node.js
+++ b/public/js/Node.js
@@ -659,12 +659,9 @@ Node.prototype.nodeConnect = function() {
 }
 Node.prototype.cleanDelete = Node.prototype.delete;
 Node.prototype.processVerilog = function() {
-
     if (this.type == NODE_INPUT) {
-        if (this.parent.isVerilogResolvable())
-            this.scope.stack.push(this.parent);
+        this.scope.stack.push(this.parent);
     }
-
     for (var i = 0; i < this.connections.length; i++) {
         if (this.connections[i].verilogLabel != this.verilogLabel) {
             this.connections[i].verilogLabel = this.verilogLabel;

--- a/public/js/logix.js
+++ b/public/js/logix.js
@@ -1457,6 +1457,19 @@ CircuitElement.prototype.verilogName = function() {
     return this.verilogType || this.objectType;
 }
 
+CircuitElement.prototype.verilogBaseType = function() {
+    return this.verilogName();
+}
+
+CircuitElement.prototype.verilogParametrizedType = function() {
+    var type = this.verilogBaseType();
+    // Suffix bitwidth for multi-bit inputs
+    // Example: DflipFlop #(2) DflipFlop_0
+    if (this.bitWidth != undefined && this.bitWidth > 1)
+        type += " #(" + this.bitWidth + ")";
+    return type
+}
+
 // Generates final verilog code for each element
 CircuitElement.prototype.generateVerilog = function() {
     // Example: and and_1(_out, _out, _Q[0]);
@@ -1472,12 +1485,7 @@ CircuitElement.prototype.generateVerilog = function() {
     }
 
     var list = outputs.concat(inputs);
-    var res = this.verilogName();
-
-    // Suffix bitwidth for multi-bit inputs
-    // Example: DflipFlop #(2) DflipFlop_0
-    if (this.bitWidth != undefined && this.bitWidth > 1)
-      res += " #(" + this.bitWidth + ")";
+    var res = this.verilogParametrizedType();
 
     res += " " + this.verilogLabel + "(" + list.map(function(x) {
         return x.verilogLabel

--- a/public/js/modules.js
+++ b/public/js/modules.js
@@ -1724,14 +1724,12 @@ Splitter.prototype.reset = function () {
     this.prevInpValue = undefined;
 }
 Splitter.prototype.processVerilog = function () {
-    // console.log(this);
+    // Splitter
     for (var j = 0; j < this.outputs.length; j++) {
-        // console.log(this.inp1.verilogLabel +":"+ this.outputs[j].verilogLabel);
         if (this.inp1.verilogLabel != "" && this.outputs[j].verilogLabel == "") {
             this.selfRef = true;
             var bitCount = 0;
             for (var i = 0; i < this.splitCount; i++) {
-                // var bitSplitValue = extractBits(this.inp1.value, bitCount, bitCount + this.bitWidthSplit[i] - 1);
                 if (this.bitWidthSplit[i] > 1)
                     var label = this.inp1.verilogLabel + '[' + (bitCount + this.bitWidthSplit[i] - 1) + ":" + bitCount + "]";
                 else
@@ -1744,19 +1742,16 @@ Splitter.prototype.processVerilog = function () {
             }
         }
     }
+    // Joiner
     if (this.inp1.verilogLabel == "") {
         this.inp1.verilogLabel = this.verilogLabel + "_inp";
-        if (this.scope.verilogWireList[this.bitWidth] != undefined) {
-            if (!this.scope.verilogWireList[this.bitWidth].contains(this.inp1.verilogLabel))
-                this.scope.verilogWireList[this.bitWidth].push(this.inp1.verilogLabel);
-        } else
-            this.scope.verilogWireList[this.bitWidth] = [this.inp1.verilogLabel];
+        if (!this.scope.verilogWireList[this.bitWidth].contains(this.inp1.verilogLabel))
+            this.scope.verilogWireList[this.bitWidth].push(this.inp1.verilogLabel);
         this.scope.stack.push(this.inp1);
     }
 }
 //added to generate Splitter INPUTS
 Splitter.prototype.generateVerilog = function () {
-	// console.log(scope.Splitter[i]);
     var res = "";
 
     if (!this.selfRef) {

--- a/public/js/modules.js
+++ b/public/js/modules.js
@@ -53,9 +53,9 @@ function AndGate(x, y, scope = globalScope, dir = "RIGHT", inputLength = 2, bitW
 AndGate.prototype = Object.create(CircuitElement.prototype);
 AndGate.prototype.constructor = AndGate;
 AndGate.prototype.tooltipText = "And Gate Tooltip : Implements logical conjunction";
+AndGate.prototype.changeInputSize = changeInputSize;
 AndGate.prototype.alwaysResolve = true;
 AndGate.prototype.verilogType = "and";
-AndGate.prototype.changeInputSize = changeInputSize;
 AndGate.prototype.helplink = "https://docs.circuitverse.org/#/gates?id=and-gate";
 //fn to create save Json Data of object
 AndGate.prototype.customSave = function () {
@@ -942,6 +942,7 @@ function NotGate(x, y, scope = globalScope, dir = "RIGHT", bitWidth = 1) {
 NotGate.prototype = Object.create(CircuitElement.prototype);
 NotGate.prototype.constructor = NotGate;
 NotGate.prototype.tooltipText = "Not Gate Tooltip : Inverts the input digital signal.";
+NotGate.prototype.verilogType = "not";
 NotGate.prototype.helplink = "https://docs.circuitverse.org/#/gates?id=not-gate";
 NotGate.prototype.customSave = function () {
     var data = {
@@ -1723,35 +1724,50 @@ Splitter.prototype.reset = function () {
     this.prevInpValue = undefined;
 }
 Splitter.prototype.processVerilog = function () {
-
-    // console.log(this.inp1.verilogLabel +":"+ this.outputs[0].verilogLabel);
-    if (this.inp1.verilogLabel != "" && this.outputs[0].verilogLabel == "") {
-        var bitCount = 0;
-        for (var i = 0; i < this.splitCount; i++) {
-            // var bitSplitValue = extractBits(this.inp1.value, bitCount, bitCount + this.bitWidthSplit[i] - 1);
-            if (this.bitWidthSplit[i] > 1)
-                var label = this.inp1.verilogLabel + '[' + (bitCount + this.bitWidthSplit[i] - 1) + ":" + bitCount + "]";
-            else
-                var label = this.inp1.verilogLabel + '[' + bitCount + "]";
-            if (this.outputs[i].verilogLabel != label) {
-                this.outputs[i].verilogLabel = label;
-                this.scope.stack.push(this.outputs[i]);
+    // console.log(this);
+    for (var j = 0; j < this.outputs.length; j++) {
+        // console.log(this.inp1.verilogLabel +":"+ this.outputs[j].verilogLabel);
+        if (this.inp1.verilogLabel != "" && this.outputs[j].verilogLabel == "") {
+            this.selfRef = true;
+            var bitCount = 0;
+            for (var i = 0; i < this.splitCount; i++) {
+                // var bitSplitValue = extractBits(this.inp1.value, bitCount, bitCount + this.bitWidthSplit[i] - 1);
+                if (this.bitWidthSplit[i] > 1)
+                    var label = this.inp1.verilogLabel + '[' + (bitCount + this.bitWidthSplit[i] - 1) + ":" + bitCount + "]";
+                else
+                    var label = this.inp1.verilogLabel + '[' + bitCount + "]";
+                if (this.outputs[i].verilogLabel != label) {
+                    this.outputs[i].verilogLabel = label;
+                    this.scope.stack.push(this.outputs[i]);
+                }
+                bitCount += this.bitWidthSplit[i];
             }
-            bitCount += this.bitWidthSplit[i];
-        }
-    } else if (this.inp1.verilogLabel == "" && this.outputs[0].verilogLabel != "") {
-
-
-        var label = "{" + this.outputs.map((x) => {
-            return x.verilogLabel
-        }).join(",") + "}";
-        // console.log("HIT",label)
-        if (this.inp1.verilogLabel != label) {
-            this.inp1.verilogLabel = label;
-            this.scope.stack.push(this.inp1);
         }
     }
+    if (this.inp1.verilogLabel == "") {
+        this.inp1.verilogLabel = this.verilogLabel + "_inp";
+        if (this.scope.verilogWireList[this.bitWidth] != undefined) {
+            if (!this.scope.verilogWireList[this.bitWidth].contains(this.inp1.verilogLabel))
+                this.scope.verilogWireList[this.bitWidth].push(this.inp1.verilogLabel);
+        } else
+            this.scope.verilogWireList[this.bitWidth] = [this.inp1.verilogLabel];
+        this.scope.stack.push(this.inp1);
+    }
 }
+//added to generate Splitter INPUTS
+Splitter.prototype.generateVerilog = function () {
+	// console.log(scope.Splitter[i]);
+    var res = "";
+
+    if (!this.selfRef) {
+        res += "assign " + this.inp1.verilogLabel + " = {";
+        for (var i = this.outputs.length - 1; i > 0; i--)
+          res += this.outputs[i].verilogLabel + ",";
+        res += this.outputs[0].verilogLabel + "};";
+    }
+    return res;
+}
+
 Splitter.prototype.customDraw = function () {
 
     ctx = simulationArea.context;

--- a/public/js/sequential.js
+++ b/public/js/sequential.js
@@ -51,6 +51,29 @@ TflipFlop.prototype.isResolvable = function() {
     if (this.clockInp.value != undefined && this.dInp.value != undefined) return true;
     return false;
 }
+//add this to output the modue
+TflipFlop.moduleVerilog = function() {
+    var output = "";
+    output += "\n";
+    output += "module TflipFlop(q, q_inv, clk, t, a_rst, pre, en);\n";
+    output += "  parameter WIDTH = 1;\n";
+    output += "  output reg [WIDTH-1:0] q, q_inv;\n";
+    output += "  input clk, a_rst, pre, en;\n";
+    output += "  input [WIDTH-1:0] t;\n";
+    output += "  \n";
+    output += "  always @ (posedge clk or posedge a_rst)\n";
+    output += "    if (a_rst) begin\n";
+    output += "      q <= 'b0;\n";
+    output += "      q_inv <= 'b1;\n";
+    output += "    end else if (en == 0) ;\n";
+    output += "    else if (t) begin\n";
+    output += "      q <= q ^ t;\n";
+    output += "      q_inv <= ~q ^ t;\n";
+    output += "    end\n";
+    output += "endmodule\n";
+    output += "\n";
+    return output;
+}
 TflipFlop.prototype.newBitWidth = function(bitWidth) {
     this.bitWidth = bitWidth;
     this.dInp.bitWidth = bitWidth;
@@ -199,6 +222,29 @@ DflipFlop.prototype.resolve = function() {
         simulationArea.simulationQueue.add(this.qOutput);
         simulationArea.simulationQueue.add(this.qInvOutput);
     }
+}
+//add this to output the modue
+DflipFlop.moduleVerilog = function() {
+    var output = "";
+    output += "\n";
+    output += "module DflipFlop(q, q_inv, clk, d, a_rst, pre, en);\n";
+    output += "  parameter WIDTH = 1;\n";
+    output += "  output reg [WIDTH-1:0] q, q_inv;\n";
+    output += "  input clk, a_rst, pre, en;\n";
+    output += "  input [WIDTH-1:0] d;\n";
+    output += "  \n";
+    output += "  always @ (posedge clk or posedge a_rst)\n";
+    output += "    if (a_rst) begin\n";
+    output += "      q <= 'b0;\n";
+    output += "      q_inv <= 'b1;\n";
+    output += "    end else if (en == 0) ;\n";
+    output += "    else begin\n";
+    output += "      q <= d;\n";
+    output += "      q_inv <= ~d;\n";
+    output += "    end\n";
+    output += "endmodule\n";
+    output += "\n";
+    return output;
 }
 DflipFlop.prototype.customSave = function() {
     var data = {
@@ -989,3 +1035,19 @@ Clock.prototype.customDraw = function() {
     ctx.stroke();
 
 }
+// //add this to output the modue
+// Clock.moduleVerilog = function() {
+//     var output = "";
+//     output += "\n";
+//     output += "module Clock(clk);\n";
+//     output += "  output reg clk;\n";
+//     output += "  always begin\n";
+//     output += "    #10\n";
+//     output += "    clk=1'b0;\n";
+//     output += "    #10\n";
+//     output += "    clk=1'b0;\n";
+//     output += "  end\n";
+//     output += "endmodule\n";
+//     output += "\n";
+//     return output;
+// }

--- a/public/js/sequential.js
+++ b/public/js/sequential.js
@@ -51,29 +51,27 @@ TflipFlop.prototype.isResolvable = function() {
     if (this.clockInp.value != undefined && this.dInp.value != undefined) return true;
     return false;
 }
-//add this to output the modue
-TflipFlop.moduleVerilog = function() {
-    var output = "";
-    output += "\n";
-    output += "module TflipFlop(q, q_inv, clk, t, a_rst, pre, en);\n";
-    output += "  parameter WIDTH = 1;\n";
-    output += "  output reg [WIDTH-1:0] q, q_inv;\n";
-    output += "  input clk, a_rst, pre, en;\n";
-    output += "  input [WIDTH-1:0] t;\n";
-    output += "  \n";
-    output += "  always @ (posedge clk or posedge a_rst)\n";
-    output += "    if (a_rst) begin\n";
-    output += "      q <= 'b0;\n";
-    output += "      q_inv <= 'b1;\n";
-    output += "    end else if (en == 0) ;\n";
-    output += "    else if (t) begin\n";
-    output += "      q <= q ^ t;\n";
-    output += "      q_inv <= ~q ^ t;\n";
-    output += "    end\n";
-    output += "endmodule\n";
-    output += "\n";
-    return output;
-}
+
+//add this to output the module
+TflipFlop.moduleVerilog = `
+module TflipFlop(q, q_inv, clk, t, a_rst, pre, en);
+  parameter WIDTH = 1;
+  output reg [WIDTH-1:0] q, q_inv;
+  input clk, a_rst, pre, en;
+  input [WIDTH-1:0] t;
+  
+  always @ (posedge clk or posedge a_rst)
+    if (a_rst) begin
+      q <= 'b0;
+      q_inv <= 'b1;
+    end else if (en == 0) ;
+    else if (t) begin
+      q <= q ^ t;
+      q_inv <= ~q ^ t;
+    end
+endmodule
+`
+
 TflipFlop.prototype.newBitWidth = function(bitWidth) {
     this.bitWidth = bitWidth;
     this.dInp.bitWidth = bitWidth;
@@ -223,29 +221,26 @@ DflipFlop.prototype.resolve = function() {
         simulationArea.simulationQueue.add(this.qInvOutput);
     }
 }
-//add this to output the modue
-DflipFlop.moduleVerilog = function() {
-    var output = "";
-    output += "\n";
-    output += "module DflipFlop(q, q_inv, clk, d, a_rst, pre, en);\n";
-    output += "  parameter WIDTH = 1;\n";
-    output += "  output reg [WIDTH-1:0] q, q_inv;\n";
-    output += "  input clk, a_rst, pre, en;\n";
-    output += "  input [WIDTH-1:0] d;\n";
-    output += "  \n";
-    output += "  always @ (posedge clk or posedge a_rst)\n";
-    output += "    if (a_rst) begin\n";
-    output += "      q <= 'b0;\n";
-    output += "      q_inv <= 'b1;\n";
-    output += "    end else if (en == 0) ;\n";
-    output += "    else begin\n";
-    output += "      q <= d;\n";
-    output += "      q_inv <= ~d;\n";
-    output += "    end\n";
-    output += "endmodule\n";
-    output += "\n";
-    return output;
-}
+
+//add this to output the module
+DflipFlop.moduleVerilog = `
+module DflipFlop(q, q_inv, clk, d, a_rst, pre, en);
+  parameter WIDTH = 1;
+  output reg [WIDTH-1:0] q, q_inv;
+  input clk, a_rst, pre, en;
+  input [WIDTH-1:0] d;
+  
+  always @ (posedge clk or posedge a_rst)
+    if (a_rst) begin
+      q <= 'b0;
+      q_inv <= 'b1;
+    end else if (en == 0) ;
+    else begin
+      q <= d;
+      q_inv <= ~d;
+    end
+endmodule
+`
 DflipFlop.prototype.customSave = function() {
     var data = {
         nodes: {
@@ -1035,19 +1030,14 @@ Clock.prototype.customDraw = function() {
     ctx.stroke();
 
 }
-// //add this to output the modue
-// Clock.moduleVerilog = function() {
-//     var output = "";
-//     output += "\n";
-//     output += "module Clock(clk);\n";
-//     output += "  output reg clk;\n";
-//     output += "  always begin\n";
-//     output += "    #10\n";
-//     output += "    clk=1'b0;\n";
-//     output += "    #10\n";
-//     output += "    clk=1'b0;\n";
-//     output += "  end\n";
-//     output += "endmodule\n";
-//     output += "\n";
-//     return output;
-// }
+Clock.moduleVerilog = `
+module Clock(clk);
+  output reg clk;
+  always begin
+    #10
+    clk=1'b0;
+    #10
+    clk=1'b0;
+  end
+endmodule
+`

--- a/public/js/sequential.js
+++ b/public/js/sequential.js
@@ -53,7 +53,8 @@ TflipFlop.prototype.isResolvable = function() {
 }
 
 //add this to output the module
-TflipFlop.moduleVerilog = `
+TflipFlop.moduleVerilog = function(){
+return `
 module TflipFlop(q, q_inv, clk, t, a_rst, pre, en);
   parameter WIDTH = 1;
   output reg [WIDTH-1:0] q, q_inv;
@@ -71,6 +72,7 @@ module TflipFlop(q, q_inv, clk, t, a_rst, pre, en);
     end
 endmodule
 `
+}
 
 TflipFlop.prototype.newBitWidth = function(bitWidth) {
     this.bitWidth = bitWidth;
@@ -223,7 +225,8 @@ DflipFlop.prototype.resolve = function() {
 }
 
 //add this to output the module
-DflipFlop.moduleVerilog = `
+DflipFlop.moduleVerilog = function(){
+    return `
 module DflipFlop(q, q_inv, clk, d, a_rst, pre, en);
   parameter WIDTH = 1;
   output reg [WIDTH-1:0] q, q_inv;
@@ -241,6 +244,7 @@ module DflipFlop(q, q_inv, clk, d, a_rst, pre, en);
     end
 endmodule
 `
+}
 DflipFlop.prototype.customSave = function() {
     var data = {
         nodes: {
@@ -1030,7 +1034,8 @@ Clock.prototype.customDraw = function() {
     ctx.stroke();
 
 }
-Clock.moduleVerilog = `
+Clock.moduleVerilog = function() {
+    return `
 module Clock(clk);
   output reg clk;
   always begin
@@ -1041,3 +1046,4 @@ module Clock(clk);
   end
 endmodule
 `
+}

--- a/public/js/sequential.js
+++ b/public/js/sequential.js
@@ -459,6 +459,19 @@ Random.prototype.customDraw = function() {
 
 }
 
+
+Random.moduleVerilog = function () {
+ return `module Random(val, clk, max);
+ parameter WIDTH = 1;
+ output reg [WIDTH-1:0] val;
+ input clk;
+ input [WIDTH-1:0] max;
+
+ always @ (posedge clk)
+   val = $urandom_range(0, max);
+endmodule`
+}
+
 function SRflipFlop(x, y, scope = globalScope, dir = "RIGHT") {
     CircuitElement.call(this, x, y, scope, dir, 1);
     this.directionFixed = true;

--- a/public/js/subcircuit.js
+++ b/public/js/subcircuit.js
@@ -115,7 +115,6 @@ SubCircuit.prototype.makeConnections = function() {
         this.localScope.Output[i].inp1.connectWireLess(this.outputNodes[i]);
         this.outputNodes[i].subcircuitOverride = true;
     }
-
 }
 
 SubCircuit.prototype.removeConnections = function() {
@@ -126,6 +125,7 @@ SubCircuit.prototype.removeConnections = function() {
     for (let i = 0; i < this.outputNodes.length; i++)
         this.localScope.Output[i].inp1.disconnectWireLess(this.outputNodes[i]);
 }
+
 
 SubCircuit.prototype.buildCircuit = function() {
 
@@ -347,6 +347,27 @@ SubCircuit.prototype.resolve = function() {
 
 SubCircuit.prototype.isResolvable = function() {
     return false
+}
+
+SubCircuit.prototype.generateVerilog = function() {
+    var inputs = [];
+    var outputs = [];
+
+    for (var i = 0; i < this.nodeList.length; i++) {
+        if (this.nodeList[i].type == NODE_INPUT) {
+            inputs.push(this.nodeList[i]);
+        } else {
+            outputs.push(this.nodeList[i]);
+        }
+    }
+
+    //changes space
+    var list = outputs.concat(inputs);
+    var res = this.verilogName() + " " + this.verilogLabel + "(" + list.map(function(x) {
+        	return x.verilogLabel
+    	}).join(", ") + ");";
+
+    return res;
 }
 
 SubCircuit.prototype.verilogName = function() {

--- a/public/js/subcircuit.js
+++ b/public/js/subcircuit.js
@@ -118,6 +118,7 @@ SubCircuit.prototype.makeConnections = function() {
 }
 
 SubCircuit.prototype.removeConnections = function() {
+    
     for (let i = 0; i < this.inputNodes.length; i++) {
         this.localScope.Input[i].output1.disconnectWireLess(this.inputNodes[i]);
     }
@@ -349,29 +350,8 @@ SubCircuit.prototype.isResolvable = function() {
     return false
 }
 
-SubCircuit.prototype.generateVerilog = function() {
-    var inputs = [];
-    var outputs = [];
-
-    for (var i = 0; i < this.nodeList.length; i++) {
-        if (this.nodeList[i].type == NODE_INPUT) {
-            inputs.push(this.nodeList[i]);
-        } else {
-            outputs.push(this.nodeList[i]);
-        }
-    }
-
-    //changes space
-    var list = outputs.concat(inputs);
-    var res = this.verilogName() + " " + this.verilogLabel + "(" + list.map(function(x) {
-        	return x.verilogLabel
-    	}).join(", ") + ");";
-
-    return res;
-}
-
 SubCircuit.prototype.verilogName = function() {
-    return verilog.fixName(scopeList[this.id].name);
+    return verilog.santizeLabel(scopeList[this.id].name);
 }
 
 SubCircuit.prototype.customDraw = function() {

--- a/public/js/verilog.js
+++ b/public/js/verilog.js
@@ -39,7 +39,7 @@ verilog = {
         for(var element of elementTypesUsed) {
             // If element has custom verilog
             if (window[element].moduleVerilog) {
-                output += window[element].moduleVerilog;
+                output += window[element].moduleVerilog();
             }
         }
         return output;

--- a/public/js/verilog.js
+++ b/public/js/verilog.js
@@ -17,6 +17,13 @@ verilog = {
     exportVerilog:function(scope = undefined){
         var dependencyList = {};
         
+        // Reset Verilog Element State
+        for (var i = 0; i < circuitElementList.length; i++) {            
+            if (window[circuitElementList[i]].resetVerilog) {
+                window[circuitElementList[i]].resetVerilog();
+            }
+        }
+
         // Generate SubCircuit Dependency Graph
         for (id in scopeList)
             dependencyList[id] = scopeList[id].getDependencies();
@@ -235,7 +242,7 @@ verilog = {
     },
     generateNodeName: function(node, currentCount, totalCount) {
         if(node.verilogLabel) return node.verilogLabel;
-        var parentVerilogLabel = node.verilogLabel;
+        var parentVerilogLabel = node.parent.verilogLabel;
         var nodeName;
         if(node.label) {
             nodeName = verilog.santizeLabel(node.label);

--- a/public/js/verilog_documentation.md
+++ b/public/js/verilog_documentation.md
@@ -1,0 +1,68 @@
+## Circuit2Verilog Module
+
+**Primary Contributors:**
+
+1. James H - J Yeh, Ph.D.
+2. Satvik Ramaprasad
+
+## Introduction
+
+This is an experimental module which generates verilog netlist (structural
+verilog) given the circuit. Currently, the module generates fully functional
+verilog code for basic circuits. For complex circuit, additional (manual) work
+may need to be done in order to make it work. We are continuously improving this
+module to work with more and more complex circuits.
+
+
+# Algorithm
+
+The basic algorithm is fairly straight forward. We have the circuit graph in
+memory. We just need to convert this graph into verilog netlist. It is done by
+performing a DFS on the circuit graph. The DFS involves the following steps
+1. Creating verilog wires as and when required
+2. Connecting verilog wires in element instantiations
+
+## Some background information
+The different sub circuits form a DAG (Directed Acyclic Graph) or dependency
+graph. Each sub circuit itself (called scope internally) is actually a (cyclic)
+graph on its own. Therefore the verilog generation is done in a 2 step DFS
+approach. The first DFS is performed on the dependency graph. The second DFS is
+done on individual sub circuit (scope).
+
+## Code/Algorithm workflow
+
+1. `exportVerilog()` - entry point
+2. `exportVerilogScope()` - DFS(1) on Sub Circuits Dependency Graph
+    1. Set Verilog Labels for all elements
+    2. `generateHeader()` - Generates Module Header
+    3. `generateOutputList()` - Output Output List
+    4. `generateInputList()` - Generates Input List
+    5. `processGraph()` -  DFS(2) on individual subcircuit/scope
+        1. DFS starts from inputs
+        2. Calls `processVerilog()` on all circuit elements (graph nodes) - resolves label names and adds neighbors to DFS stack.
+        3. Calls `generateVerilog()` on all circuit elements to get final verilog.
+    6. Generate Wire initializations
+
+
+## Functions
+**Verilog Module Functions:**
+1. `verilog.exportVerilog()` - Entry point
+1. `verilog.exportVerilogScope()` - Recursive DFS function on subcircuit graph
+1. `verilog.processGraph()` - Iterative DFS function on subcircuit scope
+1. `verilog.resetLabels()` - Resets labels in scope
+1. `verilog.setLabels()` - Sets labels in scope
+1. `verilog.generateHeader()` - Generates Verilog Module Header
+1. `verilog.generateInputList()` - Generates Verilog Module Input List
+1. `verilog.generateOutputList()` - Generates Verilog Module Output List
+1. `verilog.santizeLabel()` - Sanitizes label for node/wire
+1. `verilog.generateNodeName()` - Helper function to resolve node/wire name
+
+**CircuitElement Functions:**
+
+These functions can be overriden by derived classes.
+
+1. `CircuitElement.prototype.processVerilog()` - Graph algorithm to resolve verilog wire labels
+1. `CircuitElement.prototype.verilogName()` - Generate verilog name
+1. `CircuitElement.prototype.generateVerilog()` - Generate final verilog code
+1. `CircuitElement.prototype.verilogType` - Verilog type name
+1. `CircuitElement.moduleVerilog` - Custom module verilog for elements


### PR DESCRIPTION
Fixes #
verilog.js fixed minor bug, but unable to PR1814
logix.js added tag in CircuitElement.prototype.generateVerilog so it takes tag - because unable to incorporate verilog.js, unable to use PR#1814
module.js has minor changes to write tag, otherwise same as PR#1814
Counter, sequential, subcircuit incorporated most changes in PR#1814

Problems:
Clock is translated as input, PR#1814 does not do this
Splitter is very hard to get to work properly. I used a lot of trial and error with verilog.js and logix.js. The change in code from PR#1814 made these changes not work.

Specific errors:
Splitter inputs need to be a single variable with bitwidth, sometimes this is to the case
Splitter output sometimes disappear completely, because of DFS from input of module, and sometimes splitter input is connected to an input of device or module
Making Clock an Input of the module sometimes resulted in it being an output or wire

I think the Splitter and Clock logic needs to be reworked so PR#1814 can work well
I have tried to incorporate as much of the changes as I can
Thanks,
James
#### Describe the changes you have made in this PR -

### Screenshots of the changes (If any) -



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
