### PR TITLE
fixed-log-in-and-homepage-names

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -27,7 +27,7 @@
             <% if user_signed_in? %>
               <a href="<%= user_path(current_user) %>"><h6>My Circuits</h6></a>
             <% else %>
-              <a href="/users/sign_in"><h6>Login</h6></a>
+              <a href="/users/sign_in"><h6>Log in</h6></a>
             <% end %>
           </div>
           <div class="col-6 footer-links">

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -7,7 +7,7 @@
 
     <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6">
       <div class="form-container">
-        <h1 class="users-main-heading">Log In</h1>
+        <h1 class="users-main-heading">Log in</h1>
         <%= form_with(model: resource, as: resource_name, url: session_path(resource_name), local: true) do |f| %>
         <% flash.each do |key, value| %>
           <div class="error-message"><%= value %></div>


### PR DESCRIPTION
Fixes #1827

#### The use of microcopy "Log in" is made consistent on login and homepage. Changed it "Log in"
