### PR TITLE
Hotfix contention due to signed input in splitter

### DIFF
--- a/public/js/modules.js
+++ b/public/js/modules.js
@@ -1709,8 +1709,8 @@ Splitter.prototype.resolve = function () {
             n <<= this.bitWidthSplit[i];
             n += this.outputs[i].value;
         }
-        if (this.inp1.value != n) {
-            this.inp1.value = n;
+        if (this.inp1.value != (n >>> 0)) {
+            this.inp1.value = (n >>> 0);
             simulationArea.simulationQueue.add(this.inp1);
         }
         // else if (this.inp1.value != n) {


### PR DESCRIPTION
Fixes #1332 
Due to input becoming signed in the process, signed bit was getting included in the MSB 32 bits, hence taking the wrong value
