### PR TITLE
Add subcircuit menu to simulator html

### DIFF
--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -179,6 +179,7 @@
   </div>
   <div id='filter' class="customScroll"></div>
   <div class="accordion" id="menu"></div>
+  <div class="accordion" id="subcircuitMenu"></div>
 </div>
 
 <div class="moduleProperty noSelect effect1 properties-panel guide_2" id="moduleProperty">


### PR DESCRIPTION
Fixes elements not showing up in the subcircuit menu
