### PR TITLE
Added option to directly edit the project title from header in Simulator

### DIFF
--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -48,7 +48,9 @@
         <a href="https://docs.circuitverse.org" class="text-light" target="_blank" role="button" aria-haspopup="true" aria-expanded="false">Help</a>
       </li>
     </ul>
-    <input type="text" class="projectName font-weight-bold" id="projectName" placeholder="Project Name">
+    <label for="projectName" class="labelForProjectName">
+      <input type="text" class="projectName font-weight-bold" id="projectName" placeholder="Project Name">
+    </label>
     <ul class="nav navbar-nav noSelect pointerCursor pull-right">
       <li class="dropdown pull-right">
         <% if user_signed_in? %>

--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -48,8 +48,9 @@
         <a href="https://docs.circuitverse.org" class="text-light" target="_blank" role="button" aria-haspopup="true" aria-expanded="false">Help</a>
       </li>
     </ul>
-    <label for="projectName"></label>
+    <label class="project-name-label">
       <input type="text" class="projectName font-weight-bold" id="projectName" placeholder="Project Name">
+    </label>  
     <ul class="nav navbar-nav noSelect pointerCursor pull-right">
       <li class="dropdown pull-right">
         <% if user_signed_in? %>

--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -48,7 +48,7 @@
         <a href="https://docs.circuitverse.org" class="text-light" target="_blank" role="button" aria-haspopup="true" aria-expanded="false">Help</a>
       </li>
     </ul>
-    <input type="text" class="projectName font-weight-bold" id="projectName" placeholder="Project Name" >
+    <input type="text" class="projectName font-weight-bold" id="projectName" placeholder="Project Name">
     <ul class="nav navbar-nav noSelect pointerCursor pull-right">
       <li class="dropdown pull-right">
         <% if user_signed_in? %>

--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -50,7 +50,7 @@
     </ul>
     <label class="project-name-label">
       <input type="text" class="projectName font-weight-bold" id="projectName" placeholder="Project Name">
-    </label>  
+    </label>
     <ul class="nav navbar-nav noSelect pointerCursor pull-right">
       <li class="dropdown pull-right">
         <% if user_signed_in? %>

--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -48,7 +48,7 @@
         <a href="https://docs.circuitverse.org" class="text-light" target="_blank" role="button" aria-haspopup="true" aria-expanded="false">Help</a>
       </li>
     </ul>
-    <input type="text" class="projectName font-weight-bold" id="projectName" placeholder="Project Name" />
+    <input type="text" class="projectName font-weight-bold" id="projectName" placeholder="Project Name" >
     <ul class="nav navbar-nav noSelect pointerCursor pull-right">
       <li class="dropdown pull-right">
         <% if user_signed_in? %>

--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -48,9 +48,8 @@
         <a href="https://docs.circuitverse.org" class="text-light" target="_blank" role="button" aria-haspopup="true" aria-expanded="false">Help</a>
       </li>
     </ul>
-    <label for="projectName" class="labelForProjectName">
+    <label for="projectName"></label>
       <input type="text" class="projectName font-weight-bold" id="projectName" placeholder="Project Name">
-    </label>
     <ul class="nav navbar-nav noSelect pointerCursor pull-right">
       <li class="dropdown pull-right">
         <% if user_signed_in? %>

--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -48,9 +48,7 @@
         <a href="https://docs.circuitverse.org" class="text-light" target="_blank" role="button" aria-haspopup="true" aria-expanded="false">Help</a>
       </li>
     </ul>
-    <span class="projectName noSelect defaultCursor font-weight-bold" id="projectName">
-      Untitled
-    </span>
+    <input type="text" class="projectName font-weight-bold" id="projectName" placeholder="Project Name" />
     <ul class="nav navbar-nav noSelect pointerCursor pull-right">
       <li class="dropdown pull-right">
         <% if user_signed_in? %>

--- a/public/css/UX.css
+++ b/public/css/UX.css
@@ -87,21 +87,18 @@ button:focus {
     overflow-x: hidden;
 }
 
-.labelForProjectName {
-    margin: 0 auto;
-    position: static;
-    left: 50%;
-    margin-left: -250px;
-}
-
 .projectName {
     /*margin:3px;*/
     color: #0099ff;
+    margin: 0 auto;
     text-align: center;
     font-size: 1.4em;
+    position: static;
+    left: 50%;
     display: block;
     width: 500px;
     text-align: center;
+    margin-left: -250px;
     border: none;
     border-bottom: 1px solid transparent;
     background: transparent;

--- a/public/css/UX.css
+++ b/public/css/UX.css
@@ -87,18 +87,21 @@ button:focus {
     overflow-x: hidden;
 }
 
+.labelForProjectName {
+    margin: 0 auto;
+    position: static;
+    left: 50%;
+    margin-left: -250px;
+}
+
 .projectName {
     /*margin:3px;*/
     color: #0099ff;
-    margin: 0 auto;
     text-align: center;
     font-size: 1.4em;
-    position: static;
-    left: 50%;
     display: block;
     width: 500px;
     text-align: center;
-    margin-left: -250px;
     border: none;
     border-bottom: 1px solid transparent;
     background: transparent;
@@ -108,6 +111,12 @@ button:focus {
 
 .projectName:hover, .projectName:focus {
     border-bottom-color: rgb(216, 216, 216);
+}
+
+@media only screen and (max-width: 1344px) {
+    .projectName:hover, .projectName:focus {
+        border-bottom-color: transparent;
+    }
 }
 
 .inline {

--- a/public/css/UX.css
+++ b/public/css/UX.css
@@ -99,6 +99,15 @@ button:focus {
     width: 500px;
     text-align: center;
     margin-left: -250px;
+    border: none;
+    border-bottom: 1px solid transparent;
+    background: transparent;
+    cursor: text;
+    transition: .1s ease-in-out;
+}
+
+.projectName:hover, .projectName:focus {
+    border-bottom-color: rgb(216, 216, 216);
 }
 
 .inline {

--- a/public/css/UX.css
+++ b/public/css/UX.css
@@ -87,18 +87,21 @@ button:focus {
     overflow-x: hidden;
 }
 
+.project-name-label {
+    margin: 0 auto;
+    position: static;
+    left: 50%;
+    margin-left: -250px;
+}
+
 .projectName {
     /*margin:3px;*/
     color: #0099ff;
-    margin: 0 auto;
     text-align: center;
     font-size: 1.4em;
-    position: static;
-    left: 50%;
     display: block;
     width: 500px;
     text-align: center;
-    margin-left: -250px;
     border: none;
     border-bottom: 1px solid transparent;
     background: transparent;

--- a/public/js/UX.js
+++ b/public/js/UX.js
@@ -8,6 +8,11 @@ var ctxPos = {
     visible: false,
 };
 
+// Function updates the values of project inputs accordingly
+function watchOneInputChangeAndUpdateAnother(objectToListen, objectToChange) {
+    $(`${objectToListen}`).on('input', (e) => { $(`${objectToChange}`).val(e.target.value); }); // setting the value of header title on sidebar title change
+}
+
 // Function hides the context menu
 function hideContextMenu() {
     var el = document.getElementById('contextMenu');
@@ -149,11 +154,13 @@ function showProperties(obj) {
         $('#moduleProperty-inner').append("<p>Lite Mode : <label class='switch'> <input type='checkbox' " + ["", "checked"][lightMode + 0] + " class='objectPropertyAttributeChecked' name='changeLightMode' > <span class='slider'></span> </label></p>");
         // $('#moduleProperty-inner').append("<p>  ");
         $('#moduleProperty-inner').append("<p><button type='button' class='objectPropertyAttributeChecked btn btn-danger btn-xs' name='deleteCurrentCircuit' >Delete Circuit</button>  <button type='button' class='objectPropertyAttributeChecked btn btn-primary btn-xs' name='toggleLayoutMode' >Edit Layout</button> </p>");
-
+        
         // setting the name of the title bar as same as it is in the side bar
         $('.projectName').val($('[name="setProjectName"]').val()); // setting the initial value of title heading
-        $('[name="setProjectName"]').on('input', (e) => { $('.projectName').val(e.target.value); }); // setting the value of header title on sidebar title change
-        $('.projectName').on('input', (e) => { $('[name="setProjectName"]').val(e.target.value); }); // setting the value of sidebar title on header title change
+        watchOneInputChangeAndUpdateAnother('[name="setProjectName"]', '.projectName'); // setting the value of header title on sidebar title change
+        watchOneInputChangeAndUpdateAnother('.projectName', '[name="setProjectName"]'); // setting the value of sidebar title on header title change
+
+        
     } else {
         $('#moduleProperty').show();
 

--- a/public/js/UX.js
+++ b/public/js/UX.js
@@ -152,8 +152,8 @@ function showProperties(obj) {
 
         // setting the name of the title bar as same as it is in the side bar
         $('.projectName').val($('[name="setProjectName"]').val()); // setting the initial value of title heading
-        $('[name="setProjectName"]').on('input', (e) => $('.projectName').val(e.target.value));// setting the value of header title on sidebar title change
-        $('.projectName').on('input', (e) => $('[name="setProjectName"]').val(e.target.value));// setting the value of sidebar title on header title change
+        $('[name="setProjectName"]').on('input', (e) => { $('.projectName').val(e.target.value); }); // setting the value of header title on sidebar title change
+        $('.projectName').on('input', (e) => { $('[name="setProjectName"]').val(e.target.value); }); // setting the value of sidebar title on header title change
     } else {
         $('#moduleProperty').show();
 

--- a/public/js/UX.js
+++ b/public/js/UX.js
@@ -149,6 +149,11 @@ function showProperties(obj) {
         $('#moduleProperty-inner').append("<p>Lite Mode : <label class='switch'> <input type='checkbox' " + ["", "checked"][lightMode + 0] + " class='objectPropertyAttributeChecked' name='changeLightMode' > <span class='slider'></span> </label></p>");
         // $('#moduleProperty-inner').append("<p>  ");
         $('#moduleProperty-inner').append("<p><button type='button' class='objectPropertyAttributeChecked btn btn-danger btn-xs' name='deleteCurrentCircuit' >Delete Circuit</button>  <button type='button' class='objectPropertyAttributeChecked btn btn-primary btn-xs' name='toggleLayoutMode' >Edit Layout</button> </p>");
+
+        // setting the name of the title bar as same as it is in the side bar
+        $('.projectName').val($('[name="setProjectName"]').val()); // setting the initial value of title heading
+        $('[name="setProjectName"]').on('input', (e) => $('.projectName').val(e.target.value));// setting the value of header title on sidebar title change
+        $('.projectName').on('input', (e) => $('[name="setProjectName"]').val(e.target.value));// setting the value of sidebar title on header title change
     } else {
         $('#moduleProperty').show();
 

--- a/public/js/UX.js
+++ b/public/js/UX.js
@@ -9,9 +9,7 @@ var ctxPos = {
 };
 
 // Function updates the values of project inputs accordingly
-function watchOneInputChangeAndUpdateAnother(objectToListen, objectToChange) {
-    $(`${objectToListen}`).on('input', (e) => { $(`${objectToChange}`).val(e.target.value); }); // setting the value of header title on sidebar title change
-}
+const watchOneInputChangeAndUpdateAnother = (objectToListen, objectToChange) => $(`${objectToListen}`).on('input', (e) => { $(`${objectToChange}`).val(e.target.value); }); // setting the value of header title on sidebar title change
 
 // Function hides the context menu
 function hideContextMenu() {

--- a/public/js/UX.js
+++ b/public/js/UX.js
@@ -154,13 +154,11 @@ function showProperties(obj) {
         $('#moduleProperty-inner').append("<p>Lite Mode : <label class='switch'> <input type='checkbox' " + ["", "checked"][lightMode + 0] + " class='objectPropertyAttributeChecked' name='changeLightMode' > <span class='slider'></span> </label></p>");
         // $('#moduleProperty-inner').append("<p>  ");
         $('#moduleProperty-inner').append("<p><button type='button' class='objectPropertyAttributeChecked btn btn-danger btn-xs' name='deleteCurrentCircuit' >Delete Circuit</button>  <button type='button' class='objectPropertyAttributeChecked btn btn-primary btn-xs' name='toggleLayoutMode' >Edit Layout</button> </p>");
-        
+
         // setting the name of the title bar as same as it is in the side bar
         $('.projectName').val($('[name="setProjectName"]').val()); // setting the initial value of title heading
         watchOneInputChangeAndUpdateAnother('[name="setProjectName"]', '.projectName'); // setting the value of header title on sidebar title change
         watchOneInputChangeAndUpdateAnother('.projectName', '[name="setProjectName"]'); // setting the value of sidebar title on header title change
-
-        
     } else {
         $('#moduleProperty').show();
 


### PR DESCRIPTION
Fixes #1808 

#### Describe the changes you have made in this PR -
1. Made header project title editable from the header itself.
2. Linked Header project title and sidebar project title so that the one changes itself automatically when there is any change in another.

### Screenshots of the changes (If any) -
**Initial State**
![image](https://user-images.githubusercontent.com/49204837/98106832-ae7dd100-1ebf-11eb-8d38-7c0e404ec70e.png)

**On hover and click**
![image](https://user-images.githubusercontent.com/49204837/98107561-b38f5000-1ec0-11eb-87c2-680ef4f25d14.png)

**Automatic sync when one of the 'projects title' input changes**
![image](https://user-images.githubusercontent.com/49204837/98108094-78415100-1ec1-11eb-9847-73985f4f09e6.png)
