### PR TITLE
responsive nav

### DIFF
--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -29,7 +29,7 @@
   </button>
   <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
     <ul class="navbar-nav navbar-menu noSelect pointerCursor" id="toolbar">
-      <li class="dropdown">
+      <li class="dropdown nav-dropdown">
         <a href="#" class="" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Project<span></span></a>
         <ul class="dropdown-menu">
           <% if not @project.nil? %>
@@ -44,14 +44,14 @@
           <li><a class="dropdown-item logixButton text-left pl-1" id="fullViewOption">Preview Circuit</a></li>
         </ul>
       </li>
-      <li class="dropdown">
+      <li class="dropdown nav-dropdown">
         <a href="#" class="" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Circuit<span class="caret"></span></a>
         <ul class="dropdown-menu">
           <li><a class="dropdown-item text-left logixButton pl-1" id="newCircuit">New Circuit +</a></li>
           <li><a class="dropdown-item logixButton text-left pl-1" id="createSubCircuitPrompt">Insert SubCircuit</a></li>
         </ul>
       </li>
-      <li class="dropdown">
+      <li class="dropdown nav-dropdown">
         <a href="#" class="" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Tools<span class="caret"></span></a>
         <ul class="dropdown-menu">
           <li><a class="dropdown-item text-left pl-1 logixButton" id="createCombinationalAnalysisPrompt">Combinational<br>Analysis</a></li>
@@ -62,7 +62,7 @@
           <li><a class="dropdown-item text-left pl-1" id="customShortcut">Custom Shortcut</a></li>
         </ul>
       </li>
-      <li  class="dropdown tour-help">
+      <li class="dropdown tour-help nav-dropdown">
         <a href="#" class="" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help<span class="caret"></span></a>
         <ul class="dropdown-menu">
             <li><a class="dropdown-item text-left pl-1 logixButton" id="showTourGuide">Tutorial Guide</a></li>
@@ -151,7 +151,7 @@
     <ul class="nav navbar-nav noSelect pointerCursor pull-right account-btn">
       <li class="dropdown pull-right">
         <% if user_signed_in? %>
-          <a href="#" class="cur-user acc-drop" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><%= current_user.name %><span class="caret acc-caret"></span></a>
+          <a href="#" class="cur-user acc-drop user-field" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><%= current_user.name %><span class="caret acc-caret"></span></a>
           <ul class="dropdown-menu">
             <li><a class="dropdown-item" href=<%= user_path(current_user) %>>Dashboard</a></li>
             <li><a class="dropdown-item" href=<%= user_groups_path(current_user) %>>My Groups</a></li>
@@ -159,7 +159,7 @@
             <li><a class="dropdown-item" rel="nofollow" data-method="delete" href=<%= destroy_user_session_path %>>Sign Out</a></li>
           </ul>
         <% else %>
-          <a class="navbar-nav signIn-btn" href=<%= new_user_session_path %>> Sign In </a>
+          <a class="navbar-nav signIn-btn user-field" href=<%= new_user_session_path %>> Sign In </a>
         <% end %>
       </li>
     </ul>

--- a/public/css/main.stylesheet.css
+++ b/public/css/main.stylesheet.css
@@ -166,11 +166,20 @@ input[type="text"]:focus {
 }
 
 .projectName {
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
+  position: relative;
+  left: .5rem;
   font-size: 1.4em;
-  cursor: pointer;
+  text-align: center;
+  display: inline-block;
+  width: 35vw;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+@media(max-width: 992px) {
+  .projectName {
+    visibility: hidden;
+  }
 }
 
 .account-btn {
@@ -186,6 +195,21 @@ input[type="text"]:focus {
   border-bottom: 1px solid white;
 }
 
+.user-field {
+  display: inline-block;
+  max-width: 11rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: right;
+}
+
+@media(max-width: 992px) {
+  .user-field {
+    visibility: hidden;
+  }
+}
+
 .signIn-btn {
   color: var(--text-primary);
 }
@@ -196,10 +220,6 @@ input[type="text"]:focus {
 
 .signIn-btn:hover {
   color: var(--text-primary);
-}
-
-.header {
-  height: 50px;
 }
 
 .logo {
@@ -342,6 +362,13 @@ input[type="text"]:focus {
 .dropdown-menu > li > a:hover {
   border-radius: 7px;
   opacity: 1;
+}
+
+@media(max-width: 992px) {
+  .navbar-nav .dropdown-menu {
+    position: absolute;
+    float: none;
+  }
 }
 
 #contextMenu {
@@ -1073,6 +1100,19 @@ input:checked + .slider:before {
   float: right;
   margin-right: 10px;
   min-width: 85px;
+}
+
+@media(max-width: 992px) {
+  .navbar .nav.pull-right {
+    display: none;
+  }
+}
+
+@media(max-width:992px) {
+  .nav-dropdown {
+    text-align: center;
+    padding-top: 20px;
+  }
 }
 
 /*! download dialog styling end here */


### PR DESCRIPTION
NEW PR FOR PR #1725  and PR  #1745 

Fixes #1693 
visit #1693 to know about the issues which were present in navbar

#### Describe the changes you have made in this PR:
a>solving problems mentioned in issue #1693 


b> making whole navbar responsive :-
      1>fixing position and aligment of nav items according to window size /making them responsive 
      2>username or sign in will not overlap on toggler   
      3>making username/sign-in button responsive
      4>fixing alignment and position of username/sign-up button
      5>fixing position and alignment of  all dropdowns so that they look same at any size of browser window
      6>making dropdowns responsive
      7>limiting username and project name length at a particular limit and making them responsive 
      8>hiding project name present in navbar for smaller window


GIF::

![navbarfix](https://user-images.githubusercontent.com/55848322/94541826-acdc4000-0265-11eb-82f8-160401d5ceb2.gif)


(new changes inlcude increase in size of project and username also project and username are hidden for less than 992px)



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
