### PR TITLE
fixed ce panel's header items overlapping

### DIFF
--- a/public/css/main.stylesheet.css
+++ b/public/css/main.stylesheet.css
@@ -391,7 +391,7 @@ input[type="text"]:focus {
 
 .ce-panel {
   font: inherit;
-  width: 220px;
+  width: 240px;
   top: 90px;
   left: 10px;
 }


### PR DESCRIPTION
Fixes #1874 

#### Describe the changes you have made in this PR -
1. Extended the width of the CE container so that the elements don't overlap with each other.

### Screenshots of the changes (If any) -
**firefox (Before)**
![image](https://user-images.githubusercontent.com/49204837/98377705-289e8900-206b-11eb-8ef2-9b1f39936bdb.png)

**firefox (After)**
![image](https://user-images.githubusercontent.com/49204837/98377772-3a802c00-206b-11eb-9f2f-2976f1976691.png)

***
**Chrome (Before)**
![image](https://user-images.githubusercontent.com/49204837/98378156-ab274880-206b-11eb-983b-8766b3062f67.png)

**Chrome (After)**
![image](https://user-images.githubusercontent.com/49204837/98378240-c42ff980-206b-11eb-878d-94380d0d80d1.png)

