### PR TITLE
Resource only available routes in routes.rb

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -151,7 +151,7 @@ Rails.application.routes.draw do
       post "/forgot_password", to: "users#forgot_password"
       resources :users, only: %i[index show update]
       get "/projects/featured", to: "projects#featured_circuits"
-      resources :projects do
+      resources :projects, only: %i[index show update destroy] do
         member do
           get "toggle-star", to: "projects#toggle_star"
           get "fork", to: "projects#create_fork"


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -
Resourced only available routes using `only`.

### Screenshots of the changes (If any) -



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
