### PR TITLE
Create a dummy Circle CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,11 @@
+version: 2
+jobs:
+  checking-branch-job:
+workflows:
+  version: 2
+  build:
+    jobs:
+      - checking-branch-job:
+          filters:
+            branches:
+              ignore: 'gh-pages'


### PR DESCRIPTION


Fixes error in Circle CI for `gh-pages` branch due to triggers.

#### Describe the changes you have made in this PR -
Adds a dummy Circle CI config for skipping build on `gh-pages` branch.

### Screenshots of the changes (If any) -
![image](https://user-images.githubusercontent.com/22657113/100128732-a5709600-2ea6-11eb-9198-d1ae61406726.png)


