### PR TITLE
Circle CI: Ignore gh-pages branch for building.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,9 @@ version: 2 # use CircleCI 2.0
 jobs: # a collection of steps
   build: # runs not using Workflows must have a `build` job as entry point
     parallelism: 1 # run three instances of this job in parallel
+    branches: # run this job with branch filters
+        ignore: # ignore these branches
+          - gh-pages
     docker: # run the steps with Docker
       - image: circleci/ruby:2.6.5-node-browsers # ...with this image as the primary container; this is where all `steps` will run
         environment: # environment variables for primary container


### PR DESCRIPTION
Fixes Circle CI build errors in `gh-pages`

#### Describe the changes you have made in this PR -
Added a branch filter for the job `build` which will ignore `gh-pages` branch

### Screenshots of the changes (If any) -

![image](https://user-images.githubusercontent.com/22657113/100326934-98f85480-2ff0-11eb-80d8-cff03a07d8a1.png)
