### PR TITLE
Changed text input into tags input in 'add collaborators' modal

### DIFF
--- a/app/assets/stylesheets/projects.scss
+++ b/app/assets/stylesheets/projects.scss
@@ -204,33 +204,37 @@
 
 // collaborators tags input
 .bootstrap-tagsinput {
-  margin: 0;
-	width: 100%;
-	padding: 0.5rem 0.75rem;
-	font-size: 1rem;
-  line-height: 1.25;
   border: 1px solid $secondary-green;
-  transition: border-color 0.15s ease-in-out;
-  min-height: 180px;
   cursor: text;
-	
-	.label-info {
-    display: inline-block;
-    color: $white;
-		background-color: $primary-green;
-		padding: 0 .4em .15em;
+  font-size: 1rem;
+  line-height: 1.25;
+  margin: 0;
+  max-height: 180px;
+  min-height: 150px;
+  overflow-y: scroll;
+  padding: .5rem .75rem;
+  transition: border-color .15s ease-in-out;
+  width: 100%;
+
+  .label-info {
+    background-color: $primary-green;
     border-radius: .25rem;
-    margin-bottom: 0.4em;
+    color: $white;
+    display: inline-block;
+    margin-bottom: .4em;
+    padding: 0 .4em .15em;
 	}
-  
+
   input {
     border: 0;
   }
 }
 
-.bootstrap-tagsinput .tag [data-role="remove"]:after {
+.tag [data-role="remove"]::after {
   content: '\00d7';
   cursor: pointer;
-  margin-left: 5px;
   font-size: 18px;
+  margin-left: 5px;
 }
+
+// collaborators tags input closes

--- a/app/assets/stylesheets/projects.scss
+++ b/app/assets/stylesheets/projects.scss
@@ -201,3 +201,36 @@
   }
 }
 //project details ends
+
+// collaborators tags input
+.bootstrap-tagsinput {
+  margin: 0;
+	width: 100%;
+	padding: 0.5rem 0.75rem;
+	font-size: 1rem;
+  line-height: 1.25;
+  border: 1px solid $secondary-green;
+  transition: border-color 0.15s ease-in-out;
+  min-height: 180px;
+  cursor: text;
+	
+	.label-info {
+    display: inline-block;
+    color: $white;
+		background-color: $primary-green;
+		padding: 0 .4em .15em;
+    border-radius: .25rem;
+    margin-bottom: 0.4em;
+	}
+  
+  input {
+    border: 0;
+  }
+}
+
+.bootstrap-tagsinput .tag [data-role="remove"]:after {
+  content: '\00d7';
+  cursor: pointer;
+  margin-left: 5px;
+  font-size: 18px;
+}

--- a/app/views/projects/_add_collaborator_modal.html.erb
+++ b/app/views/projects/_add_collaborator_modal.html.erb
@@ -39,15 +39,16 @@
 
 <script>
 $(document).ready(() => {
+  // docs: http://bootstrap-tagsinput.github.io/bootstrap-tagsinput/examples/
   $('#emails').tagsinput({
-		trimValue: true,
+    trimValue: true,
     confirmKeys: [13, 44, 32],
   });
 
   $('.bootstrap-tagsinput input').attr('maxlength', '30'); // to limit the no. of chars entered in input box to avoid the overflow
 
   $('.add-collaborators-button').attr('disabled', true); // setting submit button to disabled initially
-  
+
   $('.bootstrap-tagsinput input').on('keyup', () => {
     if($('.bootstrap-tagsinput').children().length > 1) { // checking for 1 because there is already a child (input tag)
       $('.add-collaborators-button').attr('disabled', false);
@@ -63,5 +64,29 @@ $(document).ready(() => {
       $('.add-collaborators-button').attr('disabled', true);
     }
   })
+
+  document.querySelector('.bootstrap-tagsinput input').addEventListener('paste', (e) => { // listening for paste event
+    e.preventDefault();
+    let pastedEmails = '';
+    if (window.clipboardData && window.clipboardData.getData) { // IE
+      pastedEmails = window.clipboardData.getData('Text');
+    } else if (e.clipboardData && e.clipboardData.getData) { // other browsers
+      pastedEmails = e.clipboardData.getData('text/plain');
+    }
+
+    if(pastedEmails.includes('\n')) {
+      const newLinesIntoSpaces = pastedEmails.replace(/\n/g, ' '); // converting new lines in to spaces
+      const newLinesIntoSpacesSplitted = newLinesIntoSpaces.split(' '); // splitting emails by space
+      this.value = pastedEmails.replace(/./g, ''); // removing the pasted values from input box
+      newLinesIntoSpacesSplitted.forEach(value => $('#emails').tagsinput('add', value)) // adding each value as an input
+      $('.add-collaborators-button').attr('disabled', false)
+    } else {
+      const pastedEmailsSplittedBySpace = pastedEmails.split(' '); // splitting emails by space
+      this.value = pastedEmails.replace(/./g, ''); // removing the pasted values from input box
+      pastedEmailsSplittedBySpace.forEach(value => $('#emails').tagsinput('add', value)) // adding each value as an input
+      $('.add-collaborators-button').attr('disabled', false)
+    }
+  });
 });
+
 </script>

--- a/app/views/projects/_add_collaborator_modal.html.erb
+++ b/app/views/projects/_add_collaborator_modal.html.erb
@@ -1,3 +1,5 @@
+<script src="https://cdn.jsdelivr.net/bootstrap.tagsinput/0.8.0/bootstrap-tagsinput.min.js"></script>
+
 <div id="collaboratorModal" class="modal fade" role="dialog">
   <div class="modal-dialog primary-modal-dialog">
     <div class="modal-content">
@@ -6,7 +8,7 @@
         <button type="button" class="close" data-dismiss="modal">&times;</button>
       </div>
       <div class="modal-body">
-        <p>Enter Email IDs separated by commas/spaces or in separate lines. Users need to be registered already on the platform.
+        <p>Enter Email IDs separated by commas, spaces or enter. Users need to be registered already on the platform.
           Note that collaboration is not real time as of now. Every save overwites the previous data.
         </p>
         <%= form_with(model: @collaboration, local: true) do |form| %>
@@ -24,13 +26,42 @@
         </div>
         <div class="form-group">
           <label for="emails">Email IDs:</label>
-          <textarea class="form-control form-input" rows="5" id="emails" name="collaboration[emails]"></textarea>
+          <textarea class="form-control form-input" rows="5" id="emails" name="collaboration[emails]" data-role="tagsinput"></textarea>
         </div>
         <div class="modal-footer">
-          <%= form.submit "Add Collaborators", class: 'btn primary-button' %>
+          <%= form.submit "Add Collaborators", class: 'btn primary-button add-collaborators-button' %>
         </div>
         <% end %>
       </div>
     </div>
   </div>
 </div>
+
+<script>
+$(document).ready(() => {
+  $('#emails').tagsinput({
+		trimValue: true,
+    confirmKeys: [13, 44, 32],
+  });
+
+  $('.bootstrap-tagsinput input').attr('maxlength', '30'); // to limit the no. of chars entered in input box to avoid the overflow
+
+  $('.add-collaborators-button').attr('disabled', true); // setting submit button to disabled initially
+  
+  $('.bootstrap-tagsinput input').on('keyup', () => {
+    if($('.bootstrap-tagsinput').children().length > 1) { // checking for 1 because there is already a child (input tag)
+      $('.add-collaborators-button').attr('disabled', false);
+    } else {
+      $('.add-collaborators-button').attr('disabled', true);
+    }
+  });
+
+  $('.bootstrap-tagsinput').on('click', () => { // if user deletes tags using mouse click instead of backspace
+    if($('.bootstrap-tagsinput').children().length > 1) {
+      $('.add-collaborators-button').attr('disabled', false);
+    } else {
+      $('.add-collaborators-button').attr('disabled', true);
+    }
+  })
+});
+</script>


### PR DESCRIPTION
Fixes #1909 

#### Describe the changes you have made in this PR -
1. Changed text input into tags input
2. Added functionality to convert pasted emails ids into tags
3. Tags can be added by pressing **space**, **comma** or **enter**.

### Screenshots of the changes (If any) -
**Initial State (Button is disabled)**
![image](https://user-images.githubusercontent.com/49204837/101000546-12112200-3584-11eb-851f-37a0abb020df.png)

**On Input**
![image](https://user-images.githubusercontent.com/49204837/101000730-4a186500-3584-11eb-8f47-31f8b886aa6a.png)

**On Paste (with new lines)**
![newline](https://user-images.githubusercontent.com/49204837/101001595-53560180-3585-11eb-96d2-e8389314171a.gif)

**On Paste (with spaces)**
![spaces](https://user-images.githubusercontent.com/49204837/101001648-623cb400-3585-11eb-9f8e-7f2e477e2f6a.gif)
