### PR TITLE
Showing title "Sign up with" on the Sign up page's OAuth options

### DIFF
--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -59,7 +59,7 @@
               </div>
             </div>
           </div>
-          <%= render "users/shared/links" %>
+          <%= render partial: 'users/shared/links', locals: {displayText: "Sign Up With"} %>
         </div>
         <% end %>
       </div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -54,7 +54,7 @@
             </div>
           </div>
         </div>
-        <%= render "users/shared/links" %>
+        <%= render partial: "users/shared/links", locals: {displayText: "Log In With"}%>
       </div>
       <% end %>
     </div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -54,7 +54,7 @@
             </div>
           </div>
         </div>
-        <%= render partial: "users/shared/links", locals: {displayText: "Log In With"}%>
+        <%= render partial: "users/shared/links", locals: {displayText: "Log In With"} %>
       </div>
       <% end %>
     </div>

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -1,9 +1,7 @@
 <div class="field form-group users-shared">
   <div class="input-group">
     <div class="row center-row users-shared-row">
-      <h6 class="users-shared-row">
-          <%= displayText %> 
-      </h6>
+      <h6 class="users-shared-row"><%= displayText %></h6>
     </div>
     <div class="row center-row">
       <a href="/users/auth/google_oauth2">

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -1,7 +1,9 @@
 <div class="field form-group users-shared">
   <div class="input-group">
     <div class="row center-row users-shared-row">
-      <h6 class="users-shared-row">Log In With</h6>
+      <h6 class="users-shared-row">
+          <%= displayText %> 
+      </h6>
     </div>
     <div class="row center-row">
       <a href="/users/auth/google_oauth2">


### PR DESCRIPTION
#### Describe the changes you have made in this PR -
Initially, the sign up page as well as the login page showed "Log In With" on the OAuth options. Changed the Sign up page to display "Sign Up With"

### Screenshots of the changes (If any) -
Initially: 
![login_initial](https://user-images.githubusercontent.com/58396189/101611940-1e87f580-3a30-11eb-8676-d5562cc7edcd.png)
![signup_initial](https://user-images.githubusercontent.com/58396189/101611955-22b41300-3a30-11eb-85c8-fa4284f9412f.png)

Now: 
![login_final](https://user-images.githubusercontent.com/58396189/101612000-2c3d7b00-3a30-11eb-8a8c-2b1b3a7f8d7f.png)
![signup_final](https://user-images.githubusercontent.com/58396189/101612010-2e9fd500-3a30-11eb-8b78-890d955b410f.png)



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
