### PR TITLE
not allowing checkbox to get ticked when clicked on empty area of div present on left of checkbox and  accessible only through label name and checkbox itself

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -252,7 +252,7 @@
 
 .primary-checkpoint-container {
   cursor: pointer;
-  display: block;
+  display: inline-block;
   font-size: 22px;
   position: relative;
 


### PR DESCRIPTION
Fixes #1763 , #1778 
After discussio in #1778  
#1763 needs only small changes

#### Describe the changes you have made in this PR -
       
### Screenshots of the changes (If any) -
before checkbox was accessible even in empty span of div
![beforecheckbox](https://user-images.githubusercontent.com/55848322/105661387-42759c80-5ef3-11eb-9d4d-7f15adc9b749.png)
now checkbox accessible only through labelname and checkbox itself
![aftercheckbox](https://user-images.githubusercontent.com/55848322/105661391-45708d00-5ef3-11eb-9cab-d566a5152c71.png)


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
