### PR TITLE
Fixed saveOffline functionality

### DIFF
--- a/public/src/data/project.js
+++ b/public/src/data/project.js
@@ -4,7 +4,7 @@
 /* eslint-disable no-restricted-globals */
 /* eslint-disable no-alert */
 import { resetScopeList, scopeList, newCircuit } from '../circuit';
-import { showMessage, showError } from '../utils';
+import { showMessage, showError, generateId } from '../utils';
 import { checkIfBackup } from './backupCircuit';
 import {generateSaveData, getProjectName, setProjectName} from './save';
 import load from './load';

--- a/public/src/utils.js
+++ b/public/src/utils.js
@@ -7,7 +7,7 @@ import plotArea from './plotArea';
 
 window.globalScope = undefined;
 window.lightMode = false; // To be deprecated
-window.projectId = undefined;
+window.projectId = generateId();
 window.id = undefined;
 window.loading = false; // Flag - all assets are loaded
 


### PR DESCRIPTION
Fixes #
A fix to issue #2026 
#### Describe the changes you have made in this PR -
Changed window.projectId global variable assignment from undefined to generateId(); so that a unique id is generated for this global variable, instead of the undefined being used for each project. Before, because of the projectId being undefined, the Local Storage was saving each offline project in the same undefined key under projectList, leading to previous projects being overwritten. Because of this, Clicking Open Offline in the simulator would only show one project i.e. the last saved project. After fixing this, each project is saved under a different key, and no project is overwritten.
Also, fixed a generateId() is not defined error, which occurred when New Project was clicked. This error happened because of not importing generateId function from utils in project.js.

### Screenshots of the changes (If any) -
![image](https://user-images.githubusercontent.com/58357644/104809171-19774c80-580d-11eb-8200-a77d316591b9.png)
Please ignore the undefined key here, it is from saving a project when the bug still persisted. 
