### PR TITLE
Fixed saveOffline functionality

### DIFF
--- a/public/src/data/project.js
+++ b/public/src/data/project.js
@@ -4,7 +4,7 @@
 /* eslint-disable no-restricted-globals */
 /* eslint-disable no-alert */
 import { resetScopeList, scopeList, newCircuit } from '../circuit';
-import { showMessage, showError } from '../utils';
+import { showMessage, showError, generateId } from '../utils';
 import { checkIfBackup } from './backupCircuit';
 import {generateSaveData, getProjectName, setProjectName} from './save';
 import load from './load';

--- a/public/src/data/project.js
+++ b/public/src/data/project.js
@@ -47,6 +47,7 @@ export function openOffline() {
             click() {
                 if (!$('input[name=projectId]:checked').val()) return;
                 load(JSON.parse(localStorage.getItem($('input[name=projectId]:checked').val())));
+                window.projectId = $('input[name=projectId]:checked').val();
                 $(this).dialog('close');
             },
         }] : [],

--- a/public/src/setup.js
+++ b/public/src/setup.js
@@ -79,6 +79,7 @@ window.addEventListener('orientationchange', resetup); // listener
 function setupEnvironment() {
     setupModules();
     const projectId = generateId();
+    window.projectId = projectId;
     updateSimulationSet(true);
     const DPR = window.devicePixelRatio || 1;
     newCircuit('Main');

--- a/public/src/utils.js
+++ b/public/src/utils.js
@@ -7,7 +7,7 @@ import plotArea from './plotArea';
 
 window.globalScope = undefined;
 window.lightMode = false; // To be deprecated
-window.projectId = generateId();
+window.projectId = undefined;
 window.id = undefined;
 window.loading = false; // Flag - all assets are loaded
 

--- a/public/src/utils.js
+++ b/public/src/utils.js
@@ -7,7 +7,7 @@ import plotArea from './plotArea';
 
 window.globalScope = undefined;
 window.lightMode = false; // To be deprecated
-window.projectId = undefined;
+window.projectId = generateId();
 window.id = undefined;
 window.loading = false; // Flag - all assets are loaded
 


### PR DESCRIPTION
Fixes #
A fix to issue #2026 

#### Describe the changes you have made in this PR -
I am setting the global variable projectId to the project id being generated in the setupEnvironment function in src/setup.js. It is being set to undefined in src/utils.js. Before this fix, this value remained undefined. Due to it being undefined, each project was being saved in the undefined key when trying to save projects offline. Now, each project is being correctly saved in its own project id.
After correcting this, I also found a bug where when a user loads a project offline the projectId value remained as the last time the projectId global variable was set. When a user loads a project, the projectId should be set to the newly loaded project's id. I fixed this by setting window.projectId to the newly loaded project's id, in the openOffline function in src/data/project.js.
Also, I fixed a generateId() is not defined error (file src/data/project.js, line 137), which occurred when New Project was clicked. This error happened because of not importing generateId function from src/utils.js in src/data/project.js.
### Screenshots of the changes (If any) -
![image](https://user-images.githubusercontent.com/58357644/104813086-aa0f5600-5828-11eb-83ca-c5814f8655cb.png)

