### PR TITLE
Do not allow admins to add themeselves as a member in the group

### DIFF
--- a/app/controllers/group_members_controller.rb
+++ b/app/controllers/group_members_controller.rb
@@ -37,7 +37,7 @@ class GroupMembersController < ApplicationController
     group_member_emails = Utils.parse_mails(group_member_params[:emails])
 
     present_members = User.where(id: @group.group_members.pluck(:user_id)).pluck(:email)
-    mentor =  User.where(id: @group[:mentor_id]).pluck(:email)
+    mentor = User.where(id: @group[:mentor_id]).pluck(:email)
     present_members += mentor
     newly_added = group_member_emails - present_members
 

--- a/app/controllers/group_members_controller.rb
+++ b/app/controllers/group_members_controller.rb
@@ -37,6 +37,8 @@ class GroupMembersController < ApplicationController
     group_member_emails = Utils.parse_mails(group_member_params[:emails])
 
     present_members = User.where(id: @group.group_members.pluck(:user_id)).pluck(:email)
+    mentor =  User.where(id: @group[:mentor_id]).pluck(:email)
+    present_members += mentor
     newly_added = group_member_emails - present_members
 
     newly_added.each do |email|

--- a/app/controllers/group_members_controller.rb
+++ b/app/controllers/group_members_controller.rb
@@ -37,8 +37,8 @@ class GroupMembersController < ApplicationController
     group_member_emails = Utils.parse_mails(group_member_params[:emails])
 
     present_members = User.where(id: @group.group_members.pluck(:user_id)).pluck(:email)
-    mentor = User.where(id: @group[:mentor_id]).pluck(:email)
-    present_members += mentor
+    mentor_email = @group.mentor.email
+    present_members.append(mentor_email)
     newly_added = group_member_emails - present_members
 
     newly_added.each do |email|

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -25,7 +25,7 @@ class GroupsController < ApplicationController
 
   def group_invite
     if Group.with_valid_token.exists?(group_token: params[:token])
-      if current_user.groups.exists?(id: @group)
+      if current_user.groups.exists?(id: @group) || current_user.id == @group.mentor_id
         notice = "Member is already present in the group."
       else
         current_user.group_members.create!(group: @group)


### PR DESCRIPTION
Fixes #2092 


Resolved the issue (Adding group owner as member). The owner of a group could add themselves as a member in the same group hence giving the owner dual functionality which was redundant.

Adding the owner as a member here ->
![image](https://user-images.githubusercontent.com/70352627/107934710-65e9af80-6fa6-11eb-9d64-0df13067cf0e.png)
Flashing user is already present ->
![image](https://user-images.githubusercontent.com/70352627/107934762-7732bc00-6fa6-11eb-961f-0a702059b59a.png)



