### PR TITLE
Added width to Timing Diagram Panel 

### DIFF
--- a/public/css/main.stylesheet.css
+++ b/public/css/main.stylesheet.css
@@ -697,6 +697,7 @@ div.icon img {
   cursor: pointer;
   left: 300px;
   top: 90px;
+  width: 500px;
 }
 
 .timing-diagram-panel .panel-header {


### PR DESCRIPTION
**Fixed Width of timing-diagram-panel**

#### Describe the changes you have made in this PR -

### Screenshots of the changes (If any) -
Hi,
This is my first contribution.
I was looking at CircuitVerse Simulator. In that the width of timing diagram is as follows:
![timing-diagram-panel](https://user-images.githubusercontent.com/77744862/110337244-b4d9b080-804b-11eb-8786-3551b15ce585.png)
 
That much width is not needed So I edited it as follows
![timing-diagram-panel-update](https://user-images.githubusercontent.com/77744862/110337471-f702f200-804b-11eb-8263-4f03378eb6e1.png)

Thank You
 


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
