### PR TITLE
modify gitpod configuration

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -22,7 +22,6 @@ tasks:
       bundle exec rails db:seed
     command: >
       sleep 5 &&
-      createuser -s postgres &&
       redis-server --daemonize yes &&
       bundle install --without production --path vendor/bundle &&
       yarn &&

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -18,7 +18,6 @@ tasks:
       bundle exec rails db:create &&
       bundle exec rails db:schema:load &&
       bundle exec rails db:migrate &&
-      bundle exec rake sunspot:solr:start &&
       bundle exec rails db:seed
     command: >
       sleep 5 &&


### PR DESCRIPTION
Fixes the following issue

the gitpod setup fails at this step and the remaining steps do not execute
![image](https://user-images.githubusercontent.com/40966318/111289216-f16c6400-866a-11eb-9bab-c40512c0fb34.png)

#### Describe the changes you have made in this PR -
The user was already being created in the `init` task, so removed the `createuser` command from the `command` task.

then I faced another issue, which said the solr process could not be started because it was already running...
this was happening as the command to start solr process was present in both `init` task and `command`  task...
so to resolve the issue, I removed the command from the `init` task

After doing the above changes, I tested it and it works fine now!