### PR TITLE
Made the Navbar Contents visible on top on Expanding

### DIFF
--- a/app/assets/stylesheets/simulator.scss
+++ b/app/assets/stylesheets/simulator.scss
@@ -45,7 +45,7 @@
 
 .navbar {
   align-items: center;
-  border-bottom: 1px solid #fff;
+  border-bottom: 1px solid var(--br-primary);
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;

--- a/app/assets/stylesheets/simulator.scss
+++ b/app/assets/stylesheets/simulator.scss
@@ -45,7 +45,7 @@
 
 .navbar {
   align-items: center;
-  border-bottom: 1px solid #ffffff;
+  border-bottom: 1px solid #fff;
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;

--- a/app/assets/stylesheets/simulator.scss
+++ b/app/assets/stylesheets/simulator.scss
@@ -43,13 +43,13 @@
   right: 0;
 }
 
-.navbar{
+.navbar {
   align-items: center;
-  border-bottom: 1px solid white;
+  border-bottom: 1px solid #ffffff;
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  padding: 0.5rem 1rem;
+  padding: .5rem 1rem;
   position: relative;
   z-index: 200;
 }

--- a/app/assets/stylesheets/simulator.scss
+++ b/app/assets/stylesheets/simulator.scss
@@ -42,3 +42,14 @@
 .report-sidebar a:hover {
   right: 0;
 }
+
+.navbar{
+  align-items: center;
+  border-bottom: 1px solid white;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+  position: relative;
+  z-index: 200;
+}

--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -90,7 +90,7 @@
 <div id="tabsBar" class="noSelect pointerCursor" style="position:relative;z-index:101;">
   <button class="logixButton" id="newCircuit" onclick="">&#43;</button>
 </div>
-<div ondrag="(() => {$('.quick-btn').css({'box-shadow': 'none', 'background': 'var(--bg-navbar)'})})()" class='quick-btn'>
+<div ondrag="(() => {$('.quick-btn').css({'box-shadow': 'none', 'background': 'var(--bg-navbar)'})})()" class='quick-btn' style="top:125px">
       <div id='dragQPanel' class='panel-drag'>
       <span><svg style="height: 20px;" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="18" height="31" viewBox="0 0 18 31">
         <defs>

--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -11,7 +11,7 @@
 </script>
 
 <div id='exitView'></div>
-<nav class="navbar navbar-expand-lg navbar-dark header">
+<nav class="navbar navbar-expand-lg navbar-dark header" style="position:relative;display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;padding:0.5rem 1rem;z-index:200;border-bottom:1px solid white;">
   <a href="/"><span class='logo'></span></a>
   <button class="navbar-toggler collapsed" type="button" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-controls="collapsedNavbar" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
@@ -67,10 +67,30 @@
     </ul>
       <span class="projectName noSelect defaultCursor font-weight-bold" id="projectName">
          Untitled
-      </span>
-
-
-    <div ondrag="(() => {$('.quick-btn').css({'box-shadow': 'none', 'background': 'var(--bg-navbar)'})})()" class='quick-btn'>
+      </span>   
+    </div>
+    <ul class="nav navbar-nav noSelect pointerCursor pull-right account-btn">
+      <li class="dropdown pull-right">
+        <% if user_signed_in? %>
+          <a href="#" class="cur-user acc-drop user-field" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><%= current_user.name %><span class="caret acc-caret"></span></a>
+          <ul class="dropdown-menu">
+            <li><a class="dropdown-item" href=<%= user_path(current_user) %>>Dashboard</a></li>
+            <li><a class="dropdown-item" href=<%= user_groups_path(current_user) %>>My Groups</a></li>
+            <div class="dropdown-divider"></div>
+            <li><a class="dropdown-item" rel="nofollow" data-method="delete" href=<%= destroy_user_session_path %>>Sign Out</a></li>
+          </ul>
+        <% else %>
+          <a class="navbar-nav signIn-btn user-field" href=<%= new_user_session_path %>> Sign In </a>
+        <% end %>
+      </li>
+    </ul>
+  </div>
+  <!-- /.navbar-collapse -->
+</nav>
+<div id="tabsBar" class="noSelect pointerCursor" style="position:relative;z-index:101;">
+  <button class="logixButton" id="newCircuit" onclick="">&#43;</button>
+</div>
+<div ondrag="(() => {$('.quick-btn').css({'box-shadow': 'none', 'background': 'var(--bg-navbar)'})})()" class='quick-btn'>
       <div id='dragQPanel' class='panel-drag'>
       <span><svg style="height: 20px;" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="18" height="31" viewBox="0 0 18 31">
         <defs>
@@ -136,29 +156,6 @@
           <span id='slider_value'></span>
         </div>
       </div>
-      
-    </div>
-    <ul class="nav navbar-nav noSelect pointerCursor pull-right account-btn">
-      <li class="dropdown pull-right">
-        <% if user_signed_in? %>
-          <a href="#" class="cur-user acc-drop user-field" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><%= current_user.name %><span class="caret acc-caret"></span></a>
-          <ul class="dropdown-menu">
-            <li><a class="dropdown-item" href=<%= user_path(current_user) %>>Dashboard</a></li>
-            <li><a class="dropdown-item" href=<%= user_groups_path(current_user) %>>My Groups</a></li>
-            <div class="dropdown-divider"></div>
-            <li><a class="dropdown-item" rel="nofollow" data-method="delete" href=<%= destroy_user_session_path %>>Sign Out</a></li>
-          </ul>
-        <% else %>
-          <a class="navbar-nav signIn-btn user-field" href=<%= new_user_session_path %>> Sign In </a>
-        <% end %>
-      </li>
-    </ul>
-  </div>
-  <!-- /.navbar-collapse -->
-</nav>
-<div id="tabsBar" class="noSelect pointerCursor">
-  <button class="logixButton" id="newCircuit" onclick="">&#43;</button>
-</div>
 <div title="Export Verilog" id="verilog-export-code-window-div" style="display:none"><textarea id="verilog-export-code-window"></textarea></div>
 <div id="code-window" class='code-window'><textarea id="codeTextArea"></textarea></div>
 <div class="modules noSelect defaultCursor ce-panel elementPanel draggable-panel draggable-panel-css " id="guide_1">
@@ -176,7 +173,7 @@
   </div>
 </div>
 
-<div class="noSelect defaultCursor layoutElementPanel draggable-panel draggable-panel-css ">
+<div class="noSelect defaultCursor layoutElementPanel draggable-panel draggable-panel-css" style="top:inherit;">
   <div class="panel-header">Layout Elements
   <span class="fas fa-minus-square minimize"></span>
   <span class="fas fa-external-link-square-alt maximize"></span>
@@ -232,7 +229,7 @@
   </div>
 </div>
 
-<div class="moduleProperty noSelect effect1 properties-panel draggable-panel draggable-panel-css  guide_2" id="moduleProperty">
+<div class="moduleProperty noSelect effect1 properties-panel draggable-panel draggable-panel-css  guide_2" id="moduleProperty" style="top:inherit;">
   <div id="moduleProperty-title" class="noSelect panel-header">Properties
   <span class="fas fa-minus-square minimize"></span>
   <span class="fas fa-external-link-square-alt maximize"></span>

--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -158,7 +158,7 @@
       </div>
 <div title="Export Verilog" id="verilog-export-code-window-div" style="display:none"><textarea id="verilog-export-code-window"></textarea></div>
 <div id="code-window" class='code-window'><textarea id="codeTextArea"></textarea></div>
-<div class="modules noSelect defaultCursor ce-panel elementPanel draggable-panel draggable-panel-css " id="guide_1">
+<div class="modules noSelect defaultCursor ce-panel elementPanel draggable-panel draggable-panel-css " id="guide_1" style="top:inherit;">
   <div class="panel-header">Circuit Elements
   <span class="fas fa-minus-square minimize"></span>
   <span class="fas fa-external-link-square-alt maximize"></span>
@@ -173,7 +173,7 @@
   </div>
 </div>
 
-<div class="noSelect defaultCursor layoutElementPanel draggable-panel draggable-panel-css" style="top:inherit;">
+<div class="noSelect defaultCursor layoutElementPanel draggable-panel draggable-panel-css">
   <div class="panel-header">Layout Elements
   <span class="fas fa-minus-square minimize"></span>
   <span class="fas fa-external-link-square-alt maximize"></span>

--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -11,7 +11,7 @@
 </script>
 
 <div id='exitView'></div>
-<nav class="navbar navbar-expand-lg navbar-dark header" style="position:relative;display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;padding:0.5rem 1rem;z-index:200;border-bottom:1px solid white;">
+<nav class="navbar navbar-expand-lg navbar-dark header">
   <a href="/"><span class='logo'></span></a>
   <button class="navbar-toggler collapsed" type="button" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-controls="collapsedNavbar" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
Fixes #2108 
Fixes #1945 
Fixed the Navbar for smaller screens and position of Quick-btn

#### Describe the changes you have made in this PR -
Initially, the Navbar contents on expanding were hidden below the widgets.
Now on expanding, the widgets slides down thus making space for the navbar contents to be displayed properly.
The position of Quick-btn is fixed which was initially overlapping the navbar contents.

### Screenshots of the changes (If any) -
Navbar-closed
![Closed](https://user-images.githubusercontent.com/61665451/111532451-aeee7880-878b-11eb-8218-18530ffe8bc2.png)
Navbar open
![Open](https://user-images.githubusercontent.com/61665451/111532467-b31a9600-878b-11eb-948f-5df42df5f0d3.png)



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
