### PR TITLE
Added hover effect on social media icons

### DIFF
--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -28,10 +28,10 @@
 
 .footer-social-icon {
   margin-left: 15px;
-  width: 32px;
-  top: 0;
   position: relative;
+  top: 0;
   transition: top ease .5s;
+  width: 32px;
 }
 
 .footer-social-icon:hover {

--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -29,6 +29,13 @@
 .footer-social-icon {
   margin-left: 15px;
   width: 32px;
+  top:0;
+  position: relative;
+  transition: top ease 0.5s;
+
+}
+.footer-social-icon:hover{
+    top: -10px;
 }
 
 .footer-links {

--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -29,13 +29,13 @@
 .footer-social-icon {
   margin-left: 15px;
   width: 32px;
-  top:0;
+  top: 0;
   position: relative;
-  transition: top ease 0.5s;
-
+  transition: top ease .5s;
 }
-.footer-social-icon:hover{
-    top: -10px;
+
+.footer-social-icon:hover {
+  top: -10px;
 }
 
 .footer-links {


### PR DESCRIPTION
Fixes #2149

#### Describe the changes you have made in this PR - Made the social media icons lifted up with their original icons upon hovering over them which matches with the hovering effect applied to the rest of the webpage.

### Screenshots of the changes (If any) -
![Screenshot (44)](https://user-images.githubusercontent.com/51615200/113130644-ec4a1000-9239-11eb-88b8-2c52dc23d4a6.png)




Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
