### PR TITLE
Bug Fix:Text-Icon-Alignment

### DIFF
--- a/app/assets/stylesheets/simulator.scss
+++ b/app/assets/stylesheets/simulator.scss
@@ -30,7 +30,7 @@
   text-decoration: none;
   bottom: 30px;
   transition: .3s;
-  width: 160px;
+  width: 170px;
   z-index: 999;
 }
 


### PR DESCRIPTION
Fixes #
Bug Fix: Text and Icon not aligned on issue reporting tool #2202
#### Describe the changes you have made in this PR -
"Report an issue" wasn't on the same line. So, changes the width from 160px to 170px .
### Screenshots of the changes (If any) -
Before fix :
![Before image](https://user-images.githubusercontent.com/49101492/113289539-f9383380-930d-11eb-80be-991172c92a4b.png)
After fix :
![After image](https://user-images.githubusercontent.com/49101492/113289667-21279700-930e-11eb-9e61-33326a069064.png)
Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
