### PR TITLE
Fix AND,OR gate negative values and dirty workaround for Decoder 

### DIFF
--- a/simulator/src/modules/AndGate.js
+++ b/simulator/src/modules/AndGate.js
@@ -101,7 +101,7 @@ export default class AndGate extends CircuitElement {
         }
         for (let i = 1; i < this.inputSize; i++)
             result &= this.inp[i].value || 0;
-        this.output1.value = result;
+        this.output1.value = result >>> 0;
         simulationArea.simulationQueue.add(this.output1);
     }
 

--- a/simulator/src/modules/Decoder.js
+++ b/simulator/src/modules/Decoder.js
@@ -113,7 +113,7 @@ export default class Decoder extends CircuitElement {
         for (let i = 0; i < this.output1.length; i++) {
             this.output1[i].value = 0;
         }
-        this.output1[this.input.value].value = 1;
+        if(this.input.value !== undefined) this.output1[this.input.value].value = 1; // if input is undefined, don't change output
         for (let i = 0; i < this.output1.length; i++) {
             simulationArea.simulationQueue.add(this.output1[i]);
         }

--- a/simulator/src/modules/OrGate.js
+++ b/simulator/src/modules/OrGate.js
@@ -94,7 +94,7 @@ export default class OrGate extends CircuitElement {
         }
         for (let i = 1; i < this.inputSize; i++)
             result |= this.inp[i].value || 0;
-        this.output1.value = result;
+        this.output1.value = result >>> 0;
         simulationArea.simulationQueue.add(this.output1);
     }
 


### PR DESCRIPTION
#### Describe the changes you have made in this PR -
1 . AND and OR gate negative values are 2's complemented instead of '-' sign
2. Dirty workaround for when Decoder calls resolve on undefined values




Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
