### PR TITLE
i18n Task - GSoC 2021

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -50,6 +50,6 @@ class Api::V1::UsersController < Api::V1::BaseController
     end
 
     def user_params
-      params.permit(:name, :educational_institute, :country, :subscribed)
+      params.permit(:name, :educational_institute, :country, :subscribed, :locale)
     end
 end

--- a/app/views/logix/teachers.html.erb
+++ b/app/views/logix/teachers.html.erb
@@ -2,19 +2,19 @@
 
 <div class="row center-row">
   <div class="col-12">
-    <h1 class="main-heading">TEACHERS</h1>
+    <h1 class="main-heading"><%= t("teachers.teacher.title") %></h1>
     <div class="teacher-main-description-container">
-      <p class="main-description">CircuitVerse has been designed to be very easy to use in class. The platform has features to assist teachers in class and assignments.</p>
+      <p class="main-description"><%= t("teachers.teacher.description") %></p>
     </div> <br>
-    <h2>Benefits</h2>
+    <h2><%= t("teachers.benefits.title") %></h2>
   </div>
 </div>
 <div class="container-fluid teacher-fill-container-fluid">
   <div class="container">
     <div class="row center-row teacher-center-content">
       <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 teacher-left-text">
-        <h4>Create Groups and add your students</h4> <br>
-        <p>You can create groups and add your students to them! If students are already registered with CircuitVerse they will be added automatically. If they are not registered with CircuitVerse yet, an invitation will be sent to register. Once they register, they will be added automatically.</p>
+        <h4><%= t("teachers.benefits.create_group.heading") %></h4> <br>
+        <p><%= t("teachers.benefits.create_group.description") %></p>
       </div>
       <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6">
         <img class="teacher-image" src="img/groups.png" alt="Groups screenshot">
@@ -26,8 +26,8 @@
   <div class="container">
     <div class="row center-row teacher-center-content">
       <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 teacher-left-text">
-        <h4>Post Assignments</h4> <br>
-        <p>To create an assignment, simply click the add new assignment button. Give the details of the assignment and the deadline. The assignment will automatically close at the deadline. Students cannot continue their assignment unless the teacher reopens the assignment again.</p>
+        <h4><%= t("teachers.benefits.post_assignments.heading") %></h4> <br>
+        <p><%= t("teachers.benefits.post_assignments.description") %></p>
       </div>
       <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6">
         <img class="teacher-image" src="img/assignment.png" alt="Assignments screenshot">
@@ -39,8 +39,8 @@
   <div class="container">
     <div class="row center-row teacher-center-content">
       <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 teacher-left-text">
-        <h4>Grading assignments</h4> <br>
-        <p>Grade assignments very easily with the in build preview. Simply select the student, to his/her assignment work.</p>
+        <h4><%= t("teachers.benefits.grade_assignment.title") %></h4> <br>
+        <p><%= t("teachers.benefits.grade_assignment.description") %></p>
       </div>
       <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6">
         <img class="teacher-image" src="img/grading.png" alt="Grading screenshot" height="250px">
@@ -52,8 +52,8 @@
   <div class="container">
     <div class="row center-row teacher-center-content">
       <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 teacher-left-text">
-        <h4>Use Interactive Circuits in your Blogs, Study Materials, or PowerPoint presentations</h4> <br>
-        <p>Make sure the project is public. Click on embed, to get the embed HTML5 code, then simply embed the circuit. You may need to use a PowerPoint plugin like Live Slides to embed the live Circuit.</p>
+        <h4><%= t("teachers.benefits.use_interactive_circuits.heading") %></h4> <br>
+        <p><%= t("teachers.benefits.use_interactive_circuits.description") %></p>
       </div>
       <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6">
         <img class="teacher-image" src="img/embed.png" alt="Embed screenshot" height="350px">

--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -19,7 +19,7 @@
   <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
     <ul class="navbar-nav navbar-menu noSelect pointerCursor" id="toolbar">
       <li class="dropdown nav-dropdown">
-        <a href="#" class="" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Project<span></span></a>
+        <a href="#" class="" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><%= t("simulator.project.title") %><span></span></a>
         <ul class="dropdown-menu">
           <% if not @project.nil? %>
              <li><a class="dropdown-item logixButton text-left pl-1" href="<%= user_project_url(@project.author, @project) %>" target="_blank">Project Page</a></li>
@@ -35,7 +35,7 @@
         </ul>
       </li>
       <li class="dropdown nav-dropdown">
-        <a href="#" class="" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Circuit<span class="caret"></span></a>
+        <a href="#" class="" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><%= t("simulator.circuit.title") %><span class="caret"></span></a>
         <ul class="dropdown-menu">
           <li><a class="dropdown-item text-left logixButton pl-1" id="newCircuit">New Circuit + </a></li>
           <li><a class="dropdown-item text-left logixButton pl-1" id="newVerilogModule">New Verilog <br> Module</a></li>
@@ -43,7 +43,7 @@
         </ul>
       </li>
       <li class="dropdown nav-dropdown">
-        <a href="#" class="" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Tools<span class="caret"></span></a>
+        <a href="#" class="" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><%= t("simulator.tools.title") %><span class="caret"></span></a>
         <ul class="dropdown-menu">
           <li><a class="dropdown-item text-left pl-1 logixButton" id="createCombinationalAnalysisPrompt">Combinational<br>Analysis</a></li>
           <li><a class="dropdown-item text-left pl-1 logixButton" id="bitconverter">Hex-Bin-Dec<br>Converter</a></li>
@@ -54,7 +54,7 @@
         </ul>
       </li>
       <li class="dropdown tour-help nav-dropdown">
-        <a href="#" class="" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help<span class="caret"></span></a>
+        <a href="#" class="" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><%= t("simulator.help.title") %><span class="caret"></span></a>
         <ul class="dropdown-menu">
             <li><a class="dropdown-item text-left pl-1 logixButton" id="showTourGuide">Tutorial Guide</a></li>
             <li><a class="dropdown-item text-left pl-1" href="https://docs.circuitverse.org" class="" target="_blank" role="button" aria-haspopup="true" aria-expanded="false">User Manual</a></li>

--- a/app/views/users/logix/edit.html.erb
+++ b/app/views/users/logix/edit.html.erb
@@ -34,7 +34,8 @@
           </div>
           <div class="field form-group">
             <h6><%= f.label :locale %></h6>
-            <%= f.select :locale, I18n.available_locales, { prompt: 'Select the locale' }, { class: 'form-control form-input' } %>
+            
+            <%= f.select :locale, [["English", "en"], ["Chinese (PRC)", "zh-cn"], ["Japanese", "ja"], ["Hindi", "hi"], ["Bahasa Indonesia", "id"]], { prompt: 'Select the locale' }, { class: 'form-control form-input' } %>
           </div>
           <div class="field form-group users-edit-primary-checkpoint">
             <label for="profile_subscribed" class="primary-checkpoint-container"><h6>Subscribed to mails?</h6>

--- a/config/locales/devise.id.yml
+++ b/config/locales/devise.id.yml
@@ -1,0 +1,65 @@
+# Additional translations at https://github.com/plataformatec/devise/wiki/I18n
+
+id:
+  devise:
+    confirmations:
+      confirmed: "Email anda telah berhasil dikonfirmasi."
+      send_instructions: "Anda akan menerima sebuah email dengan instruksi bagaimana cara untuk mengkonfirmasikan email anda."
+      send_paranoid_instructions: "Jika email anda telah terdaftar, anda akan menerima email dengan instruksi bagaimana cara untuk mengkonfirmasikan email anda."
+    failure:
+      already_authenticated: "Anda telah masuk."
+      inactive: "Akun anda belum diaktifkan."
+      invalid: "%{authentication_keys} atau sandi anda tidak cocok."
+      locked: "Akun anda terkunci."
+      last_attempt: "Anda memiliki 1 kali kesempatan sebelum akun anda dikunci."
+      not_found_in_database: "%{authentication_keys} atau sandi anda tidak cocok."
+      timeout: "Sesi anda telah berakhir. Silahkan masuk kembali untuk melanjutkan"
+      unauthenticated: "Anda perlu untuk masuk atau daftar sebelum melanjutkan."
+      unconfirmed: "Anda harus mengkonfirmasi email anda terlebih dahulu sebelum melanjutkan."
+    mailer:
+      confirmation_instructions:
+        subject: "Instruksi untuk Konfirmasi"
+      reset_password_instructions:
+        subject: "Instruksi untuk Mereset Sandi"
+      unlock_instructions:
+        subject: "Instruksi untuk Membuka Kunci"
+      email_changed:
+        subject: "Email berubah"
+      password_change:
+        subject: "Sandi berubah"
+    omniauth_callbacks:
+      failure: 'Tidak dapat mengautentikasi anda dari %{kind} dikarenakan "%{reason}".'
+      success: "Autentikasi berhasil dari akun %{kind}."
+    passwords:
+      no_token: "Anda tidak dapat mengakses halaman ini tanpa melalui email yang menginstruksikan cara untuk mereset sandi. Jika anda benar membuka tautan dari email reset password, maka pastikan anda memasukkan URL secara utuh."
+      send_instructions: "Anda akan menerima email dengan instruksi cara untuk mereset sandi anda."
+      send_paranoid_instructions: "Jika email anda telah terdaftar, anda akan menerima tautan untuk memulihkan sandi anda."
+      updated: "Sandi anda berhasil diubah dan anda telah dimasukkan."
+      updated_not_active: "Sandi anda berhasil diubah."
+    registrations:
+      destroyed: "Sampai jumpa! Akun anda telah dibatalkan. Kami berharap bertemu lagi dengan anda."
+      signed_up: "Selamat Datang! Anda telah berhasil masuk."
+      signed_up_but_inactive: "Anda telah berhasil terdaftar. Tetapi, kami tidak dapat memasukkan anda dikarenakan akun anda belum diaktifkan."
+      signed_up_but_locked: "Anda telah berhasil terdaftar. Tetapi, kami tidak dapat memasukkan anda dikarenakan akun anda terkunci."
+      signed_up_but_unconfirmed: "Sebuah pesan dengan tautan untuk konfirmasi telah di kirim ke alamat email anda. Mohon untuk mengikuti tautan yang ada untuk mengaktifkan akun anda."
+      update_needs_confirmation: "Akun anda telah berhasil diubah, mohon verifikasi email anda. Cek email anda dan ikuti cara yang dicantumkan untuk mengkonfirmasi email anda."
+      updated: "Akun anda telah berhasil diubah."
+      updated_but_not_signed_in: "Akun Anda telah berhasil diperbarui, tetapi karena kata sandi Anda diubah, Anda harus masuk lagi"
+    sessions:
+      signed_in: "Anda telah berhasil masuk."
+      signed_out: "Anda telah berhasil keluar."
+      already_signed_out: "Anda telah berhasil keluar."
+    unlocks:
+      send_instructions: "Anda akan menerima email dengan instruksi bagaimana cara untuk membuka kunci pada akun anda."
+      send_paranoid_instructions: "Jika akun anda terdaftar, anda akan menerima email dengan instruksi bagaimana cara untuk membuka kunci pada akun anda."
+      unlocked: "Akun anda telah berhasil dibuka. Silahkan masuk untuk melanjutkan."
+  errors:
+    messages:
+      already_confirmed: "telah dikonfirmasi, Silahkan coba untuk masuk"
+      confirmation_period_expired: "butuh dikonfirmasi dalam waktu %{period}, tolong anda minta kembali"
+      expired: "telah habis masa berlakunya, tolong anda minta kembali"
+      not_found: "tidak dapat kami temukan"
+      not_locked: "tidak terkunci"
+      not_saved:
+        one: "1 masalah menghalangi %{resource} untuk dapat disimpan:"
+        other: "%{count} masalah menghalangi %{resource} untuk dapat disimpan:"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,43 @@ en:
   hello: "Hello world"
 
 # Used in distance_of_time_in_words(), distance_of_time_in_words_to_now(), time_ago_in_words()
+  teachers:
+    title: "CircuitVerse - Teachers"
+    teacher: 
+      title: "TEACHERS"
+      description: "CircuitVerse has been designed to be very easy to use in class. The platform has features to assist teachers in class and assignments."
+    benefits:
+      title: "Benefits"
+      create_group:
+        heading: "Create Groups and add your students"
+        description: "You can create groups and add your students to them! If students are already registered with CircuitVerse they will be added automatically. If they are not registered with CircuitVerse yet, an invitation will be sent to register. Once they register, they will be added automatically."
+      post_assignments:
+        heading: "Post Assignments"
+        description: "To create an assignment, simply click the add new assignment button. Give the details of the assignment and the deadline. The assignment will automatically close at the deadline. Students cannot continue their assignment unless the teacher reopens the assignment again."
+      grade_assignment:
+        heading: "Grading assignments"
+        description: "Grade assignments very easily with the in build preview. Simply select the student, to his/her assignment work."
+      use_interactive_circuits:
+        heading: "Use Interactive Circuits in your Blogs, Study Materials, or PowerPoint presentations"
+        description: "Make sure the project is public. Click on embed, to get the embed HTML5 code, then simply embed the circuit. You may need to use a PowerPoint plugin like Live Slides to embed the live Circuit." 
+  
+  simulator:
+    project:
+      title: "Project"
+      new_project: "New Project"
+
+    circuit:
+      title: "Circuit"
+      new_circuit_plus: "New Circuit +"
+
+    tools:
+      title: "Tools"
+      combinational_analysis: "Combinational Analysis"
+
+    help:
+      title: "Help"
+      tutorial_guide: "Tutorial Guide"
+  
   datetime:
     distance_in_words:
       half_a_minute: "half a minute"

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -1,0 +1,75 @@
+id:
+# Used in distance_of_time_in_words(), distance_of_time_in_words_to_now(), time_ago_in_words()
+  teachers:
+    title: "CircuitVerse - Pengajar"
+    teacher: 
+      title: "PENGAJAR"
+      description: "CircuitVerse telah di desain untuk digunakan secara mudah di kelas. Platform ini memiliki banyak fitur untuk membantu pengajar di kelas maupun pengerjaan tugas."
+    benefits:
+      title: "Keuntungan"
+      create_group:
+        heading: "Buat Grup dan tambahkan siswa anda."
+        description: "Anda dapat membuat grup dan menambahkan siswa Anda ke dalamnya! Jika siswa sudah terdaftar dengan CircuitVerse, mereka akan ditambahkan secara otomatis. Jika mereka belum terdaftar di CircuitVerse, undangan akan dikirim untuk mendaftar. Setelah mereka mendaftar, mereka akan ditambahkan secara otomatis."
+      post_assignments:
+        heading: "Posting tugas"
+        description: "Untuk membuat tugas, cukup klik tombol tambahkan tugas baru. Berikan detail tugas dan tenggat waktunya. Tugas akan ditutup secara otomatis pada tenggat waktu. Siswa tidak dapat melanjutkan tugasnya kecuali pengajar membuka kembali tugasnya."
+      grade_assignment:
+        heading: "Menilai tugas"
+        description: "Menilai tugas dengan sangat mudah dengan pratinjau dalam versi build. Cukup pilih siswa dan tugas yang ia kerjakan."
+      use_interactive_circuits:
+        heading: "Gunakan Sirkuit Interaktif di Blog, Materi Studi, atau presentasi PowerPoint Anda."
+        description: "Pastikan proyek tersebut publik. Klik sematkan, untuk mendapatkan kode embed HTML5, lalu cukup sematkan sirkuit. Anda mungkin perlu menggunakan plugin PowerPoint seperti Live Slides untuk menyematkan Sirkuit langsung." 
+
+  simulator:
+    project:
+      title: "Proyek"
+      new_project: "Buat Proyek"
+
+    circuit:
+      title: "Sirkuit"
+      new_circuit_plus: "Tambah Sirkuit"
+
+    tools:
+      title: "Alat"
+      combinational_analysis: "Analisis Kombinasi"
+
+    help:
+      title: "Bantuan"
+      tutorial_guide: "Bantuan Tutorial"
+  
+  datetime:
+    distance_in_words:
+      half_a_minute: "setengah menit"
+      less_than_x_seconds:
+        one:   "1 detik" # default was: "less than 1 second"
+        other: "%{count} detik" # default was: "less than %{count} seconds"
+      x_seconds:
+        one:   "1 detik"
+        other: "%{count} detik"
+      less_than_x_minutes:
+        one:   "a menit" # default was: "less than a minute"
+        other: "%{count} menit" # default was: "less than %{count} minutes"
+      x_minutes:
+        one:   "1 menit"
+        other: "%{count} menit"
+      about_x_hours:
+        one:   "1 jam" # default was: "about 1 hour"
+        other: "%{count} jam" # default was: "about %{count} hours"
+      x_days:
+        one:   "1 hari"
+        other: "%{count} hari"
+      about_x_months:
+        one:   "1 bulan" # default was: "about 1 month"
+        other: "%{count} bulan" # default was: "about %{count} months"
+      x_months:
+        one:   "1 bulan"
+        other: "%{count} bulan"
+      about_x_years:
+        one:   "1 tahun" # default was: "about 1 year"
+        other: "%{count} tahun" # default was: "about %{count} years"
+      over_x_years:
+        one:   "1 tahun" # default was: "over 1 year"
+        other: "%{count} tahun" # default was: "over %{count} years"
+      almost_x_years:
+        one:   "1 tahun" # default was: "almost 1 year"
+        other: "%{count} tahun" # default was: "almost %{count} years"


### PR DESCRIPTION
Fixes #849 

#### Describe the changes you have made in this PR -
Following the starter task for GSoC provided in [here](https://gist.github.com/tachyons/8eac33b3b44aed2364abdc6485bf596c)

- [x] Currently circuitverse allows user to change locale from user edit page, currently it lists locales as ml, ja etc,
List full name of the locale there
- [x] Translate [teachers page](https://circuitverse.org/teachers) using i18n to a non English language, 
you can use google translate for text incase English is the only language you are familiar with
- [x] Add locale of the user in CV api
- [x] Get the locale value to simulator and translate top menu (Project, Circuit, Tools, Help)

### Screenshots of the changes (If any) -

- User Edit Page (Locale)
![image](https://user-images.githubusercontent.com/48849323/114514563-9e83cd80-9c65-11eb-98f6-c1409ae90202.png)
- Translation for Indonesia Language
![image](https://user-images.githubusercontent.com/48849323/114514719-ca9f4e80-9c65-11eb-9a26-2e59b8a15e59.png)
- Translation for Simulator (For now, i just translate the top menu)
![image](https://user-images.githubusercontent.com/48849323/114514867-f0c4ee80-9c65-11eb-932d-6bbc99978599.png)


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
