### PR TITLE
Fix: Improper forking of assignment submissions

### DIFF
--- a/app/jobs/assignment_deadline_submission_job.rb
+++ b/app/jobs/assignment_deadline_submission_job.rb
@@ -17,9 +17,8 @@ class AssignmentDeadlineSubmissionJob < ApplicationJob
           assignment.projects.each do |proj|
             next unless proj.project_submission == false
 
-            submission = proj.dup
+            submission = proj.fork(proj.author)
             submission.project_submission = true
-            submission.forked_project_id = proj.id
             proj.assignment_id = nil
             proj.save!
             submission.save!


### PR DESCRIPTION
Fixes Bug where group mentor could not see submissions post assignment deadline

#### Describe the changes you have made in this PR -
Proper forking of submission projects


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
