### PR TITLE
Fixed Positioning of ContextMenu

### DIFF
--- a/simulator/src/ux.js
+++ b/simulator/src/ux.js
@@ -72,50 +72,50 @@ function showContextMenu() {
     });
     var windowHeight = $(window).height() / 2;
     var windowWidth = $(window).width() / 2;
-    //for top, left, right, bottom position calculation
-    var t;
-    var l;
-    var r;
-    var b;
+    // for top, left, right, bottom
+    var topPos;
+    var leftPos;
+    var rightPos;
+    var bottomPos;
     if (ctxPos.y > windowHeight && ctxPos.x <= windowWidth) {
         //When user click on bottom-left part of window
-        l = ctxPos.x;
-        b = $(window).height() - ctxPos.y;
+        leftPos = ctxPos.x;
+        bottomPos = $(window).height() - ctxPos.y;
         $("#contextMenu").css({
-            left: `${l}px`,
-            bottom: `${b}px`,
+            left: `${leftPos}px`,
+            bottom: `${bottomPos}px`,
             right: 'auto',
             top: 'auto',
         });
     } else if (ctxPos.y > windowHeight && ctxPos.x > windowWidth) {
         //When user click on bottom-right part of window
-        b = $(window).height() - ctxPos.y;
-        r = $(window).width() - ctxPos.x;
+        bottomPos = $(window).height() - ctxPos.y;
+        rightPos = $(window).width() - ctxPos.x;
         $("#contextMenu").css({
             left: 'auto',
-            bottom: `${b}px`,
-            right: `${r}px`,
+            bottom: `${bottomPos}px`,
+            right: `${rightPos}px`,
             top: 'auto',
         });
     } else if (ctxPos.y <= windowHeight && ctxPos.x <= windowWidth) {
         //When user click on top-left part of window
-        l = ctxPos.x;
-        t = ctxPos.y;
+        leftPos = ctxPos.x;
+        topPos = ctxPos.y;
         $("#contextMenu").css({
-            left: `${l}px`,
+            left: `${leftPos}px`,
             bottom: 'auto',
             right: 'auto',
-            top: `${t}px`,
+            top: `${topPos}px`,
         });
     } else {
         //When user click on top-right part of window
-        r = $(window).width() - ctxPos.x;
-        t = ctxPos.y;
+        rightPos = $(window).width() - ctxPos.x;
+        topPos = ctxPos.y;
         $("#contextMenu").css({
             left: 'auto',
             bottom: 'auto',
-            right: `${r}px`,
-            top: `${t}px`,
+            right: `${rightPos}px`,
+            top: `${topPos}px`,
         });
     }
     ctxPos.visible = true;

--- a/simulator/src/ux.js
+++ b/simulator/src/ux.js
@@ -69,9 +69,42 @@ function showContextMenu() {
     $('#contextMenu').css({
         visibility: 'visible',
         opacity: 1,
-        top: `${ctxPos.y}px`,
-        left: `${ctxPos.x}px`,
     });
+    var windowHeight = $(window).height() / 2;
+    var windowWidth = $(window).width() / 2;
+    if (ctxPos.y > windowHeight && ctxPos.x <= windowWidth) {
+        //When user click on bottom-left part of window
+        $("#contextMenu").css({
+            left: ctxPos.x + 'px',
+            bottom: $(window).height() - ctxPos.y + 'px',
+            right: 'auto',
+            top: 'auto',
+        });
+    } else if (ctxPos.y > windowHeight && ctxPos.x > windowWidth) {
+        //When user click on bottom-right part of window
+        $("#contextMenu").css({
+            left: 'auto',
+            bottom: $(window).height() - ctxPos.y + 'px',
+            right: $(window).width() - ctxPos.x + 'px',
+            top: 'auto',
+        });
+    } else if (ctxPos.y <= windowHeight && ctxPos.x <= windowWidth) {
+        //When user click on top-left part of window
+        $("#contextMenu").css({
+            left: ctxPos.x + 'px',
+            bottom: 'auto',
+            right: 'auto',
+            top: ctxPos.y + 'px',
+        });
+    } else {
+        //When user click on top-right part of window
+        $("#contextMenu").css({
+            left: 'auto',
+            bottom: 'auto',
+            right: $(window).width() - ctxPos.x + 'px',
+            top: ctxPos.y + 'px',
+        });
+    }
     ctxPos.visible = true;
     return false;
 }

--- a/simulator/src/ux.js
+++ b/simulator/src/ux.js
@@ -72,7 +72,11 @@ function showContextMenu() {
     });
     var windowHeight = $(window).height() / 2;
     var windowWidth = $(window).width() / 2;
-    var t, l, r, b;    // for top, left, right, bottom
+    //for top, left, right, bottom position calculation
+    var t;
+    var l;
+    var r;
+    var b;
     if (ctxPos.y > windowHeight && ctxPos.x <= windowWidth) {
         //When user click on bottom-left part of window
         l = ctxPos.x;

--- a/simulator/src/ux.js
+++ b/simulator/src/ux.js
@@ -72,37 +72,46 @@ function showContextMenu() {
     });
     var windowHeight = $(window).height() / 2;
     var windowWidth = $(window).width() / 2;
+    var t, l, r, b;    // for top, left, right, bottom
     if (ctxPos.y > windowHeight && ctxPos.x <= windowWidth) {
         //When user click on bottom-left part of window
+        l = ctxPos.x;
+        b = $(window).height() - ctxPos.y;
         $("#contextMenu").css({
-            left: ctxPos.x + 'px',
-            bottom: $(window).height() - ctxPos.y + 'px',
+            left: `${l}px`,
+            bottom: `${b}px`,
             right: 'auto',
             top: 'auto',
         });
     } else if (ctxPos.y > windowHeight && ctxPos.x > windowWidth) {
         //When user click on bottom-right part of window
+        b = $(window).height() - ctxPos.y;
+        r = $(window).width() - ctxPos.x;
         $("#contextMenu").css({
             left: 'auto',
-            bottom: $(window).height() - ctxPos.y + 'px',
-            right: $(window).width() - ctxPos.x + 'px',
+            bottom: `${b}px`,
+            right: `${r}px`,
             top: 'auto',
         });
     } else if (ctxPos.y <= windowHeight && ctxPos.x <= windowWidth) {
         //When user click on top-left part of window
+        l = ctxPos.x;
+        t = ctxPos.y;
         $("#contextMenu").css({
-            left: ctxPos.x + 'px',
+            left: `${l}px`,
             bottom: 'auto',
             right: 'auto',
-            top: ctxPos.y + 'px',
+            top: `${t}px`,
         });
     } else {
         //When user click on top-right part of window
+        r = $(window).width() - ctxPos.x;
+        t = ctxPos.y;
         $("#contextMenu").css({
             left: 'auto',
             bottom: 'auto',
-            right: $(window).width() - ctxPos.x + 'px',
-            top: ctxPos.y + 'px',
+            right: `${r}px`,
+            top: `${t}px`,
         });
     }
     ctxPos.visible = true;


### PR DESCRIPTION
Dynamic Position of context-menu depending upon the position of the click on the screen.

Fixes #2145 
Before the context menu moved out of the screen on clicking on corners or at certain places.
![context-menu-error](https://user-images.githubusercontent.com/61665451/118358961-c5a02880-b59e-11eb-8b55-aba7a74a8c4c.gif)



#### Describe the changes you have made in this PR -
Added check conditions for the location of the click on the screen and rendering positioning of context-menu accordingly.

### Screenshots of the changes (If any) -
![context-menu](https://user-images.githubusercontent.com/61665451/118358920-97bae400-b59e-11eb-9d4b-ecf95d1f4960.gif)


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
