### PR TITLE
Navbar disapper during tutorial guide

### DIFF
--- a/app/assets/stylesheets/simulator.scss
+++ b/app/assets/stylesheets/simulator.scss
@@ -55,7 +55,7 @@
   top: 46px;
 }
 
-.navbar-toggler{
+.navbar-toggler {
   font-size: 1.02rem;
-  padding: 0.15rem 0.75rem;
+  padding: .15rem .75rem;
 }

--- a/app/assets/stylesheets/simulator.scss
+++ b/app/assets/stylesheets/simulator.scss
@@ -43,19 +43,19 @@
   right: 0;
 }
 
-
-.navbar{
+.navbar {
   position: inherit;
   top: 0;
   width: 100vw;
   z-index: 10000;
 }
-#tabsbar{
+
+#tabsbar {
   position: inherit;
   top: 46px;
 }
 
 .navbar-toggler{
-  padding: 0.15rem 0.75rem;
   font-size: 1.02rem;
+  padding: 0.15rem 0.75rem;
 }

--- a/app/assets/stylesheets/simulator.scss
+++ b/app/assets/stylesheets/simulator.scss
@@ -42,3 +42,20 @@
 .report-sidebar a:hover {
   right: 0;
 }
+
+
+.navbar{
+  position: inherit;
+  top: 0;
+  width: 100vw;
+  z-index: 10000;
+}
+#tabsbar{
+  position: inherit;
+  top: 46px;
+}
+
+.navbar-toggler{
+  padding: 0.15rem 0.75rem;
+  font-size: 1.02rem;
+}

--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -68,9 +68,47 @@
       <span class="projectName noSelect defaultCursor font-weight-bold" id="projectName">
          Untitled
       </span>
+      
+    </div>
+    <ul class="nav navbar-nav noSelect pointerCursor pull-right account-btn">
+      <li class="dropdown pull-right">
+        <% if user_signed_in? %>
+          <a href="#" class="cur-user acc-drop user-field" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><%= current_user.name %><span class="caret acc-caret"></span></a>
+          <ul class="dropdown-menu">
+            <li><a class="dropdown-item" href=<%= user_path(current_user) %>>Dashboard</a></li>
+            <li><a class="dropdown-item" href=<%= user_groups_path(current_user) %>>My Groups</a></li>
+            <div class="dropdown-divider"></div>
+            <li><a class="dropdown-item" rel="nofollow" data-method="delete" href=<%= destroy_user_session_path %>>Sign Out</a></li>
+          </ul>
+        <% else %>
+          <a class="navbar-nav signIn-btn user-field" href=<%= new_user_session_path %>> Sign In </a>
+        <% end %>
+      </li>
+    </ul>
+  </div>
+  <!-- /.navbar-collapse -->
+</nav>
+<div id="tabsBar" class="noSelect pointerCursor">
+  <button class="logixButton" id="newCircuit" onclick="">&#43;</button>
+</div>
+<div title="Export Verilog" id="verilog-export-code-window-div" style="display:none"><textarea id="verilog-export-code-window"></textarea></div>
+<div id="code-window" class='code-window'><textarea id="codeTextArea"></textarea></div>
+<div class="modules noSelect defaultCursor ce-panel elementPanel draggable-panel draggable-panel-css " id="guide_1">
+  <div class="panel-header">Circuit Elements
+  <span class="fas fa-minus-square minimize"></span>
+  <span class="fas fa-external-link-square-alt maximize"></span>
+  </div>
+  <div class="panel-body" id="testid">
+    <div style="position: relative;">
+    <input type="text" class="search-input" value="" placeholder="Search..">
+    <span><i class="fas search-close fa-times-circle"></i></span>
+    </div>
+    <div class="search-results"></div>
+    <div class="accordion" id="menu"></div>
+  </div>
+</div>
 
-
-    <div ondrag="(() => {$('.quick-btn').css({'box-shadow': 'none', 'background': 'var(--bg-navbar)'})})()" class='quick-btn'>
+<div ondrag="(() => {$('.quick-btn').css({'box-shadow': 'none', 'background': 'var(--bg-navbar)'})})()" class='quick-btn'>
       <div id='dragQPanel' class='panel-drag'>
       <span><svg style="height: 20px;" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="18" height="31" viewBox="0 0 18 31">
         <defs>
@@ -138,45 +176,6 @@
           <button class="zoom-slider-increment" id="increment">+</button>
         </div>
       </div>
-      
-    </div>
-    <ul class="nav navbar-nav noSelect pointerCursor pull-right account-btn">
-      <li class="dropdown pull-right">
-        <% if user_signed_in? %>
-          <a href="#" class="cur-user acc-drop user-field" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><%= current_user.name %><span class="caret acc-caret"></span></a>
-          <ul class="dropdown-menu">
-            <li><a class="dropdown-item" href=<%= user_path(current_user) %>>Dashboard</a></li>
-            <li><a class="dropdown-item" href=<%= user_groups_path(current_user) %>>My Groups</a></li>
-            <div class="dropdown-divider"></div>
-            <li><a class="dropdown-item" rel="nofollow" data-method="delete" href=<%= destroy_user_session_path %>>Sign Out</a></li>
-          </ul>
-        <% else %>
-          <a class="navbar-nav signIn-btn user-field" href=<%= new_user_session_path %>> Sign In </a>
-        <% end %>
-      </li>
-    </ul>
-  </div>
-  <!-- /.navbar-collapse -->
-</nav>
-<div id="tabsBar" class="noSelect pointerCursor">
-  <button class="logixButton" id="newCircuit" onclick="">&#43;</button>
-</div>
-<div title="Export Verilog" id="verilog-export-code-window-div" style="display:none"><textarea id="verilog-export-code-window"></textarea></div>
-<div id="code-window" class='code-window'><textarea id="codeTextArea"></textarea></div>
-<div class="modules noSelect defaultCursor ce-panel elementPanel draggable-panel draggable-panel-css " id="guide_1">
-  <div class="panel-header">Circuit Elements
-  <span class="fas fa-minus-square minimize"></span>
-  <span class="fas fa-external-link-square-alt maximize"></span>
-  </div>
-  <div class="panel-body" id="testid">
-    <div style="position: relative;">
-    <input type="text" class="search-input" value="" placeholder="Search..">
-    <span><i class="fas search-close fa-times-circle"></i></span>
-    </div>
-    <div class="search-results"></div>
-    <div class="accordion" id="menu"></div>
-  </div>
-</div>
 
 <div class="noSelect defaultCursor layoutElementPanel draggable-panel draggable-panel-css ">
   <div class="panel-header">Layout Elements

--- a/simulator/src/tutorials.js
+++ b/simulator/src/tutorials.js
@@ -80,13 +80,13 @@ export const tour = [
         },
     },
     {
-        element: '.tour-help',
+        element: '.navbar',
         popover: {
             className: 'tourHelpStep',
             title: 'Restart tutorial anytime',
-            description: 'You can restart this tutorial anytime by clicking on "Tutorial Guide" under this dropdown.',
-            position: 'right',
-            offset: 0,
+            description: 'You can restart this tutorial anytime by clicking on "Tutorial Guide" under Help dropdown.',
+            position: 'down',
+            offset: 400,
         },
     },
 


### PR DESCRIPTION
Fixes #2251 

#### Describe the changes you have made in this PR -
1.   Moved the quick button outside the Navbar div. (Since whenever quick button got selected, navbar also got highlighted)
2.   Changed the navbar position property from relative to inherit to avoid it moving.
3.   Entire navbar to be highlighted while tutorial of Help drop-down is shown.

### Screenshots of the changes (If any) -
![tutorialGuideFix](https://user-images.githubusercontent.com/61665451/118395753-a91cf280-b669-11eb-8990-a2a266259e18.gif)



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
