### PR TITLE
Added link to Blog in Header and Footer

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -29,6 +29,7 @@
             <% else %>
               <a href="/users/sign_in"><h6>Log in</h6></a>
             <% end %>
+                 <a href="https://blog.circuitverse.org/"><h6>Blog</h6></a>
           </div>
           <div class="col-6 footer-links">
             <a href="/docs" target="_blank"><h6>Documentation</h6></a>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -37,6 +37,9 @@
       <li class="nav-item px-1">
         <a class="nav-link navbar-item navbar-text <%= request.path == '/about' ? 'active' : '' %>" href="/about"><%= t('headers.about') %></a>
       </li>
+       <li class="nav-item px-1">
+        <a class="nav-link navbar-item navbar-text" href="https://blog.circuitverse.org">Blog</a>
+      </li>
       <% if user_signed_in? %>
       <div class="navbar-nav nav-item dropdown">
         <li class="nav-item px-1">


### PR DESCRIPTION
Fixes #2268

#### Describe the changes you have made in this PR -
There is no direct link of CircuitVerse blog site available in the navbar as well as footer in the main website of CircuitVerse
Added link to Blog in the nav and footer, which will redirect users to https://blog.circuitverse.org
