### PR TITLE
upgraded eslint version to 7

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -6,7 +6,7 @@ plugins:
 
   eslint:
     enabled: true
-    channel: "eslint-6"
+    channel: "eslint-7"
     exclude_patterns:
       - "!public/js/"
   scss-lint:


### PR DESCRIPTION
#### Describe the changes you have made in this PR -

- Changed version of codeclimate eslint to 7 because eslint recently released their latest version (7.28.0).
- The latest release in local setup was conflicting with codeclimate eslint version 6. This PR fixes this conflict.

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
