### PR TITLE
Fix: password input on login and signup 

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -240,7 +240,6 @@
   background-color: $white;
   border: 1px solid $secondary-green;
   border-radius: 0;
-  height: 40px;
   max-width: 100%;
 }
 

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -95,7 +95,6 @@
 
 .password-icon {
   color: $secondary-green;
-  height: 40px;
   width: 40px;
 }
 


### PR DESCRIPTION
Resolves issue CircuitVerse#2278

Fixes #2278 
The input element in div form-input for the password in login and signup was overflowing, hiding the bottom border of form-input.

#### Describe the changes you have made in this PR -
The height of the input element fits inside the div form-input. The border is visible properly now.

### Screenshots of the changes -
#### Before:
<img width="350" alt="login" src="https://user-images.githubusercontent.com/35415933/121490504-b6bc6280-c9f2-11eb-8266-6e93e321c10b.png">

#### After:
<img width="350" alt="Screen Shot 2021-06-30 at 10 34 00 AM" src="https://user-images.githubusercontent.com/35415933/123911431-6a34c900-d999-11eb-9589-e3653db69a3d.png">
