### PR TITLE
Added link of Blog in nav and footer  Issue #2268

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -23,6 +23,7 @@
           <div class="col-5 footer-links">
             <a href="/simulator"><h6>Simulator</h6></a>
             <a href="/learn" target="_blank"><h6>Learn</h6></a>
+            <a href="https://blog.circuitverse.org" target="_blank"><h6>Blog</h6></a>
             <a href="/examples"><h6>Examples</h6></a>
             <% if user_signed_in? %>
               <a href="<%= user_path(current_user) %>"><h6>My Circuits</h6></a>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -35,6 +35,9 @@
         <a class="nav-link navbar-item navbar-text <%= request.path == '/teachers' ? 'active' : '' %>" href="/teachers">Teachers</a>
       </li>
       <li class="nav-item px-1">
+        <a class="nav-link navbar-item navbar-text <%= request.path == '/blog' ? 'active' : '' %>" href="https://blog.circuitverse.org/">Blog</a>
+      </li>
+      <li class="nav-item px-1">
         <a class="nav-link navbar-item navbar-text <%= request.path == '/about' ? 'active' : '' %>" href="/about"><%= t('headers.about') %></a>
       </li>
       <% if user_signed_in? %>


### PR DESCRIPTION
Fixes #
Issue: https://github.com/CircuitVerse/CircuitVerse/issues/2268

#### Describe the changes you have made in this PR -
Added link of Blog in nav and footer of https://circuitverse.org/
### Screenshots of the changes (If any) -
<img width="676" alt="Screenshot 2021-07-16 at 12 32 30 AM" src="https://user-images.githubusercontent.com/54110949/125844391-35bd71bf-1b77-45d9-bcfe-461c86cb9fcc.png">
<img width="682" alt="Screenshot 2021-07-16 at 12 33 56 AM" src="https://user-images.githubusercontent.com/54110949/125844420-21345766-d5ad-4163-b31f-d0af51ec8cf7.png">



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
