### PR TITLE
Fix - Migration of Rails from 6.0.3.6 to 6.0.4 breaks commontator gem

### DIFF
--- a/app/views/commontator/comments/_show.html.erb
+++ b/app/views/commontator/comments/_show.html.erb
@@ -40,7 +40,7 @@
           <% is_deleted = comment.is_deleted? %>
           <% del_string = is_deleted ? 'undelete' : 'delete' %>
           <% unless is_deleted %>
-            <%= link_to commontator.polymorphic_path([del_string, comment]),
+            <%= link_to commontator.polymorphic_path([del_string.to_sym, comment]),
                         data: is_deleted ? {} : { confirm: t('commontator.comment.actions.confirm_delete') },
                         method: :put,
                         id: "commontator-comment-#{comment.id}-#{del_string}",

--- a/app/views/commontator/subscriptions/_link.html.erb
+++ b/app/views/commontator/subscriptions/_link.html.erb
@@ -8,7 +8,7 @@
 <% sub_string = is_subscribed ? 'unsubscribe' : 'subscribe' %>
 &nbsp;
 <%= link_to t("commontator.subscription.actions.#{sub_string}"),
-            commontator.polymorphic_path([sub_string, thread]),
+            commontator.polymorphic_path([sub_string.to_sym, thread]),
             method: :put,
             id: "commontator-thread-#{thread.id}-#{sub_string}",
             class: "anchor-text sub_string mt-0 pt-0",

--- a/app/views/commontator/threads/_show.html.erb
+++ b/app/views/commontator/threads/_show.html.erb
@@ -60,7 +60,7 @@
         <% end %>
 
         <%= link_to t("commontator.thread.actions.#{close_string}"),
-                    commontator.polymorphic_path([close_string, thread]),
+                    commontator.polymorphic_path([close_string.to_sym, thread]),
                     data: is_closed ? {} :
                                       { confirm: t('commontator.thread.actions.confirm_close') },
                     method: :put,


### PR DESCRIPTION
Fixes #

convert polymorphic route arguments into symbols using ```to_sym``` method

### Screenshots of the changes (If any) -

Before

![image](https://user-images.githubusercontent.com/55848322/126438505-e1d39cad-7afc-4ad2-8635-15708877e1df.png)

Now 

![image](https://user-images.githubusercontent.com/55848322/126438700-36f1ab5a-2925-4393-881d-b7367efb3146.png)



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
