### PR TITLE
Stability(Simulator): Fix Subcircuits resulting in Queue Overflow

### DIFF
--- a/simulator/src/engine.js
+++ b/simulator/src/engine.js
@@ -386,10 +386,6 @@ export function play(scope = globalScope, resetNodes = false) {
         forceResetNodesSet(false);
     }
 
-    // Add subcircuits if they can be resolved -- needs to be removed/ deprecated
-    for (let i = 0; i < scope.SubCircuit.length; i++) {
-        if (scope.SubCircuit[i].isResolvable()) simulationArea.simulationQueue.add(scope.SubCircuit[i]);
-    }
     // To store list of circuitselements that have shown contention but kept temporarily
     // Mainly to resolve tristate bus issues
     simulationArea.contentionPending = [];

--- a/simulator/src/subcircuit.js
+++ b/simulator/src/subcircuit.js
@@ -564,17 +564,21 @@ export default class SubCircuit extends CircuitElement {
     }
 
     /**
-     * Not resolvable. Subcircuit's scope is added to the main scope directly
+     * By design, subcircuit element's input and output nodes are wirelessly
+     * connected to the localscope (clone of the scope of the subcircuit's
+     * circuit). So it is almost like the actual circuit is copied in the
+     * location of the subcircuit element. Therefore no resolve needed.
      */
     isResolvable() {
         return false;
     }
 
     /**
-     * Leave this to the scope of the subcircuit. Do nothing.
+     * If element not resolvable (always in subcircuits), removePropagation
+     * is called on it.
      */
     removePropagation() {
-        return;
+        // Leave this to the scope of the subcircuit. Do nothing.
     }
 
     verilogName(){

--- a/simulator/src/subcircuit.js
+++ b/simulator/src/subcircuit.js
@@ -539,13 +539,6 @@ export default class SubCircuit extends CircuitElement {
         }
     }
 
-    isResolvable() {
-        if (CircuitElement.prototype.isResolvable.call(this)) {
-            return true;
-        }
-        return false;
-    }
-
     /**
      * Procedure if any element is double clicked inside a subcircuit
     **/
@@ -571,33 +564,17 @@ export default class SubCircuit extends CircuitElement {
     }
 
     /**
-     * not used because for now everythiing is added onto the globalscope
+     * Not resolvable. Subcircuit's scope is added to the main scope directly
      */
-    resolve() {
-        // deprecated
-        // var subcircuitScope = this.localScope;//scopeList[this.id];
-        // // this.scope.pending.clean(this); // To remove any pending instances
-        // // return;
-        //
-        // for (i = 0; i < subcircuitScope.Input.length; i++) {
-        //     subcircuitScope.Input[i].state = this.inputNodes[i].value;
-        // }
-        //
-        // for (i = 0; i < subcircuitScope.Input.length; i++) {
-        //     simulationArea.simulationQueue.add(subcircuitScope.Input[i]);
-        // }
-        // play(subcircuitScope);
-        //
-        // for (i = 0; i < subcircuitScope.Output.length; i++) {
-        //     this.outputNodes[i].value = subcircuitScope.Output[i].inp1.value;
-        // }
-        // for (i = 0; i < subcircuitScope.Output.length; i++) {
-        //     this.scope.stack.push(this.outputNodes[i]);
-        // }
-    }
-
     isResolvable() {
         return false;
+    }
+
+    /**
+     * Leave this to the scope of the subcircuit. Do nothing.
+     */
+    removePropagation() {
+        return;
     }
 
     verilogName(){


### PR DESCRIPTION
 * According to the design of subcircuits, the localscope is
   directly connected to the main scope. Earlier, output values of
   subcircuits were being set to undefined and propagated before
   the localscope resolved. This resulted in repeated adding of
   some nodes in the simulation queue, causing an overflow.

 * This commit fixes the above problem by making the subcircuits
   not propagate undefined values.



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
