### PR TITLE
fixes: Simulator Navbar disappears at the end of tutorials guide 

### DIFF
--- a/app/assets/stylesheets/simulator.scss
+++ b/app/assets/stylesheets/simulator.scss
@@ -22,16 +22,16 @@
 }
 
 .report-sidebar a {   
-  color: #fff;
+  color: $white;
   font-size: 13px;
   padding: 10px;
   position: fixed;
-  right: -119px !important;
+  right: -119px;
   text-decoration: none;
   bottom: 30px;
   transition: .3s;
-  width: 160px !important;
-  z-index: 999 !important;
+  width: 160px;
+  z-index: 999;
 }
 
 .report-sidebar span {
@@ -40,5 +40,5 @@
 }
 
 .report-sidebar a:hover {
-  right: 0 !important;
+  right: 0;
 }

--- a/app/assets/stylesheets/simulator.scss
+++ b/app/assets/stylesheets/simulator.scss
@@ -22,16 +22,16 @@
 }
 
 .report-sidebar a {   
-  color: $white;
+  color: #fff;
   font-size: 13px;
   padding: 10px;
-  position: absolute;
-  right: -119px;
+  position: fixed;
+  right: -119px !important;
   text-decoration: none;
   bottom: 30px;
   transition: .3s;
-  width: 160px;
-  z-index: 999;
+  width: 160px !important;
+  z-index: 999 !important;
 }
 
 .report-sidebar span {
@@ -40,5 +40,5 @@
 }
 
 .report-sidebar a:hover {
-  right: 0;
+  right: 0 !important;
 }


### PR DESCRIPTION
Fixes #2348 

#### Describe the changes you have made in this PR -

I have changed the styling of the issue button as it was overriding CSS of others, I convert its the position from absolute to fixed and also assigned it '!important' keyword on it's size

### Screenshots of the changes (If any) -
* Before 
![Screenshot (58)](https://user-images.githubusercontent.com/76901313/127197977-4cb2a49d-be3f-44f7-8f27-a351adf2e6f1.png)
![Screenshot (59)](https://user-images.githubusercontent.com/76901313/127197985-d8f2ad7c-3476-4043-9018-f7ac85ae67d0.png)

* After
![Screenshot (56)](https://user-images.githubusercontent.com/76901313/127198042-dbf7b4d9-92a6-4030-b6e5-f27c0ea0b602.png)
![Screenshot (57)](https://user-images.githubusercontent.com/76901313/127198052-5718da87-f721-4e9b-8cbc-31085e1088d9.png)


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
