### PR TITLE
fix: lms assignment grade scale fix to 1-100

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -2,6 +2,7 @@
 
 class Assignment < ApplicationRecord
   validates :name, length: { minimum: 1 }
+  validates :grading_scale, inclusion: { in: %w(percent), message: "needs to be fixed at 1-100 for passing the grade back to LMS" }, if: :lti_integrated?
   belongs_to :group
   has_many :projects, class_name: "Project", dependent: :nullify
 

--- a/app/views/assignments/_form.html.erb
+++ b/app/views/assignments/_form.html.erb
@@ -75,14 +75,14 @@
         e.preventDefault();
         var radio = $(e.currentTarget);
         if (radio.is(':checked')) {
-            $('.lms-integration-message').css("display", "block");
-            $('.lms-grade-fixed-message').css("display", "block");
-            $('#assignment_grading_scale').val('percent');
-            $('#assignment_grading_scale').attr('disabled', 'disabled');
+          $('.lms-integration-message').css("display", "block");
+          $('.lms-grade-fixed-message').css("display", "block");
+          $('#assignment_grading_scale').attr('readonly', 'readonly');
+          $('#assignment_grading_scale').val('percent');
         } else {
-            $('.lms-integration-message').css("display", "none");
-            $('.lms-grade-fixed-message').css("display", "none");
-            $('#assignment_grading_scale').removeAttr('disabled');
+          $('.lms-integration-message').css("display", "none");
+          $('.lms-grade-fixed-message').css("display", "none");
+          $('#assignment_grading_scale').removeAttr('readonly');
         }
     });
     $('#lms-integration-check').trigger('change');

--- a/app/views/assignments/_form.html.erb
+++ b/app/views/assignments/_form.html.erb
@@ -38,6 +38,9 @@
     <h6><%= form.label :grading_scale %></h6>
     <% if @assignment.new_record? %>
       <span> (Cannot be changed once set)</span>
+      <div class="lms-grade-fixed-message"> <!-- Operated by script -->
+        <p>Grading Scale needs to be fixed at 1-100 for passing the grade back to LMS</a></p>
+      </div>
       <%= form.select :grading_scale, [["No Grade", :no_scale], ["Letter(A-F)", :letter], ["Percent(1-100)", :percent], ["Custom", :custom]], {}, class: 'form-control form-input' %>
     <% else %>
       <div class="assignments-noedit-grade-field">
@@ -71,11 +74,15 @@
     $('#lms-integration-check').change(function (e) {
         e.preventDefault();
         var radio = $(e.currentTarget);
-
         if (radio.is(':checked')) {
             $('.lms-integration-message').css("display", "block");
+            $('.lms-grade-fixed-message').css("display", "block");
+            $('#assignment_grading_scale').val('percent');
+            $('#assignment_grading_scale').attr('disabled', 'disabled');
         } else {
             $('.lms-integration-message').css("display", "none");
+            $('.lms-grade-fixed-message').css("display", "none");
+            $('#assignment_grading_scale').removeAttr('disabled');
         }
     });
     $('#lms-integration-check').trigger('change');

--- a/spec/requests/lti_spec.rb
+++ b/spec/requests/lti_spec.rb
@@ -23,7 +23,7 @@ describe LtiController, type: :request do
             @member = FactoryBot.create(:user)
             @not_member = FactoryBot.create(:user)
             FactoryBot.create(:group_member, user: @member, group: @group)
-            @assignment = FactoryBot.create(:assignment, group: @group, lti_consumer_key: @oauth_consumer_key_fromlms, lti_shared_secret: @oauth_shared_secret_fromlms)
+            @assignment = FactoryBot.create(:assignment, group: @group, grading_scale: 2, lti_consumer_key: @oauth_consumer_key_fromlms, lti_shared_secret: @oauth_shared_secret_fromlms)
         end
 
         context "when lti parameters are valid" do


### PR DESCRIPTION
Fixes #2361

#### Describe the changes you have made in this PR -
* Grading scale will be 1-100 for all LTI integrated assignments
* Proper validators has been added to the `assignment model` to check if the correct grading scale is chosen
* In the frontend side when the checkbox will be ticked the grading scale will be changed to 1-100 and will go to readonly mode

### Screenshots of the changes (If any) -
Frontend changes and makes the field readonly on ticking the LMS Checkbox
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/52851184/128331162-ef4ef978-fadc-4def-9d75-dc89db7aff0e.png">

When wrong grading scale is passed back to backend
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/52851184/128330752-d112e066-8be1-4762-85a0-58768bb4ed6c.png"> 