### PR TITLE
fix: center items in about us page

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -48,7 +48,7 @@ body {
   text-align: justify;
 }
 
-.centered-paragraph{
+.centered-paragraph {
   margin: 30px 0;
   text-align: center;
 }
@@ -65,10 +65,10 @@ body {
   text-align: center;
 }
 
-.div-flex-center{
+.div-flex-center {
+  align-items: center;
   display: flex;
   justify-content: center;
-  align-items: center;
 }
 
 .center-image {

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -48,6 +48,10 @@ body {
   text-align: justify;
 }
 
+.centered-paragraph{
+  margin: 30px 0;
+  text-align: center;
+}
 //alignment
 .alert {
   display: block;
@@ -59,6 +63,12 @@ body {
   margin-right: auto;
   max-width: 1344px;
   text-align: center;
+}
+
+.div-flex-center{
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .center-image {

--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -5,10 +5,10 @@
     <div class="col-xs col-sm col-md col-lg">
       <h1 class="main-heading"><%= t("about.main_heading") %></h1>
         <p class="main-description"><%= t("about.main_description") %></p>
-        <p class="justified-paragraph"><%= t("about.product_details") %></p>
+        <p class="centered-paragraph"><%= t("about.product_details") %></p>
     </div>
   </div>
-  <div class="col-xs col-sm col-md col-lg">
+  <div class="col-xs col-sm col-md col-lg div-flex-center">
     <a class="btn primary-button" href="/tos" target="_blank"><%= t("about.terms_of_service") %></a>
     <a class="btn primary-button" href="/privacy" target="_blank"><%= t("about.privacy_policy") %></a>
   </div>


### PR DESCRIPTION
Fixes #2376 

#### Describe the changes you have made in this PR -

* Make buttons and description center.

### Screenshots of the changes (If any) -

* Before
![bandicam 2021-08-07 11-19-19-558](https://user-images.githubusercontent.com/76901313/128589695-297d369c-ac0e-448f-b16c-e5e1581e70af.jpg)

* After
![bandicam 2021-08-07 11-19-46-514](https://user-images.githubusercontent.com/76901313/128589693-1e9eb44a-990e-40a8-8409-c32227949fab.jpg)

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
