### PR TITLE
fix : conditional enable of feature lms_integration

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -10,7 +10,7 @@ class AssignmentsController < ApplicationController
   before_action :sanitize_assignment_description, only: %i[show edit]
   after_action :check_reopening_status, only: [:update]
   after_action :allow_iframe_lti, only: %i[show], constraints: lambda {
-    Flipper.enabled?(:lms_integration)
+    Flipper.enabled?(:lms_integration, current_user)
   }
 
   # GET /assignments
@@ -64,7 +64,7 @@ class AssignmentsController < ApplicationController
   def create
     description = params["description"]
 
-    if Flipper.enabled?(:lms_integration) && params["lms-integration-check"]
+    if Flipper.enabled?(:lms_integration, current_user) && params["lms-integration-check"]
       lti_consumer_key = SecureRandom.hex(4)
       lti_shared_secret = SecureRandom.hex(4)
     end
@@ -79,7 +79,7 @@ class AssignmentsController < ApplicationController
     @assignment.status = "open"
     @assignment.deadline = Time.zone.now + 1.year if @assignment.deadline.nil?
 
-    if Flipper.enabled?(:lms_integration)
+    if Flipper.enabled?(:lms_integration, current_user)
       @assignment.lti_consumer_key = lti_consumer_key
       @assignment.lti_shared_secret = lti_shared_secret
     end
@@ -100,7 +100,7 @@ class AssignmentsController < ApplicationController
   def update
     description = params["description"]
 
-    if Flipper.enabled?(:lms_integration) && params["lms-integration-check"]
+    if Flipper.enabled?(:lms_integration, current_user) && params["lms-integration-check"]
       lti_consumer_key = @assignment.lti_consumer_key.presence || SecureRandom.hex(4)
       lti_shared_secret = @assignment.lti_shared_secret.presence || SecureRandom.hex(4)
     end
@@ -108,7 +108,7 @@ class AssignmentsController < ApplicationController
     params = assignment_update_params
     @assignment.description = description
 
-    if Flipper.enabled?(:lms_integration)
+    if Flipper.enabled?(:lms_integration, current_user)
       @assignment.lti_consumer_key = lti_consumer_key
       @assignment.lti_shared_secret = lti_shared_secret
     end

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -20,7 +20,7 @@ class GradesController < ApplicationController
     @grade.user_id = current_user.id
     @grade.remarks = remarks
 
-    if Flipper.enabled?(:lms_integration) && session[:is_lti]
+    if Flipper.enabled?(:lms_integration, current_user) && session[:is_lti]
       # pass grade back to the LMS if session is LTI
       project = Project.find(grade_params[:project_id])
       assignment = Assignment.find(grade_params[:assignment_id])

--- a/app/controllers/simulator_controller.rb
+++ b/app/controllers/simulator_controller.rb
@@ -12,7 +12,7 @@ class SimulatorController < ApplicationController
   skip_before_action :verify_authenticity_token, only: %i[get_data create]
   after_action :allow_iframe, only: %i[embed]
   after_action :allow_iframe_lti, only: %i[show], constraints: lambda {
-    Flipper.enabled?(:lms_integration)
+    Flipper.enabled?(:lms_integration, current_user)
   }
 
   def self.policy_class

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -99,7 +99,7 @@ class User < ApplicationRecord
   end
 
   def flipper_id
-    "User;#{id}"
+    "User:#{id}"
   end
 
   def moderator?

--- a/app/views/assignments/_form.html.erb
+++ b/app/views/assignments/_form.html.erb
@@ -12,7 +12,7 @@
     </div>
   <% end %>
 
-  <% if Flipper.enabled?(:lms_integration) %>
+  <% if Flipper.enabled?(:lms_integration, current_user) %>
     <div id="lms-integration-field" class="field form-group">
       <label for="lms-integration-check" class="primary-checkpoint-container" id="lms-integration-check-elements"><h6>Integrate with LMS</h6>
        <%= check_box_tag "lms-integration-check", checked: @assignment.lti_integrated? %>
@@ -40,7 +40,7 @@
     <h6><%= form.label :grading_scale %></h6>
     <% if @assignment.new_record? %>
       <span> (Cannot be changed once set)</span>
-      <% if Flipper.enabled?(:lms_integration) %>
+      <% if Flipper.enabled?(:lms_integration, current_user) %>
         <div class="lms-grade-fixed-message"> <!-- Operated by script -->
           <p>Grading Scale needs to be fixed at 1-100 for passing the grade back to LMS</a></p>
         </div>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -61,7 +61,7 @@
           <td>
             <div class="groups-assignment-details groups-expanded-assignment-name">
               <%= assignment.name %>
-              <% if Flipper.enabled?(:lms_integration) %>
+              <% if Flipper.enabled?(:lms_integration, current_user) %>
                 <% if policy(@group).admin_access? && assignment.lti_integrated? %>
                  <br>
                  <a data-toggle="modal" href="#lmscredentialsModal-<%= assignment.id %>">Show LMS Credentials</a>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,7 +94,7 @@ Rails.application.routes.draw do
 
   # lti
   scope "lti"  do
-    match 'launch', to: 'lti#launch', via: [:get, :post], constraints: -> { Flipper.enabled?(:lms_integration) } 
+    match 'launch', to: 'lti#launch', via: [:get, :post] 
   end
 
   mount Commontator::Engine => "/commontator"


### PR DESCRIPTION
#### Describe the changes you have made in this PR -
fix: now in flipper UI userid can be passed to enable/disable lms_integration
fix: the lti routes has been moved out of the flipper condition
### Screenshots of the changes (If any) -
Here more actors can be added from the Flipper UIto enable the `lms_integration` feature for individual users
<img width="664" alt="image" src="https://user-images.githubusercontent.com/52851184/130316499-66bffae7-92ea-4916-8d79-dced4614e956.png">
