### PR TITLE
Security: Site-wide rate limiting

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -29,6 +29,13 @@ class Rack::Attack
   # Disabled in test env in environments/test.rb
   Rack::Attack.enabled = !ENV["DISABLE_RACK_ATTACK"] unless Rails.env.production?
 
+  ### Throttle Non Asset requests sitewide ###
+
+  # Throttle by ip
+  throttle('throttle non asset requests by ip', limit: 300, period: 5.minutes) do |req|
+    req.remote_ip unless (req.path.start_with?('/assets') or req.path.start_with?('/uploads'))
+  end
+
   ### Throttle logins ###
 
   # Throttle by IP


### PR DESCRIPTION
 - 300 requests per 5 minutes per IP
 - Does not limit `/assets` and `/uploads` which are used to fetch media