### PR TITLE
Fix EOL inconsistency between windows and linux for docker-compose

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # All files in bin/ should use LF
-./bin/** text eol=lf
+bin/** text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# All files in bin/ should use LF
+./bin/** text eol=lf


### PR DESCRIPTION
Fixes #2090
Specifies using Line Feed instead of Carriage Return Line Feed for docker entrypoint scripts

Fixes Docker builds on Windows