### PR TITLE
increasing right css value for watermark

### DIFF
--- a/app/views/simulator/embed.html.erb
+++ b/app/views/simulator/embed.html.erb
@@ -49,7 +49,7 @@
           <a style="text-decoration:none;
               position: fixed;
               bottom: 0px;
-              right: 0px;
+              right: 25px;
               padding: 8px;
               font-family: Verdana;
               font-size: 12px;

--- a/app/views/simulator_old/embed.html.erb
+++ b/app/views/simulator_old/embed.html.erb
@@ -69,7 +69,7 @@
           <a style="text-decoration:none;
               position: fixed;
               bottom: 0px;
-              right: 0px;
+              right: 25px;
               padding: 8px;
               font-family: Verdana;
               font-size: 12px;


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -

1. Increased watermark CSS style right property

### Screenshots of the changes (If any) -

Before:
![watermarkBefore](https://user-images.githubusercontent.com/16468702/135685171-1c76f77c-69e7-4d9c-937c-e6b36fe347c8.JPG)

After:
Desktop
![watermarkAfter](https://user-images.githubusercontent.com/16468702/135685179-d6046996-aeea-49de-98a2-8ad13ffc97a9.JPG)

Mobile View
![watermarkAfterMobile](https://user-images.githubusercontent.com/16468702/135724181-a6556240-0ff0-4df7-9f71-9baa039307e0.JPG)


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
