### PR TITLE
OSD: add readonly attribute to textarea

### DIFF
--- a/app/views/groups/_add_member_modal.html.erb
+++ b/app/views/groups/_add_member_modal.html.erb
@@ -36,7 +36,7 @@
           <span><%= t("groups.invite_link_btn") %></span>
         <% end %>
         <div class="collapse" id="collapseExample">
-          <textarea id="embedInviteLink" class="group-invite-link-text" rows="4" cols="35"></textarea>
+          <textarea readonly="readonly" id="embedInviteLink" class="group-invite-link-text" rows="4" cols="35"></textarea>
         </div>
       </div>
     </div>


### PR DESCRIPTION
# Fix for issue #2510

#### Added a readonly attribute to the group invite textarea so it cannot be modified.

To test this, login and go to My Groups -> Create Group -> Add members -> Group Invite Link.

