### PR TITLE
fixes: swap the position of notifications and testing button

### DIFF
--- a/app/views/activity_notification/notifications/default/index.html.erb
+++ b/app/views/activity_notification/notifications/default/index.html.erb
@@ -11,10 +11,6 @@
         </span></span>
       <% end %>
     </h1>
-    <div class="d-flex align-items-center justify-content-center" style="height: 350px;">
-       Browser notifications are:&nbsp;<strong id="browser-notifications-status">disabled</strong>&nbsp;&nbsp;
-      <button class="btn btn-success" id="browser-notifications-permission-request">Enable</button>
-    </div>
   </div>
   <div class="notifications">
     <% if @index_options[:with_group_members] %>
@@ -23,6 +19,10 @@
       <%= render_notification @notifications, @index_options.slice(:routing_scope, :devise_default_routes).merge(fallback: :default) %>
       <%#= render_notification @notifications, @index_options.slice(:routing_scope, :devise_default_routes).merge(fallback: :text) %>
     <% end %>
+  </div>
+  <div class="d-flex align-items-center justify-content-center" style="height: 150px;">
+     Browser notifications are:&nbsp;<strong id="browser-notifications-status">disabled</strong>&nbsp;&nbsp;
+    <button class="btn btn-success" id="browser-notifications-permission-request">Enable</button>
   </div>
 </div>
 


### PR DESCRIPTION
Fixes #2558 

#### Describe the changes you have made in this PR -
- swap the position of notifications and testing button
- reduce the height of the testing container to 150 as it was taking unnecessary space of 350px.


### Screenshots of the changes (If any) -
- before
![Screenshot (163)](https://user-images.githubusercontent.com/76901313/137943826-6e545bbe-0e66-4035-97f6-5c1483ba05db.png)

- after
![Screenshot (164)](https://user-images.githubusercontent.com/76901313/137943760-5d78ee27-7751-4cfc-8817-128e9fbedd49.png)


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
