### PR TITLE
fixes: size of group members for 'non-admin group viewer' should be less

### DIFF
--- a/app/assets/stylesheets/groups.scss
+++ b/app/assets/stylesheets/groups.scss
@@ -164,32 +164,46 @@
 .groups-members-card-details {
   padding-right: 0;
   text-align: left;
+
+  i {
+    margin-right: 3px;
+    margin-top: 0;
+    padding-bottom: 5px;
+  }
+}
+
+.groups-members-card-details-non-user {
   display: flex;
   align-items: center;
 
   i {
-    margin-right: 20px;
-    margin-top: 0;
+    padding-bottom: 0px;
+    margin-right: 15px;
+  }
+
+  .groups-members-card-name-container {
+    height: auto;
+
+    &:hover {
+      .tooltiptext {
+        left: 21%;
+      }
+
+      .tooltiptext {
+        opacity: 1;
+        visibility: visible;
+      }
+    }
   }
 }
 
 .groups-members-card-name-container {
   display: inline-block;
+  height: 25px;
   max-width: 110px;
   overflow: hidden;
   padding-top: 1px;
   text-overflow: ellipsis;
-
-  .tooltiptext {
-    left: 25%;
-  }
-}
-
-.groups-members-card-name-container:hover {
-  .tooltiptext {
-    opacity: 1;
-    visibility: visible;
-  }
 }
 
 .groups-members-card-name {

--- a/app/assets/stylesheets/groups.scss
+++ b/app/assets/stylesheets/groups.scss
@@ -151,6 +151,16 @@
   width: 300px;
 }
 
+.groups-members-card-viewer {
+  background-color: $card-green;
+  border: 1px solid $secondary-green;
+  display: inline-block;
+  height: auto;
+  margin: 10px;
+  padding: 15px;
+  width: 200px;
+}
+
 .groups-members-card-details {
   padding-right: 0;
   text-align: left;

--- a/app/assets/stylesheets/groups.scss
+++ b/app/assets/stylesheets/groups.scss
@@ -173,26 +173,25 @@
 }
 
 .groups-members-card-details-non-user {
-  display: flex;
   align-items: center;
-
+  display: flex;
+  
   i {
-    padding-bottom: 0px;
     margin-right: 15px;
+    padding-bottom: 0;
   }
 
   .groups-members-card-name-container {
     height: auto;
+  }
+}
 
-    &:hover {
-      .tooltiptext {
-        left: 21%;
-      }
-
-      .tooltiptext {
-        opacity: 1;
-        visibility: visible;
-      }
+.groups-members-card-details-non-user {
+  &:hover {
+    .tooltiptext {
+      left: 21%;
+      opacity: 1;
+      visibility: visible;
     }
   }
 }

--- a/app/assets/stylesheets/groups.scss
+++ b/app/assets/stylesheets/groups.scss
@@ -164,21 +164,32 @@
 .groups-members-card-details {
   padding-right: 0;
   text-align: left;
+  display: flex;
+  align-items: center;
 
   i {
-    margin-right: 3px;
+    margin-right: 20px;
     margin-top: 0;
-    padding-bottom: 5px;
   }
 }
 
 .groups-members-card-name-container {
   display: inline-block;
-  height: 25px;
   max-width: 110px;
   overflow: hidden;
   padding-top: 1px;
   text-overflow: ellipsis;
+
+  .tooltiptext {
+    left: 25%;
+  }
+}
+
+.groups-members-card-name-container:hover {
+  .tooltiptext {
+    opacity: 1;
+    visibility: visible;
+  }
 }
 
 .groups-members-card-name {

--- a/app/assets/stylesheets/groups.scss
+++ b/app/assets/stylesheets/groups.scss
@@ -172,7 +172,7 @@
   }
 }
 
-.groups-members-card-details-non-user {
+.groups-members-card-details-non-admin {
   align-items: center;
   display: flex;
   
@@ -186,7 +186,7 @@
   }
 }
 
-.groups-members-card-details-non-user {
+.groups-members-card-details-non-admin {
   &:hover {
     .tooltiptext {
       left: 21%;

--- a/app/helpers/group_members_helper.rb
+++ b/app/helpers/group_members_helper.rb
@@ -1,11 +1,16 @@
 # frozen_string_literal: true
 
 module GroupMembersHelper
+  def membersCardViewerContainer(group)
+    policy(group).admin_access? ? 'col-xs-12 col-sm-12 col-md-6 col-lg-4 groups-members-card-container' : 'col-xs-12 col-sm-12 col-md-6 col-lg-3 groups-members-card-container'
+  end
+
+
   def membersCardViewer(group)
-    if policy(group).admin_access?
-      return 'col-7 groups-members-card-details'
-    else
-      return 'col-11 groups-members-card-details groups-members-card-details-non-admin'
-    end
+    policy(group).admin_access? ? 'groups-members-card' : 'groups-members-card-viewer'
+  end
+
+  def membersCardViewerDetail(group)
+    policy(group).admin_access? ? 'col-7 groups-members-card-details' : 'col-11 groups-members-card-details groups-members-card-details-non-admin'
   end
 end

--- a/app/helpers/group_members_helper.rb
+++ b/app/helpers/group_members_helper.rb
@@ -1,4 +1,11 @@
 # frozen_string_literal: true
 
 module GroupMembersHelper
+  def membersCardViewer(group)
+    if policy(group).admin_access?
+      return 'col-7 groups-members-card-details'
+    else
+      return 'col-11 groups-members-card-details groups-members-card-details-non-admin'
+    end
+  end
 end

--- a/app/views/groups/_group_members.html.erb
+++ b/app/views/groups/_group_members.html.erb
@@ -2,7 +2,7 @@
   <div class="<%= policy(group).admin_access? ? 'col-xs-12 col-sm-12 col-md-6 col-lg-4 groups-members-card-container' : 'col-xs-12 col-sm-12 col-md-6 col-lg-3 groups-members-card-container' %>">
     <div class="<%= policy(group).admin_access? ? 'groups-members-card' : 'groups-members-card-viewer' %>">
       <div class="row">
-        <div class="<%= policy(group).admin_access? ? 'col-7 groups-members-card-details' : 'col-7 groups-members-card-details groups-members-card-details-non-user' %>">
+        <div class="<%= policy(group).admin_access? ? 'col-7 groups-members-card-details' : 'col-7 groups-members-card-details groups-members-card-details-non-admin' %>">
           <i class="fa fa-user"></i>
           <div class="groups-members-card-name-container">
           <span class="tooltiptext"><%= user.name %></span>

--- a/app/views/groups/_group_members.html.erb
+++ b/app/views/groups/_group_members.html.erb
@@ -2,7 +2,7 @@
   <div class="<%= policy(group).admin_access? ? 'col-xs-12 col-sm-12 col-md-6 col-lg-4 groups-members-card-container' : 'col-xs-12 col-sm-12 col-md-6 col-lg-3 groups-members-card-container' %>">
     <div class="<%= policy(group).admin_access? ? 'groups-members-card' : 'groups-members-card-viewer' %>">
       <div class="row">
-        <div class="<%= policy(group).admin_access? ? 'col-7 groups-members-card-details' : 'col-11 groups-members-card-details groups-members-card-details-non-admin' %>">
+        <div class="<%= membersCardViewer(group) %>">
           <i class="fa fa-user"></i>
           <div class="groups-members-card-name-container">
           <span class="tooltiptext"><%= user.name %></span>

--- a/app/views/groups/_group_members.html.erb
+++ b/app/views/groups/_group_members.html.erb
@@ -5,6 +5,7 @@
         <div class="col-7 groups-members-card-details">
           <i class="fa fa-user"></i>
           <div class="groups-members-card-name-container">
+          <span class="tooltiptext"><%= user.name %></span>
             <%= link_to user.name, user, class: "groups-members-card-name" %>
           </div>
           <% if policy(group).admin_access? %>

--- a/app/views/groups/_group_members.html.erb
+++ b/app/views/groups/_group_members.html.erb
@@ -2,7 +2,7 @@
   <div class="<%= policy(group).admin_access? ? 'col-xs-12 col-sm-12 col-md-6 col-lg-4 groups-members-card-container' : 'col-xs-12 col-sm-12 col-md-6 col-lg-3 groups-members-card-container' %>">
     <div class="<%= policy(group).admin_access? ? 'groups-members-card' : 'groups-members-card-viewer' %>">
       <div class="row">
-        <div class="<%= policy(group).admin_access? ? 'col-7 groups-members-card-details' : 'col-7 groups-members-card-details groups-members-card-details-non-admin' %>">
+        <div class="<%= policy(group).admin_access? ? 'col-7 groups-members-card-details' : 'col-11 groups-members-card-details groups-members-card-details-non-admin' %>">
           <i class="fa fa-user"></i>
           <div class="groups-members-card-name-container">
           <span class="tooltiptext"><%= user.name %></span>

--- a/app/views/groups/_group_members.html.erb
+++ b/app/views/groups/_group_members.html.erb
@@ -1,6 +1,6 @@
 <% group.users.each do |user| %>
-  <div class="col-xs-12 col-sm-12 col-md-6 col-lg-4 groups-members-card-container">
-    <div class="groups-members-card">
+  <div class="<%= policy(group).admin_access? ? 'col-xs-12 col-sm-12 col-md-6 col-lg-4 groups-members-card-container' : 'col-xs-12 col-sm-12 col-md-6 col-lg-3 groups-members-card-container' %>">
+    <div class="<%= policy(group).admin_access? ? 'groups-members-card' : 'groups-members-card-viewer' %>">
       <div class="row">
         <div class="col-7 groups-members-card-details">
           <i class="fa fa-user"></i>
@@ -11,14 +11,14 @@
             <p class="groups-members-card-email"><%= user.email %></p>
           <% end %>
         </div>
-        <div class="col-5 groups-members-card-button">
-          <% if policy(group).admin_access? %>
-            <%= link_to '#', data: {toggle: "modal", target: "#deletememberModal", currentgroupmember: GroupMember.find_by(user_id:user.id,group_id:group.id).id}, class:"mini-button groups-delete-mini-button" do %>
-              <%= image_tag("SVGs/deleteGroup.svg", alt: "Remove Member") %>
-              <span><%= t("remove") %></span>
-            <% end %>
-          <% end %>
-        </div>
+        <% if policy(group).admin_access? %>
+          <div class="col-5 groups-members-card-button">
+              <%= link_to '#', data: {toggle: "modal", target: "#deletememberModal", currentgroupmember: GroupMember.find_by(user_id:user.id,group_id:group.id).id}, class:"mini-button groups-delete-mini-button" do %>
+                <%= image_tag("SVGs/deleteGroup.svg", alt: "Remove Member") %>
+                <span><%= t("remove") %></span>
+              <% end %>
+          </div>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/groups/_group_members.html.erb
+++ b/app/views/groups/_group_members.html.erb
@@ -2,7 +2,7 @@
   <div class="<%= policy(group).admin_access? ? 'col-xs-12 col-sm-12 col-md-6 col-lg-4 groups-members-card-container' : 'col-xs-12 col-sm-12 col-md-6 col-lg-3 groups-members-card-container' %>">
     <div class="<%= policy(group).admin_access? ? 'groups-members-card' : 'groups-members-card-viewer' %>">
       <div class="row">
-        <div class="col-7 groups-members-card-details">
+        <div class="<%= policy(group).admin_access? ? 'col-7 groups-members-card-details' : 'col-7 groups-members-card-details groups-members-card-details-non-user' %>">
           <i class="fa fa-user"></i>
           <div class="groups-members-card-name-container">
           <span class="tooltiptext"><%= user.name %></span>

--- a/app/views/groups/_group_members.html.erb
+++ b/app/views/groups/_group_members.html.erb
@@ -1,8 +1,8 @@
 <% group.users.each do |user| %>
-  <div class="<%= policy(group).admin_access? ? 'col-xs-12 col-sm-12 col-md-6 col-lg-4 groups-members-card-container' : 'col-xs-12 col-sm-12 col-md-6 col-lg-3 groups-members-card-container' %>">
-    <div class="<%= policy(group).admin_access? ? 'groups-members-card' : 'groups-members-card-viewer' %>">
+  <div class="<%= membersCardViewerContainer(group) %>">
+    <div class="<%= membersCardViewer(group) %>">
       <div class="row">
-        <div class="<%= membersCardViewer(group) %>">
+        <div class="<%= membersCardViewerDetail(group) %>">
           <i class="fa fa-user"></i>
           <div class="groups-members-card-name-container">
           <span class="tooltiptext"><%= user.name %></span>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -33,7 +33,7 @@
     <% end %>
   </div>
   <hr>
-  <div class="row center-row groups-members-scroll-row">
+  <div class="<%= policy(@group).admin_access? ? 'row center-row groups-members-scroll-row' : 'row groups-members-scroll-row' %>">
     <%= render partial: "group_members", locals: {group: @group} %>
   </div>
   <div class="row center-row groups-row">


### PR DESCRIPTION
Fixes #2582 

#### Describe the changes you have made in this PR -
- Added a new class for 'groups-members-card-viewer' where the width: 200px and height: auto
- If the visiter is not admin the grid is now divided into 3 but it should be 4 according to width size.
- embed ruby if condition before remove-button div.

### Screenshots of the changes (If any) -
- Before
![bandicam 2021-11-03 21-15-24-473](https://user-images.githubusercontent.com/76901313/140094201-bd41d2c5-5893-4a2c-aa33-90a894d0edce.jpg)

- After
![bandicam 2021-11-03 21-15-39-876](https://user-images.githubusercontent.com/76901313/140094225-b5f85a48-9fcc-4a2f-ac74-6c6646fb65dc.jpg)


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
