### PR TITLE
Replaced deleted keyword with closed keyword which fixes #2600

### DIFF
--- a/simulator/src/circuit.js
+++ b/simulator/src/circuit.js
@@ -112,7 +112,7 @@ function deleteCurrentCircuit(scopeId = globalScope.id) {
         return;
     }
 
-    const confirmation = confirm(`Are you sure want to delete: ${scope.name}\nThis cannot be undone.`);
+    const confirmation = confirm(`Are you sure want to close: ${scope.name}\nThis cannot be undone.`);
     if (confirmation) {
         if (scope.verilogMetadata.isVerilogCircuit) {
             scope.initialize();
@@ -122,8 +122,8 @@ function deleteCurrentCircuit(scopeId = globalScope.id) {
         $(`#${scope.id}`).remove();
         delete scopeList[scope.id];
         switchCircuit(Object.keys(scopeList)[0]);
-        showMessage('Circuit was successfully deleted');
-    } else { showMessage('Circuit was not deleted'); }
+        showMessage('Circuit was successfully closed');
+    } else { showMessage('Circuit was not closed'); }
 }
 
 /**


### PR DESCRIPTION
Fixes #2600

#### Describe the changes you have made in this PR -
As a discussion in pull request https://github.com/CircuitVerse/CircuitVerse/pull/2586 i have changed the keyword delete to close in both the prompt box and the modal 

### Screenshots of the changes (If any) -

### Initially

![image](https://user-images.githubusercontent.com/87171452/141832810-1dded0c1-4b63-4b17-b23d-688037f4da19.png)
![image](https://user-images.githubusercontent.com/87171452/141832821-8ed7aded-f89c-4022-9f5e-f1203729fa97.png)


### Finally

![image](https://user-images.githubusercontent.com/87171452/141832846-8379bc98-4c74-4db1-8c56-8ad319aa0dfe.png)
![image](https://user-images.githubusercontent.com/87171452/141832853-1c592195-b0a4-4a6d-a42a-ba57777b461a.png)




Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
