### PR TITLE
Fixes : Timeline - Position Issue #1945

### DIFF
--- a/simulator/src/css/main.stylesheet.css
+++ b/simulator/src/css/main.stylesheet.css
@@ -307,6 +307,12 @@ input[type="text"]:focus {
   color: white;
 
 }
+/* Mobile view quick bar position */
+@media screen and (max-width:991px){
+  .quick-btn{
+    top:10px;
+  }
+}
 /* dropdown-menu styles */
 
 .dropdown > ul {
@@ -423,7 +429,7 @@ input[type="text"]:focus {
 .ce-panel {
   font: inherit;
   width: 240px;
-  top: 90px;
+  top: 246px;
   left: 10px;
 }
 
@@ -677,7 +683,7 @@ div.icon img {
 .moduleProperty {
   font: inherit;
   width: 250px;
-  top: 90px;
+  top: 246px;
   right: 10px;
 }
 
@@ -699,6 +705,11 @@ div.icon img {
   top: 90px;
 }
 
+@media screen and (max-width:991px) {
+  .timing-diagram-panel{
+    left: 200px;
+  }
+}
 .timing-diagram-panel .panel-header {
   border-radius: 5px;
   border-top-right-radius: 5px;
@@ -1155,6 +1166,7 @@ input:checked + .slider:before {
 }
 .navbar {
   transition: background .5s ease-out; 
+  z-index: 100;
 }
 
 

--- a/simulator/src/css/main.stylesheet.css
+++ b/simulator/src/css/main.stylesheet.css
@@ -704,7 +704,11 @@ div.icon img {
   left: 300px;
   top: 90px;
 }
-
+@media screen and (max-width:1143px) {
+  .timing-diagram-panel{
+    left: 100px;
+  }
+}
 @media screen and (max-width:991px) {
   .timing-diagram-panel{
     left: 200px;


### PR DESCRIPTION
Fixes #1945 
Fixes #2108 

#### Describe the changes you have made in this PR -

#### Bugs

1.) The "TIMING DIAGRAM" is overlapping to one more template in the screen sizes 1143px or less.
2.) The toggling on of the navigation bar at screen sizes less than 991px, the contents of the navigation bar are hidden.

This pr fixed both of these issues.

### Screenshots of the changes (If any) -

<img width="913" alt="Screenshot 2021-11-19 at 2 51 59 PM" src="https://user-images.githubusercontent.com/76155456/142599619-1bdbfcd2-dcce-45bb-aafe-54d11109256d.png">

Please provide me with appropriate feedback/review so that I can continue working on this.
