### PR TITLE
Renaming Resume and Pause Timing Diagram  to  Resume auto-scroll and Pause auto-scroll

### DIFF
--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -205,8 +205,8 @@
       <button class='custom-btn--tertiary panel-button' title="Autocalibrate Cycle Units"><span class="fas fa-magic timing-diagram-calibrate"></button>
       <button class='custom-btn--primary panel-button' title="Zoom In"><span class="fas fa-search-plus timing-diagram-zoom-in"></button>
       <button class='custom-btn--primary panel-button' title="Zoom Out"><span class="fas fa-search-minus timing-diagram-zoom-out"></button>
-      <button class='custom-btn--primary panel-button' title="Resume auto-scroll"><span class="fas fa-play resume-autoscroll"></button>
-      <button class='custom-btn--primary panel-button' title="Pause auto-scroll"><span class="fas fa-pause pause-autoscroll"></button>
+      <button class='custom-btn--primary panel-button' title="Resume auto-scroll"><span class="fas fa-play timing-diagram-resume"></button>
+      <button class='custom-btn--primary panel-button' title="Pause auto-scroll"><span class="fas fa-pause timing-diagram-pause"></button>
       1 cycle = 
       <input id="timing-diagram-units" type="number" min="1" autocomplete="off" value="1000">
       Units

--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -205,8 +205,8 @@
       <button class='custom-btn--tertiary panel-button' title="Autocalibrate Cycle Units"><span class="fas fa-magic timing-diagram-calibrate"></button>
       <button class='custom-btn--primary panel-button' title="Zoom In"><span class="fas fa-search-plus timing-diagram-zoom-in"></button>
       <button class='custom-btn--primary panel-button' title="Zoom Out"><span class="fas fa-search-minus timing-diagram-zoom-out"></button>
-      <button class='custom-btn--primary panel-button' title="Resume Timing Diagram"><span class="fas fa-play timing-diagram-resume"></button>
-      <button class='custom-btn--primary panel-button' title="Pause Timing Diagram"><span class="fas fa-pause timing-diagram-pause"></button>
+      <button class='custom-btn--primary panel-button' title="Resume auto-scroll"><span class="fas fa-play resume-autoscroll"></button>
+      <button class='custom-btn--primary panel-button' title="Pause auto-scroll"><span class="fas fa-pause pause-autoscroll"></button>
       1 cycle = 
       <input id="timing-diagram-units" type="number" min="1" autocomplete="off" value="1000">
       Units

--- a/simulator/src/plotArea.js
+++ b/simulator/src/plotArea.js
@@ -425,10 +425,10 @@ export function setupTimingListeners() {
     $('.timing-diagram-calibrate').on('click', () => {
         plotArea.calibrate();
     })
-    $('.resume-autoscroll').on('click', () => {
+    $('.timing-diagram-resume').on('click', () => {
         plotArea.resume();
     })
-    $('.pause-autoscroll').on('click', () => {
+    $('.timing-diagram-pause').on('click', () => {
         plotArea.pause();
     })
     $('.timing-diagram-download').on('click', () => {

--- a/simulator/src/plotArea.js
+++ b/simulator/src/plotArea.js
@@ -425,10 +425,10 @@ export function setupTimingListeners() {
     $('.timing-diagram-calibrate').on('click', () => {
         plotArea.calibrate();
     })
-    $('.timing-diagram-resume').on('click', () => {
+    $('.resume-autoscroll').on('click', () => {
         plotArea.resume();
     })
-    $('.timing-diagram-pause').on('click', () => {
+    $('.pause-autoscroll').on('click', () => {
         plotArea.pause();
     })
     $('.timing-diagram-download').on('click', () => {


### PR DESCRIPTION
Fixes #2095 

#### Describe the changes you have made in this PR -
I have renamed the tooltips to "Resume auto-scroll" and "Pause auto-scroll" respectively as described in the issue that the  "Resume Timing Diagram" and "Pause Timing Diagram"  are misleading the users...

### Screenshots of the changes (If any) -
<img width="949" alt="2021-11-20" src="https://user-images.githubusercontent.com/89515816/142723428-8dcdbade-71ab-47e8-8ecc-8ff6be92a1ae.png">
<img width="930" alt="2021-11-20 (1)" src="https://user-images.githubusercontent.com/89515816/142723442-ca32c2ad-bd6c-4778-90b0-879530d143a1.png">



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
