### PR TITLE
Fix the Longer Circuit  Name Bug : Insert Subcircuit Dialog

### DIFF
--- a/simulator/src/css/main.stylesheet.css
+++ b/simulator/src/css/main.stylesheet.css
@@ -1277,12 +1277,12 @@ font: inherit;
 }
 
 #insertSubcircuitDialog > label {
-  height: 30px;
   border-radius: 3px;
-  margin: 0 5px;
+  margin: 0 10px;
   margin-bottom: 4px;
   justify-content: center;
-  padding-left: 10px;
+  padding: 4px 4px 4px 13px;
+  line-height: 20px;
 }
 
 #miniMap {


### PR DESCRIPTION
Fixes #1711 

#### Describe the changes you have made in this PR -

#### Bug:
Longer Circuit names either with space or without space give abnormality while the Insert Subcircuit option is clicked.

#### After changes
Now The Circuit Name with space does not overlap and remains inside the div, making the text enter the next line.


### Screenshots of the changes (If any) -

<img width="1680" alt="Screenshot 2021-11-21 at 5 43 22 PM" src="https://user-images.githubusercontent.com/76155456/142762396-1256d255-8470-4dd2-bca1-cf44f94d6da6.png">


Kindly provide me with appropriate feedback so that I can continue working on this.
