### PR TITLE
Added a View option in menu bar Fixes: #1966

### DIFF
--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -53,6 +53,13 @@
           <li><a class="dropdown-item text-left pl-1 logixButton" id="generateVerilog">Export Verilog</a>
         </ul>
       </li>
+      <li class="dropdown nav-dropdown">
+        <a href="#" class="" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><%= t("simulator.nav_item.view") %><span class="caret"></span></a>
+        <ul class="dropdown-menu">
+         <li><a class="dropdown-item text-left pl-1" id="testbench_Link">Testbench</a></li>
+         <li><a class="dropdown-item text-left pl-1" id="timing_Diagram">Timing Diagram</a></li>
+        </ul>
+      </li>
       <li class="dropdown tour-help nav-dropdown">
         <a href="#" class="" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><%= t("simulator.nav_item.help") %><span class="caret"></span></a>
         <ul class="dropdown-menu">
@@ -190,7 +197,7 @@
     <div class="accordion" id="subcircuitMenu"></div>
   </div>
 </div>
-<div class="timing-diagram-panel draggable-panel">
+<div id="TimingDiagram" class="timing-diagram-panel draggable-panel" style="display:none;">
 <div class="panel-header">Timing Diagram
   <span class="fas fa-minus-square minimize panel-button"></span>
   <span class="fas fa-external-link-square-alt maximize panel-button-icon"></span>
@@ -219,7 +226,7 @@
     </div>
   </div>
 </div>
-<div class="testbench-manual-panel draggable-panel noSelect defaultCursor">
+<div id="testbenchDialog"  style="display: none;" class="testbench-manual-panel draggable-panel noSelect defaultCursor">
   <div class="panel-header">Testbench
     <span class="fas fa-minus-square minimize panel-button"></span>
     <span class="fas fa-external-link-square-alt maximize panel-button-icon"></span>
@@ -304,8 +311,8 @@
     <div class="layout-body">
       <div>
         <p class="text-center mb-2">Select a theme: </p>
-          <select id="selectVerilogTheme" class="applyTheme" style="width:90%;">    
-            <optgroup label="Light Themes">     
+          <select id="selectVerilogTheme" class="applyTheme" style="width:90%;">
+            <optgroup label="Light Themes">
               <option>default</option>
               <option>solarized</option>
               <option>elegant</option>
@@ -702,7 +709,24 @@
     </div>
   </div>
 </div>
+<script>
+  // To hide and show testbench and Timing Diagram dialogs
+  $('#testbench_Link').click((event) => {
+    if ($('#testbenchDialog').css('display') === 'none') {
+        $('#testbenchDialog').show();
+      } else {
+        $('#testbenchDialog').hide();
+      }
+  });
 
+  $('#timing_Diagram').click((event) => {
+    if ($('#TimingDiagram').css('display') === 'none') {
+        $('#TimingDiagram').show();
+      } else {
+        $('#TimingDiagram').hide();
+      }
+  });
+</script>
 <script>
   const embed = false;
   user_id = "<%= user_signed_in? ? " #{current_user.id.to_s} - #{current_user.name}" : "Guest user" %>";

--- a/config/locales/views/simulator/navigation/en.yml
+++ b/config/locales/views/simulator/navigation/en.yml
@@ -1,7 +1,8 @@
 en:
   simulator:
-    nav_item: 
+    nav_item:
       project: "Project"
       circuit: "Circuit"
       tools: "Tools"
       help: "Help"
+      view: "View"


### PR DESCRIPTION
Fixes #1966 

#### Describe the changes you have made in this PR -

#### Requested Feature
Before, the Simulator area (working area) is cluttered with different dialogs, which may not be used frequently by the User, Now added the `View` Option for Testbench and Timing Diagram dialogs, to open when the user needs them, make the simulator canvas less cluttered and offer more space to work.

#### Changes 
Added view option in the menu bar for 
- [x] Testbench 
- [x] Timing Diagram

### Screenshots of the changes (If any) -


https://user-images.githubusercontent.com/76155456/164971908-3bbb4169-9c18-482a-a88f-72481615f5a3.mov






Please provide me with appropriate feedback, so that I can continue working on this.
