### PR TITLE
Edit Project screen open in new tab

### DIFF
--- a/simulator/src/data/save.js
+++ b/simulator/src/data/save.js
@@ -326,7 +326,6 @@ export default async function save() {
 
     projectSavedSet(true);
 
-    $('.loadingIcon').fadeIn();
     const data = generateSaveData();
 
     const projectName = getProjectName();
@@ -343,6 +342,7 @@ export default async function save() {
         // Create new project - this part needs to be improved and optimised
         const form = $('<form/>', {
             action: '/simulator/create_data',
+            target:'_blank',
             method: 'post',
         });
         form.append(
@@ -377,6 +377,10 @@ export default async function save() {
 
         $('body').append(form);
         form.submit();
+        const url_projectName = projectName.replace(/\s+/g, '-').toLowerCase();
+        setInterval(()=>{
+            window.location.href =`/simulator/edit/${url_projectName}`;
+        },1000);
     } else {
         // updates project - this part needs to be improved and optimised
         $.ajax({


### PR DESCRIPTION
Fixes #1358 

#### Describe the changes you have made in this PR -

#### Before
Whenever a user clicks to save his project [online], he gets redirected to the Edit Project Screen losing his work area.

If he wants to work further on his project he needs to click on the update project button from the Edit Project Screen then click on Launch Simulator to get his circuit back.

#### After Changes

The Edit Project Screen opens in a new tab, on clicking on the `save online` button.

### Screenshots of the changes (If any) -


https://user-images.githubusercontent.com/76155456/143478271-baac52f3-348f-4e59-8b52-a87ec74c10e5.mov


#### Code Reference:

```
target:'_blank'
```
To open the form in the new Tab.

-----

```
  setInterval(()=>{
            window.location.href =`/simulator/edit/${url_projectName}`;
        },1000);
```
`setInterval()` is used to redirect the page to `/simulator/edit/{project_name}` after clicking on the `save online` button . So that, the user can continue working on the project and save the changes in the current project.


Please provide me with appropriate feedback so that I can continue working on this
