### PR TITLE
Fix : Added Author name below the project name in favourite page  #1315

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -224,7 +224,7 @@
   border: 1px solid $primary-green;
   border-radius: 0;
   display: inline-block;
-  max-height: 370px;
+  max-height: 418px;
   margin-bottom: 15px;
   margin-left: 10px;
   margin-right: 10px;

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -224,11 +224,11 @@
   border: 1px solid $primary-green;
   border-radius: 0;
   display: inline-block;
-  max-height: 418px;
   margin-bottom: 15px;
   margin-left: 10px;
   margin-right: 10px;
   margin-top: 15px;
+  max-height: 418px;
   max-width: 350px;
   min-width: 260px;
   width: 92%;
@@ -257,7 +257,9 @@
     white-space: nowrap;
   }
 }
-
+.users-card-authorname {
+  height: 18px;
+}
 .users-card-name:hover .tooltiptext {
   opacity: 1;
   visibility: visible;

--- a/app/views/users/circuitverse/_dashboard.html.erb
+++ b/app/views/users/circuitverse/_dashboard.html.erb
@@ -7,6 +7,9 @@
             <p><%= project.name %></p>
             <span class="tooltiptext"><%= project.name %></span>
           </div>
+          <p>
+            <sub>Author: <%= project.author.name %></sub>
+          <p>
           <div class="users-tag-container">
             <% if !project.assignment_id.nil? %>
               <span class="badge search-tag"><%= t("assignment") %></span>

--- a/app/views/users/circuitverse/_dashboard.html.erb
+++ b/app/views/users/circuitverse/_dashboard.html.erb
@@ -7,7 +7,7 @@
             <p><%= project.name %></p>
             <span class="tooltiptext"><%= project.name %></span>
           </div>
-          <p>
+          <p class="users-card-authorname">
             <sub>Author: <%= project.author.name %></sub>
           <p>
           <div class="users-tag-container">


### PR DESCRIPTION
Fixes #1315 

#### Describe the changes you have made in this PR -

#### Before:
The circuits on the Favourites Page don't display the author name, which becomes confusing and that is important information that should be supplied.

#### Fixed Changes:
Added the author name below the project title to make it clear for the user which circuit belong to him and which one is forked.

### Screenshots of the changes (If any) -

<img width="1680" alt="Screenshot 2021-11-26 at 1 00 50 AM" src="https://user-images.githubusercontent.com/76155456/143587935-7925a69b-4dc1-4156-82fc-3a403e802c31.png">


Please provide me with appropriate feedback so that I can continue working on this.

