### PR TITLE
Added more Verbose Input description for  splitters

### DIFF
--- a/simulator/src/circuitElement.js
+++ b/simulator/src/circuitElement.js
@@ -50,7 +50,7 @@ export default class CircuitElement {
         this.scope = scope;
         this.baseSetup();
 
-        this.bitWidth = bitWidth || parseInt(prompt('Enter bitWidth','Enter the source bandwidth here'), 10) || 1;
+        this.bitWidth = bitWidth || parseInt(prompt('Enter bitWidth' , 'Enter the source bandwidth here:  Eg.  4'), 10) || 1;
         this.direction = dir;
         this.directionFixed = false;
         this.labelDirectionFixed = false;

--- a/simulator/src/circuitElement.js
+++ b/simulator/src/circuitElement.js
@@ -50,7 +50,7 @@ export default class CircuitElement {
         this.scope = scope;
         this.baseSetup();
 
-        this.bitWidth = bitWidth || parseInt(prompt('Enter bitWidth'), 10) || 1;
+        this.bitWidth = bitWidth || parseInt(prompt('Enter bitWidth','Enter the source bandwidth here'), 10) || 1;
         this.direction = dir;
         this.directionFixed = false;
         this.labelDirectionFixed = false;

--- a/simulator/src/circuitElement.js
+++ b/simulator/src/circuitElement.js
@@ -50,7 +50,7 @@ export default class CircuitElement {
         this.scope = scope;
         this.baseSetup();
 
-        this.bitWidth = bitWidth || parseInt(prompt('Enter bitWidth' , 'Enter the source bandwidth here:  Eg.  4'), 10) || 1;
+        this.bitWidth = bitWidth || parseInt(prompt('Enter bitWidth', 'Enter the source bandwidth here:  Eg.  4'), 10) || 1;
         this.direction = dir;
         this.directionFixed = false;
         this.labelDirectionFixed = false;

--- a/simulator/src/modules/Splitter.js
+++ b/simulator/src/modules/Splitter.js
@@ -38,7 +38,7 @@ export default class Splitter extends CircuitElement {
         */
         this.rectangleObject = false;
 
-        this.bitWidthSplit = bitWidthSplit || prompt('Enter bitWidth Split' , 'eg. 1 1 1 1').split(' ').filter((lambda) => lambda !== '').map((lambda) => parseInt(lambda, 10) || 1);
+        this.bitWidthSplit = bitWidthSplit || prompt('Enter bitWidth Split', 'eg. 1 1 1 1').split(' ').filter((lambda) => lambda !== '').map((lambda) => parseInt(lambda, 10) || 1);
         this.splitCount = this.bitWidthSplit.length;
 
         this.setDimensions(10, (this.splitCount - 1) * 10 + 10);

--- a/simulator/src/modules/Splitter.js
+++ b/simulator/src/modules/Splitter.js
@@ -38,7 +38,7 @@ export default class Splitter extends CircuitElement {
         */
         this.rectangleObject = false;
 
-        this.bitWidthSplit = bitWidthSplit || prompt('Enter bitWidth Split').split(' ').filter((lambda) => lambda !== '').map((lambda) => parseInt(lambda, 10) || 1);
+        this.bitWidthSplit = bitWidthSplit || prompt('Enter bitWidth Split','eg.  2 4 5 8 12').split(' ').filter((lambda) => lambda !== '').map((lambda) => parseInt(lambda, 10) || 1);
         this.splitCount = this.bitWidthSplit.length;
 
         this.setDimensions(10, (this.splitCount - 1) * 10 + 10);

--- a/simulator/src/modules/Splitter.js
+++ b/simulator/src/modules/Splitter.js
@@ -38,7 +38,7 @@ export default class Splitter extends CircuitElement {
         */
         this.rectangleObject = false;
 
-        this.bitWidthSplit = bitWidthSplit || prompt('Enter bitWidth Split','eg.  2 4 5 8 12').split(' ').filter((lambda) => lambda !== '').map((lambda) => parseInt(lambda, 10) || 1);
+        this.bitWidthSplit = bitWidthSplit || prompt('Enter bitWidth Split' , 'eg. 1 1 1 1').split(' ').filter((lambda) => lambda !== '').map((lambda) => parseInt(lambda, 10) || 1);
         this.splitCount = this.bitWidthSplit.length;
 
         this.setDimensions(10, (this.splitCount - 1) * 10 + 10);


### PR DESCRIPTION
Fixes #1368
#### Describe the changes you have made in this PR -
I have added more verbose input descriptions for splitters as described in issue#1368 

### Screenshots of the changes (If any) -
BEFORE->
![Screenshot (19)](https://user-images.githubusercontent.com/89515816/143678061-c849ca93-aa46-4054-a15d-da336c80fcb7.png)
![Screenshot (20)](https://user-images.githubusercontent.com/89515816/143678069-db46f132-3316-40c7-ada6-2b984a181fe9.png)

AFTER->
![Screenshot (22)](https://user-images.githubusercontent.com/89515816/143678793-49a06fc9-cb9c-481f-b77d-6f141b494b80.png)
![Screenshot (21)](https://user-images.githubusercontent.com/89515816/143678805-a37d183d-c177-4ebf-9311-1e6f72714842.png)


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
