### PR TITLE
Added Redo option for the Simulator #376 #1856

### DIFF
--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -125,6 +125,10 @@
         </button>
       </div>
       <div>
+        <button type="button" class="quick-btn-redo" title="Redo" id="redoButton">
+        </button>
+      </div>
+      <div>
         <button type="button" class="quick-btn-view" title="Preview Circuit" id="viewButton"><i style="color: #ddd;" class="fas fa-expand-arrows-alt"></i>
         </button>
       </div>

--- a/simulator/src/circuit.js
+++ b/simulator/src/circuit.js
@@ -219,6 +219,8 @@ export default class Scope {
         // root object for referring to main canvas - intermediate node uses this
         this.root = new CircuitElement(0, 0, this, 'RIGHT', 1);
         this.backups = [];
+        // maintaining a state (history) for redo function
+        this.history = [];
         this.timeStamp = new Date().getTime();
         this.verilogMetadata = {
             isVerilogCircuit: false,

--- a/simulator/src/data/backupCircuit.js
+++ b/simulator/src/data/backupCircuit.js
@@ -58,6 +58,7 @@ export function scheduleBackup(scope = globalScope) {
     var backup = JSON.stringify(backUp(scope));
     if (scope.backups.length === 0 || scope.backups[scope.backups.length - 1] !== backup) {
         scope.backups.push(backup);
+        scope.history = [];
         scope.timeStamp = new Date().getTime();
         projectSavedSet(false);
     }

--- a/simulator/src/data/backupCircuit.js
+++ b/simulator/src/data/backupCircuit.js
@@ -56,7 +56,7 @@ export function backUp(scope = globalScope) {
 
 export function scheduleBackup(scope = globalScope) {
     var backup = JSON.stringify(backUp(scope));
-    if ((scope.backups.length === 0 || scope.backups[scope.backups.length - 1] !== backup) && backUp(scope).allNodes.length !== 0 ) {
+    if (scope.backups.length === 0 || scope.backups[scope.backups.length - 1] !== backup) {
         scope.backups.push(backup);
         scope.history = [];
         scope.timeStamp = new Date().getTime();

--- a/simulator/src/data/backupCircuit.js
+++ b/simulator/src/data/backupCircuit.js
@@ -56,7 +56,7 @@ export function backUp(scope = globalScope) {
 
 export function scheduleBackup(scope = globalScope) {
     var backup = JSON.stringify(backUp(scope));
-    if (scope.backups.length === 0 || scope.backups[scope.backups.length - 1] !== backup) {
+    if ((scope.backups.length === 0 || scope.backups[scope.backups.length - 1] !== backup) && backUp(scope).allNodes.length !== 0 ) {
         scope.backups.push(backup);
         scope.history = [];
         scope.timeStamp = new Date().getTime();

--- a/simulator/src/data/redo.js
+++ b/simulator/src/data/redo.js
@@ -1,0 +1,48 @@
+/* eslint-disable import/no-cycle */
+/**
+ * Function to restore copy from backup
+ * @param {Scope=} scope - The circuit on which redo is called
+ * @category data
+ */
+ import { layoutModeGet } from '../layoutMode';
+ import Scope, { scopeList } from '../circuit';
+ import { loadScope } from './load';
+ import { updateRestrictedElementsInScope } from '../restrictedElementDiv';
+ import { forceResetNodesSet } from '../engine';
+ 
+ /**
+  * Function called to generate a prompt to save an image
+  * @param {Scope=} - the circuit in which we want to call redo
+  * @category data
+  * @exports redo
+  */
+ export default function redo(scope = globalScope) {
+     if (layoutModeGet()) return;
+     if (scope.history.length === 0) return;
+     const backupOx = globalScope.ox;
+     const backupOy = globalScope.oy;
+     const backupScale = globalScope.scale;
+     globalScope.ox = 0;
+     globalScope.oy = 0;
+     const tempScope = new Scope(scope.name);
+     loading = true;
+     const redoData = scope.history.pop();
+     scope.backups.push(redoData)
+     loadScope(tempScope, JSON.parse(redoData));
+     tempScope.backups = scope.backups;
+     tempScope.history = scope.history;
+     tempScope.id = scope.id;
+     tempScope.name = scope.name;
+     scopeList[scope.id] = tempScope;
+     globalScope = tempScope;
+     globalScope.ox = backupOx;
+     globalScope.oy = backupOy;
+     globalScope.scale = backupScale;
+     loading = false;
+     forceResetNodesSet(true);
+    
+     // Updated restricted elements
+     updateRestrictedElementsInScope();
+ }
+ // for html file
+ 

--- a/simulator/src/data/redo.js
+++ b/simulator/src/data/redo.js
@@ -4,45 +4,43 @@
  * @param {Scope=} scope - The circuit on which redo is called
  * @category data
  */
- import { layoutModeGet } from '../layoutMode';
- import Scope, { scopeList } from '../circuit';
- import { loadScope } from './load';
- import { updateRestrictedElementsInScope } from '../restrictedElementDiv';
- import { forceResetNodesSet } from '../engine';
- 
- /**
-  * Function called to generate a prompt to save an image
-  * @param {Scope=} - the circuit in which we want to call redo
-  * @category data
-  * @exports redo
-  */
- export default function redo(scope = globalScope) {
-     if (layoutModeGet()) return;
-     if (scope.history.length === 0) return;
-     const backupOx = globalScope.ox;
-     const backupOy = globalScope.oy;
-     const backupScale = globalScope.scale;
-     globalScope.ox = 0;
-     globalScope.oy = 0;
-     const tempScope = new Scope(scope.name);
-     loading = true;
-     const redoData = scope.history.pop();
-     scope.backups.push(redoData)
-     loadScope(tempScope, JSON.parse(redoData));
-     tempScope.backups = scope.backups;
-     tempScope.history = scope.history;
-     tempScope.id = scope.id;
-     tempScope.name = scope.name;
-     scopeList[scope.id] = tempScope;
-     globalScope = tempScope;
-     globalScope.ox = backupOx;
-     globalScope.oy = backupOy;
-     globalScope.scale = backupScale;
-     loading = false;
-     forceResetNodesSet(true);
-    
-     // Updated restricted elements
-     updateRestrictedElementsInScope();
- }
- // for html file
- 
+import { layoutModeGet } from '../layoutMode';
+import Scope, { scopeList } from '../circuit';
+import { loadScope } from './load';
+import { updateRestrictedElementsInScope } from '../restrictedElementDiv';
+import { forceResetNodesSet } from '../engine';
+/**
+ * Function called to generate a prompt to save an image
+ * @param {Scope=} - the circuit in which we want to call redo
+ * @category data
+ * @exports redo
+ */
+export default function redo(scope = globalScope) {
+    if (layoutModeGet()) return;
+    if (scope.history.length === 0) return;
+    const backupOx = globalScope.ox;
+    const backupOy = globalScope.oy;
+    const backupScale = globalScope.scale;
+    globalScope.ox = 0;
+    globalScope.oy = 0;
+    const tempScope = new Scope(scope.name);
+    loading = true;
+    const redoData = scope.history.pop();
+    scope.backups.push(redoData);
+    loadScope(tempScope, JSON.parse(redoData));
+    tempScope.backups = scope.backups;
+    tempScope.history = scope.history;
+    tempScope.id = scope.id;
+    tempScope.name = scope.name;
+    scopeList[scope.id] = tempScope;
+    globalScope = tempScope;
+    globalScope.ox = backupOx;
+    globalScope.oy = backupOy;
+    globalScope.scale = backupScale;
+    loading = false;
+    forceResetNodesSet(true);
+
+    // Updated restricted elements
+    updateRestrictedElementsInScope();
+}
+// for html file

--- a/simulator/src/data/undo.js
+++ b/simulator/src/data/undo.js
@@ -9,7 +9,7 @@ import Scope, { scopeList } from '../circuit';
 import { loadScope } from './load';
 import { updateRestrictedElementsInScope } from '../restrictedElementDiv';
 import { forceResetNodesSet } from '../engine';
-
+import { scheduleBackup } from './backupCircuit';
 /**
  * Function called to generate a prompt to save an image
  * @param {Scope=} - the circuit in which we want to call undo
@@ -19,6 +19,7 @@ import { forceResetNodesSet } from '../engine';
 export default function undo(scope = globalScope) {
     if (layoutModeGet()) return;
     if (scope.backups.length === 0) return;
+    scheduleBackup(); // Backup current globalscope
     const backupOx = globalScope.ox;
     const backupOy = globalScope.oy;
     const backupScale = globalScope.scale;
@@ -26,8 +27,11 @@ export default function undo(scope = globalScope) {
     globalScope.oy = 0;
     const tempScope = new Scope(scope.name);
     loading = true;
-    loadScope(tempScope, JSON.parse(scope.backups.pop()));
+    const undoData = scope.backups.pop();
+    scope.history.push(undoData);
+    scope.backups.length !== 0 && loadScope(tempScope, JSON.parse(scope.backups[scope.backups.length - 1]));
     tempScope.backups = scope.backups;
+    tempScope.history = scope.history;
     tempScope.id = scope.id;
     tempScope.name = scope.name;
     scopeList[scope.id] = tempScope;

--- a/simulator/src/data/undo.js
+++ b/simulator/src/data/undo.js
@@ -17,9 +17,9 @@ import { scheduleBackup } from './backupCircuit';
  * @exports undo
  */
 export default function undo(scope = globalScope) {
-    if (layoutModeGet()) return;
-    if (scope.backups.length === 0) return;
     scheduleBackup(); // Backup current globalscope
+    if (layoutModeGet()) return;
+    if (scope.backups.length < 2) return;
     const backupOx = globalScope.ox;
     const backupOy = globalScope.oy;
     const backupScale = globalScope.scale;

--- a/simulator/src/data/undo.js
+++ b/simulator/src/data/undo.js
@@ -9,7 +9,6 @@ import Scope, { scopeList } from '../circuit';
 import { loadScope } from './load';
 import { updateRestrictedElementsInScope } from '../restrictedElementDiv';
 import { forceResetNodesSet } from '../engine';
-import { scheduleBackup } from './backupCircuit';
 /**
  * Function called to generate a prompt to save an image
  * @param {Scope=} - the circuit in which we want to call undo
@@ -17,7 +16,6 @@ import { scheduleBackup } from './backupCircuit';
  * @exports undo
  */
 export default function undo(scope = globalScope) {
-    scheduleBackup(); // Backup current globalscope
     if (layoutModeGet()) return;
     if (scope.backups.length < 2) return;
     const backupOx = globalScope.ox;

--- a/simulator/src/listeners.js
+++ b/simulator/src/listeners.js
@@ -14,6 +14,7 @@ import {
 } from './restrictedElementDiv';
 import { removeMiniMap, updatelastMinimapShown } from './minimap';
 import undo from './data/undo';
+import redo from "./data/redo";
 import { copy, paste, selectAll } from './events';
 import save from './data/save';
 import { createElement } from './ux';
@@ -38,7 +39,9 @@ export default function startListeners() {
     $('#undoButton').on('click',() => {
         undo();
     });
-
+    $('#redoButton').on('click',() => {
+        redo();
+    })
     $('#viewButton').on('click',() => {
         fullView();
     });
@@ -132,8 +135,14 @@ export default function startListeners() {
             simulationArea.controlDown = true;
         }
 
-        if (simulationArea.controlDown && e.key.charCodeAt(0) == 122) { // detect the special CTRL-Z code
+        if (simulationArea.controlDown && e.key.charCodeAt(0) == 122 && !simulationArea.shiftDown) { // detect the special CTRL-Z code
             undo();
+        }
+        if (simulationArea.controlDown && e.key.charCodeAt(0) == 122 && simulationArea.shiftDown) { // detect the special Cmd + shift + z code (macOs)
+            redo();
+        }
+        if (simulationArea.controlDown && e.key.charCodeAt(0) == 121 && !simulationArea.shiftDown) { // detect the special ctrl + Y code (windows)
+            redo();
         }
 
         if (listenToSimulator) {


### PR DESCRIPTION
Fixes #376 #1856 


#### Describe the changes you have made in this PR -

There was no redo option available in the simulator
Added a `redo` option to make the CircuitVerse more user-friendly.

User can redo their work using option present in option bar or Using keyboard shortcuts :
`ctrl + z` for undo .
`ctrl  + y` for redo (windows).
`cmd + z` for undo (macOs).
`shift + cmd + z` for redo (macOs).

### Screenshots of the changes (If any) -

https://user-images.githubusercontent.com/76155456/143687180-dc93b876-85e8-4b9c-a2a2-31720185fafa.mov




Please provide me with appropriate feedback on this PR so that I can continue working on this.