### PR TITLE
added timing diagram panel width constraint according to the document's width to prevent overflow

### DIFF
--- a/simulator/src/plotArea.js
+++ b/simulator/src/plotArea.js
@@ -404,7 +404,7 @@ export function setupTimingListeners() {
         plotArea.resize();
     })
     $('.timing-diagram-larger').on('click', () => {
-        $('#plot').width($('#plot').width() + 20)
+        $('#plot').width(Math.min($('#plot').width() + 20, $(document).width() - 200));
         plotArea.resize();
     })
     $('.timing-diagram-small-height').on('click', () => {


### PR DESCRIPTION

Fixes #2689 

#### Describe the changes you have made in this PR -
Using the min method, setting the width of the timing diagram panel. It is either going to be <code>document.width - 200</code>. or minimum (whichever is lower)

### Screenshots of the changes (If any) -
![image](https://user-images.githubusercontent.com/49204837/145671382-c0076de0-f46f-4a02-bbf1-ca80f979885e.png)

