### PR TITLE
Fix : Undoing subcircuit after removing an input/output node in main circuit crashes the simulator #2688

### DIFF
--- a/simulator/src/data/redo.js
+++ b/simulator/src/data/redo.js
@@ -9,6 +9,7 @@ import Scope, { scopeList } from '../circuit';
 import { loadScope } from './load';
 import { updateRestrictedElementsInScope } from '../restrictedElementDiv';
 import { forceResetNodesSet } from '../engine';
+import { scheduleBackup } from './backupCircuit';
 /**
  * Function called to generate a prompt to save an image
  * @param {Scope=} - the circuit in which we want to call redo
@@ -16,6 +17,7 @@ import { forceResetNodesSet } from '../engine';
  * @exports redo
  */
 export default function redo(scope = globalScope) {
+    scheduleBackup();
     if (layoutModeGet()) return;
     if (scope.history.length === 0) return;
     const backupOx = globalScope.ox;

--- a/simulator/src/data/undo.js
+++ b/simulator/src/data/undo.js
@@ -9,6 +9,7 @@ import Scope, { scopeList } from '../circuit';
 import { loadScope } from './load';
 import { updateRestrictedElementsInScope } from '../restrictedElementDiv';
 import { forceResetNodesSet } from '../engine';
+import { scheduleBackup } from './backupCircuit';
 /**
  * Function called to generate a prompt to save an image
  * @param {Scope=} - the circuit in which we want to call undo
@@ -16,6 +17,7 @@ import { forceResetNodesSet } from '../engine';
  * @exports undo
  */
 export default function undo(scope = globalScope) {
+    scheduleBackup();
     if (layoutModeGet()) return;
     if (scope.backups.length < 2) return;
     const backupOx = globalScope.ox;
@@ -25,8 +27,7 @@ export default function undo(scope = globalScope) {
     globalScope.oy = 0;
     const tempScope = new Scope(scope.name);
     loading = true;
-    const undoData = scope.backups.pop();
-    scope.history.push(undoData);
+    scope.history.push(scope.backups.pop());
     scope.backups.length !== 0 && loadScope(tempScope, JSON.parse(scope.backups[scope.backups.length - 1]));
     tempScope.backups = scope.backups;
     tempScope.history = scope.history;


### PR DESCRIPTION
Fixes #2688

#### Bug:
Undoing circuit with a subcircuit of the main circuit, after removing an input/output node in the main circuit, crashes the simulator.

### Screenshots of the changes (If any) -

https://user-images.githubusercontent.com/76155456/145671640-9a4c8427-d08d-491e-ae92-1d3ec6a31e31.mov


#### undo and redo functionality for unsaved project
https://user-images.githubusercontent.com/76155456/145670928-1f4262d2-1714-472c-bdff-37f440b36fe7.mov

with the reference video, when we undo and then click on the canvas, then it will not empty the `scope.history`  array and same for the saved project.

#### undo and redo functionality for saved project
https://user-images.githubusercontent.com/76155456/145670951-26cc330b-5a69-482e-b438-0d9021049b0a.mov

with the reference video when we undo to a certain limit and then the user does some work ahead, then no redo possible, and the same for unsaved projects.



