### PR TITLE
added horizontal padding to the 'render circuit image' button

### DIFF
--- a/simulator/src/css/main.stylesheet.css
+++ b/simulator/src/css/main.stylesheet.css
@@ -1142,6 +1142,7 @@ input:checked + .slider:before {
   line-height: inherit;
   border-radius: 1px;
   font: inherit;
+  padding: 0 10px;
 }
 
 .ui-dialog .ui-dialog-buttonpane button:hover {


### PR DESCRIPTION
#### Describe the changes you have made in this PR -
Added horizontal padding

### Screenshots of the changes (If any) -
**Before**
![image](https://user-images.githubusercontent.com/49204837/145700694-b1dc2b78-7941-47a1-8705-e8fd7c60e3b1.png)


**After**
![image](https://user-images.githubusercontent.com/49204837/145700680-50c75dc4-d168-44aa-9fd9-638d0e09b1b6.png)
