### PR TITLE
adding border to the text box

### DIFF
--- a/simulator/src/css/main.stylesheet.css
+++ b/simulator/src/css/main.stylesheet.css
@@ -1315,8 +1315,9 @@ font: inherit;
 
 #bitconverterprompt input {
   background: transparent;
-  border: none;
-  outline: none;
+  border: solid;
+  border-width: thin;
+  border-radius: 3px;
   text-align: center;
   font: inherit;
 }


### PR DESCRIPTION
 
 solves issue #2699  by adding a border to the text box making it easily distinguishable .
 
before:
![Screenshot (503)](https://user-images.githubusercontent.com/86882411/146016693-4b2410b8-8b9c-46b7-aabc-55c8873e86a9.png)

After:
![Screenshot (502)](https://user-images.githubusercontent.com/86882411/146016807-9b731e46-c7e7-4330-b7ac-57bf294db3ad.png)


