### PR TITLE
Fix : Re-entering of email in forgot password #489

### DIFF
--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -21,7 +21,7 @@
           <div class="field form-group">
             <h6><%= f.label :email %></h6>
             <div class="input-group">
-              <%= f.email_field :email, autofocus: true, class:"form-control form-input" %>
+              <%= f.email_field :email, autofocus: true, class:"form-control form-input user-email-input" %>
             </div>
           </div>
           <div class="field form-group">
@@ -36,3 +36,7 @@
     </div>
   </div>
 </div>
+<script>
+  $('.user-email-input').val(localStorage.getItem("Email"));
+  localStorage.removeItem("Email");
+</script>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -15,7 +15,7 @@
         <div class="field form-group">
           <h6><%= f.label :email %></h6>
           <div class="input-group">
-            <%= f.email_field :email, autofocus: true, class:"form-control form-input" %>
+            <%= f.email_field :email, autofocus: true, class:"form-control form-input user-email-input" %>
           </div>
         </div>
         <div class="field form-group">
@@ -60,5 +60,9 @@
     </div>
   </div>
 </div>
-
+<script>
+    $(".users-forgot-password-text").on('click', () => {
+      localStorage.setItem('Email', $(".user-email-input").val());
+    });
+</script>
 <script src="/js/togglePassword.js"></script>


### PR DESCRIPTION
Fixes #489

#### Describe the changes you have made in this PR -

Fix : Remove re-entering of email in forgot password

When the user clicks on the `Forget Password?`, temporarily store the entered email in the localStorage and once redirected
remove the item from the localStorage. 


### Screenshots of the changes (If any) -

https://user-images.githubusercontent.com/76155456/146351410-ddb04f03-2975-4116-b254-dde1965c2cf5.mov


Please provide me with appropriate feedback so that I can continue working on it.
