### PR TITLE
Fix: clashing inputs on generating 2 combinational circuits #2203

### DIFF
--- a/simulator/src/combinationalAnalysis.js
+++ b/simulator/src/combinationalAnalysis.js
@@ -11,6 +11,8 @@ import AndGate from './modules/AndGate';
 import OrGate from './modules/OrGate';
 import NotGate from './modules/NotGate';
 import { stripTags } from './utils';
+import simulationArea from './simulationArea';
+import { findDimensions } from './canvasApi';
 
 var inputSample = 5;
 var dataSample = [['01---', '11110', '01---', '00000'], ['01110', '1-1-1', '----0'], ['01---', '11110', '01110', '1-1-1', '0---0'], ['----1']];
@@ -48,7 +50,7 @@ export function createCombinationalAnalysisPrompt(scope = globalScope) {
                     outputList = outputList.filter((e) => e);
                     booleanExpression = booleanExpression.replace(/ /g, '');
                     booleanExpression = booleanExpression.toUpperCase();
-                    
+
                     var booleanInputVariables = [];
                     for (var i = 0; i < booleanExpression.length; i++) {
                         if ((booleanExpression[i] >= 'A' && booleanExpression[i] <= 'Z')) {
@@ -58,11 +60,11 @@ export function createCombinationalAnalysisPrompt(scope = globalScope) {
                         }
                     }
                     booleanInputVariables.sort();
-                    
+
                     if (inputList.length > 0 && outputList.length > 0 && booleanInputVariables.length == 0) {
                         $(this).dialog('close');
                         createBooleanPrompt(inputList, outputList, null, scope);
-                    } 
+                    }
                     else if (booleanInputVariables.length > 0 && inputList.length == 0 && outputList.length == 0) {
                         $(this).dialog('close');
                         var output = solveBooleanFunction(booleanInputVariables, booleanExpression);
@@ -232,6 +234,7 @@ function generateBooleanTableData(outputListNames) {
 }
 
 function drawCombinationalAnalysis(combinationalData, inputList, outputListNames, scope = globalScope) {
+    findDimensions(scope);
     var inputCount = inputList.length;
     var maxTerms = 0;
     for (var i = 0; i < combinationalData.length; i++) { maxTerms = Math.max(maxTerms, combinationalData[i].length); }
@@ -240,6 +243,15 @@ function drawCombinationalAnalysis(combinationalData, inputList, outputListNames
     var startPosY = 200;
 
     var currentPosY = 300;
+
+    if (simulationArea.maxWidth && simulationArea.maxHeight) {
+        if (simulationArea.maxHeight + currentPosY > simulationArea.maxWidth) {
+            startPosX += simulationArea.maxWidth;
+        } else {
+            startPosY += simulationArea.maxHeight;
+            currentPosY += simulationArea.maxHeight;
+        }
+    }
     var andPosX = startPosX + inputCount * 40 + 40 + 40;
     var orPosX = andPosX + Math.floor(maxTerms / 2) * 10 + 80;
     var outputPosX = orPosX + 60;
@@ -259,7 +271,7 @@ function drawCombinationalAnalysis(combinationalData, inputList, outputListNames
             inputObjects.push(new ConstantVal(startPosX + i * 40, startPosY, scope, 'DOWN', 1, '1'));
             inputObjects[i].setLabel('_C_');
         }
-        
+
         inputObjects[i].newLabelDirection('UP');
         var v1 = new Node(startPosX + i * 40, startPosY + 20, 2, scope.root);
         inputObjects[i].output1.connect(v1);
@@ -351,7 +363,7 @@ function drawCombinationalAnalysis(combinationalData, inputList, outputListNames
  * output array which contains solution of the truth table
  * of given boolean expression
  * @param {Array}  inputListNames - labels for input nodes
- * @param {String} booleanExpression - boolean expression which is to be solved 
+ * @param {String} booleanExpression - boolean expression which is to be solved
  */
 function solveBooleanFunction(inputListNames, booleanExpression) {
     let i;
@@ -421,7 +433,7 @@ function solveBooleanFunction(inputListNames, booleanExpression) {
                 equation = equation.substring(0, start)
                 + solve(equation.substring(start + 1, end))
                 + equation.substring(end + 1);
-            }       
+            }
         }
         equation = equation.replace(/''/g, '');
         equation = equation.replace(/0'/g, '1');
@@ -430,7 +442,7 @@ function solveBooleanFunction(inputListNames, booleanExpression) {
             if ((equation[i] == '0' || equation[i] == '1') && (equation[i + 1] == '0' || equation[i + 1] == '1')) {
                 equation = equation.substring(0, i + 1) + '*' + equation.substring(i + 1, equation.length);
             }
-        }        
+        }
         try {
             const safeEval = eval;
             const answer = safeEval(equation);
@@ -439,7 +451,7 @@ function solveBooleanFunction(inputListNames, booleanExpression) {
             }
             if (answer > 0) {
                 return 1;
-            }    
+            }
             return '';
         } catch (e) {
             return '';


### PR DESCRIPTION
Fixes #2203 

Simulator overwrites the first input element when generating 2nd combinational circuit with different boolean variables.

#### Describe the changes you have made in this PR -

Before:

<img width="1680" alt="before changes" src="https://user-images.githubusercontent.com/70064696/113412638-66170080-93d6-11eb-8010-b4e08d4426c1.png"/>

After 

<img width="1680" alt="after changes" src="https://user-images.githubusercontent.com/76155456/148636170-699d7cba-0357-427e-80f7-67ea44882889.png">

Please provide me with appropriate feedback so that I can continue working on this.
