### PR TITLE
Added horizontal padding to 'render circuit image' button

### DIFF
--- a/simulator/src/css/main.stylesheet.css
+++ b/simulator/src/css/main.stylesheet.css
@@ -1142,6 +1142,7 @@ input:checked + .slider:before {
   line-height: inherit;
   border-radius: 1px;
   font: inherit;
+  padding: 0 10px;
 }
 
 .ui-dialog .ui-dialog-buttonpane button:hover {


### PR DESCRIPTION
#### Describe the changes you have made in this PR -
Added horizontal padding to the 'render circuit image' button.

### Screenshots of the changes (If any) -
**Before**
![image](https://user-images.githubusercontent.com/49204837/149891099-90a6051b-1cb8-433a-a5c6-721e0aaf0b10.png)


**After**
![image](https://user-images.githubusercontent.com/49204837/149891037-88d60635-4119-4ff4-82dd-c7f31b726620.png)
