### PR TITLE
Apply padding to tools submenu button#2652

### DIFF
--- a/app/javascript/src/sass/color_theme.scss
+++ b/app/javascript/src/sass/color_theme.scss
@@ -231,7 +231,7 @@ $output-rect: blue;
 
 
 
-.caret-upside{
+.caret-upside {
   transform: rotate(180deg) translate(0,2px) !important;
 }
 .panel-body {

--- a/app/javascript/src/sass/color_theme.scss
+++ b/app/javascript/src/sass/color_theme.scss
@@ -150,6 +150,7 @@ $output-rect: blue;
   color: #fff;
 }
 
+
 .projectName {
   color: #fff;
 }
@@ -228,6 +229,11 @@ $output-rect: blue;
   background: var(--primary);
 }
 
+
+
+.caret-upside{
+  transform: rotate(180deg) translate(0,2px) !important;
+}
 .panel-body {
   color: var(--text-panel);
   border-top: 1px solid var(--br-secondary);

--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -35,7 +35,7 @@
         </ul>
       </li>
       <li class="dropdown nav-dropdown">
-        <a href="#" class="dropdown-caret" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><%= t("simulator.nav_item.circuit") %><span class="caret" ></span></a>
+        <a href="#" class="dropdown-caret" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><%= t("simulator.nav_item.circuit") %><span class="caret"></span></a>
         <ul class="dropdown-menu">
           <li><a class="dropdown-item text-left logixButton pl-1" id="newCircuit">New Circuit + </a></li>
           <li><a class="dropdown-item text-left logixButton pl-1" id="newVerilogModule">New Verilog <br> Module</a></li>
@@ -620,26 +620,19 @@
     $('.dropdown.open').removeClass('open');
     $(this).parent('.dropdown').addClass('open');
   });
-
-
 </script>
 
 <!-- on click for dropdowns -->
-
 <script>
-
 $('.dropdown-caret').click(function(){
      $(this).find('span').toggleClass("caret-upside");
   })
-
   $(document).click(function(){
-    
     if($('.caret').hasClass("caret-upside"))
       {
         $('.caret').removeClass("caret-upside")
       }
   })
-
 </script>
 
 <link rel="stylesheet" type="text/css" href="/css/restrictedElements.css">

--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -643,7 +643,7 @@ $('.dropdown-caret').click(function(){
 </script>
 
 <link rel="stylesheet" type="text/css" href="/css/restrictedElements.css">
-
+<link rel="stylesheet" type="text/css" href="../../../simulator/src/css/main.stylesheet.css">
 <script type="text/javascript" src="/js/metadata.json"></script>
 
 <script>

--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -19,7 +19,7 @@
   <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
     <ul class="navbar-nav navbar-menu noSelect pointerCursor" id="toolbar">
       <li class="dropdown nav-dropdown">
-        <a href="#" class="" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><%= t("simulator.nav_item.project") %><span></span></a>
+        <a href="#" class="dropdown-caret" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><%= t("simulator.nav_item.project") %><span class="caret"></span></a>
         <ul class="dropdown-menu">
           <% if not @project.nil? %>
              <li><a class="dropdown-item logixButton text-left pl-1" href="<%= user_project_url(@project.author, @project) %>" target="_blank">Project Page</a></li>
@@ -35,7 +35,7 @@
         </ul>
       </li>
       <li class="dropdown nav-dropdown">
-        <a href="#" class="" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><%= t("simulator.nav_item.circuit") %><span class="caret"></span></a>
+        <a href="#" class="dropdown-caret" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><%= t("simulator.nav_item.circuit") %><span class="caret" ></span></a>
         <ul class="dropdown-menu">
           <li><a class="dropdown-item text-left logixButton pl-1" id="newCircuit">New Circuit + </a></li>
           <li><a class="dropdown-item text-left logixButton pl-1" id="newVerilogModule">New Verilog <br> Module</a></li>
@@ -43,7 +43,7 @@
         </ul>
       </li>
       <li class="dropdown nav-dropdown">
-        <a href="#" class="" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><%= t("simulator.nav_item.tools") %><span class="caret"></span></a>
+        <a href="#" class="dropdown-caret" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><%= t("simulator.nav_item.tools") %><span class="caret"></span></a>
         <ul class="dropdown-menu">
           <li><a class="dropdown-item text-left pl-1 logixButton" id="createCombinationalAnalysisPrompt">Combinational<br>Analysis</a></li>
           <li><a class="dropdown-item text-left pl-1 logixButton" id="bitconverter">Hex-Bin-Dec<br>Converter</a></li>
@@ -54,7 +54,7 @@
         </ul>
       </li>
       <li class="dropdown tour-help nav-dropdown">
-        <a href="#" class="" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><%= t("simulator.nav_item.help") %><span class="caret"></span></a>
+        <a href="#" class="dropdown-caret" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><%= t("simulator.nav_item.help") %><span class="caret"></span></a>
         <ul class="dropdown-menu">
             <li><a class="dropdown-item text-left pl-1 logixButton" id="showTourGuide">Tutorial Guide</a></li>
             <li><a class="dropdown-item text-left pl-1" href="https://docs.circuitverse.org" class="" target="_blank" role="button" aria-haspopup="true" aria-expanded="false">User Manual</a></li>
@@ -620,6 +620,26 @@
     $('.dropdown.open').removeClass('open');
     $(this).parent('.dropdown').addClass('open');
   });
+
+
+</script>
+
+<!-- on click for dropdowns -->
+
+<script>
+
+$('.dropdown-caret').click(function(){
+     $(this).find('span').toggleClass("caret-upside");
+  })
+
+  $(document).click(function(){
+    
+    if($('.caret').hasClass("caret-upside"))
+      {
+        $('.caret').removeClass("caret-upside")
+      }
+  })
+
 </script>
 
 <link rel="stylesheet" type="text/css" href="/css/restrictedElements.css">

--- a/simulator/src/css/main.stylesheet.css
+++ b/simulator/src/css/main.stylesheet.css
@@ -1328,6 +1328,7 @@ font: inherit;
 
 
 .ui-dialog .ui-dialog-buttonpane button {
+  padding:4px !important;
   margin-left: .4em;
 }
 


### PR DESCRIPTION
Fixes #2652 

#### Describe the changes you have made in this PR -Applied padding to the tools submenu button in the simulator.

### Screenshots of the changes (If any) -
Before:
![143591781-17c15797-a34d-4278-a5c8-166877544cfe](https://user-images.githubusercontent.com/61861303/150098557-f7ebdb0c-f872-413e-a6e9-e3f4029b72fd.jpeg)

After:

<img width="751" alt="Screenshot 2022-01-19 at 12 42 57 PM" src="https://user-images.githubusercontent.com/61861303/150098653-5837d4f5-42c6-4439-9050-3255d933fa0c.png">
<img width="549" alt="Screenshot 2022-01-19 at 12 43 19 PM" src="https://user-images.githubusercontent.com/61861303/150098673-b29a7a3e-13f1-495d-828f-e7256a97aca0.png">

Video Demonstration:https://www.loom.com/share/00cbb0bb3f5a4a42bb1f77ddad2b03f4




Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
