### PR TITLE
Fixed Responsiveness of Examples Page cards

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -123,7 +123,7 @@
 
   p {
     max-height: 30px;
-    max-width: 160px;
+    max-width: 150px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;


### PR DESCRIPTION
Fixes #2857 

#### Describe the changes you have made in this PR -
Changes in margin of the button were useless, as they were ruining the symmetry of the page. So, width of the label had to manipulated with to manage the button within the bounds.

The buttons, circuit card and label, basically the entire ``/examples``  page in effectively response now.

### Screenshots of the changes (If any) -
![Screenshot 2022-02-01 at 2 13 34 PM](https://user-images.githubusercontent.com/76054330/151937440-40132a2f-1438-457a-9c2b-21d6bc62efa1.png)


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
