### PR TITLE
bug: fixed editor scrollbar #2868

### DIFF
--- a/simulator/src/Verilog2CV.js
+++ b/simulator/src/Verilog2CV.js
@@ -176,6 +176,14 @@ export default function generateVerilogCircuit(verilogCode, scope = globalScope)
     });
 }
 
+export function codeMirrorEditorResize(){
+    var navbarHeight = $('.navbar').outerHeight();
+    var tabsbarHeight = $('#tabsBar').outerHeight();
+    var h = window.innerHeight - navbarHeight - tabsbarHeight;
+    console.log(h);
+    $(".codeMirror").height(h);
+}
+
 export function setupCodeMirrorEnvironment() {
     var myTextarea = document.getElementById("codeTextArea");
 
@@ -198,4 +206,9 @@ export function setupCodeMirrorEnvironment() {
     setTimeout(function() {
         editor.refresh();
     },1);
+
+    var navbarHeight = $('.navbar').outerHeight();
+    var tabsbarHeight = $('#tabsBar').outerHeight();
+    var h = window.innerHeight - navbarHeight - tabsbarHeight;
+    $(".codeMirror").height(h);
 }

--- a/simulator/src/Verilog2CV.js
+++ b/simulator/src/Verilog2CV.js
@@ -180,7 +180,6 @@ export function codeMirrorEditorResize(){
     var navbarHeight = $('.navbar').outerHeight();
     var tabsbarHeight = $('#tabsBar').outerHeight();
     var h = window.innerHeight - navbarHeight - tabsbarHeight;
-    console.log(h);
     $(".codeMirror").height(h);
 }
 

--- a/simulator/src/css/main.stylesheet.css
+++ b/simulator/src/css/main.stylesheet.css
@@ -1777,8 +1777,12 @@ input[type='range']::-webkit-slider-thumb {
 
 
 .code-window .CodeMirror {
-  height: calc(100% - 78px);
-  overflow: scroll;
+  height: calc(100vh - 72px);
+}
+@media(max-width: 991px){
+  .code-window .CodeMirror {
+    height: calc(100vh - 82px);
+  }
 }
 
 .code-window-embed .CodeMirror {

--- a/simulator/src/css/main.stylesheet.css
+++ b/simulator/src/css/main.stylesheet.css
@@ -1773,18 +1773,6 @@ input[type='range']::-webkit-slider-thumb {
 
 /*! Color them dialog styles ends here*/
 
-
-
-
-.code-window .CodeMirror {
-  height: calc(100vh - 72px);
-}
-@media(max-width: 991px){
-  .code-window .CodeMirror {
-    height: calc(100vh - 82px);
-  }
-}
-
 .code-window-embed .CodeMirror {
   height: 100%;
   overflow: scroll;

--- a/simulator/src/setup.js
+++ b/simulator/src/setup.js
@@ -25,7 +25,7 @@ import 'codemirror/mode/javascript/javascript'; // verilog.js from codemirror is
 import 'codemirror/addon/edit/closebrackets';
 import 'codemirror/addon/hint/anyword-hint';
 import 'codemirror/addon/hint/show-hint';
-import { setupCodeMirrorEnvironment } from './Verilog2CV';
+import { setupCodeMirrorEnvironment, codeMirrorEditorResize } from './Verilog2CV';
 import { keyBinder } from './hotkey_binder/keyBinder';
 import '../vendor/jquery-ui.min.css';
 import '../vendor/jquery-ui.min';
@@ -68,6 +68,8 @@ export function resetup() {
     update(); // INEFFICIENT, needs to be deprecated
     simulationArea.prevScale = 0;
     dots();
+    
+    codeMirrorEditorResize();
 }
 
 window.onresize = resetup; // listener

--- a/simulator/src/setup.js
+++ b/simulator/src/setup.js
@@ -68,7 +68,6 @@ export function resetup() {
     update(); // INEFFICIENT, needs to be deprecated
     simulationArea.prevScale = 0;
     dots();
-    
     codeMirrorEditorResize();
 }
 


### PR DESCRIPTION
Fixes #2868 

#### Describe the changes you have made in this PR -
##### Vertical Scrolling
Currently 2 scrollbars were getting displayed.
1. one of the div with class-name `codeMirror`
2. second - CodeMirror editors integrated scrollbar
Removed the First one.

##### Horizontal Scrolling
The height given to the editor was larger than the viewport height.
So the horizontal scrollbar being at bottom of editor was not displayed
Fixed the height to `veiwport height - (navbar+tabsbar)`

### Screenshots of the changes (If any) -
https://user-images.githubusercontent.com/61665451/151987100-d9188040-dbf2-43c7-a4a7-99966dc63ae8.mov




Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
