### PR TITLE
Asking Notification permissions

### DIFF
--- a/app/assets/javascripts/webpush.js.erb
+++ b/app/assets/javascripts/webpush.js.erb
@@ -31,7 +31,14 @@ function checkPermissions() {
   if (Notification.permission === "granted") {
     document.getElementById("browser-notifications-status").innerText = "enabled!";
     document.getElementById("browser-notifications-permission-request").innerText = "Test!";
-  } else {
+  }else if (Notification.permission !== 'denied' || Notification.permission === "default") {
+    Notification.requestPermission(function (permission) {
+      if (permission === "granted") {
+         document.getElementById("browser-notifications-status").innerText = "enabled!";
+         document.getElementById("browser-notifications-permission-request").innerText = "Test!";
+      }
+    });
+  }else {
     document.getElementById("browser-notifications-status").innerText = "disabled!";
     document.getElementById("browser-notifications-permission-request").innerText = "Enable!";
   }


### PR DESCRIPTION
Fixes #2862

#### Describe the changes you have made in this PR -
The main issue initially was that, It pre-assumes that either notifications are on or they are off. But for new users who just landed to their profile for very first time they need to be asked for Notification permission. This PR includes dealing with that specific case. 
### Screenshots of the changes (If any) -



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
