### PR TITLE
Add option for publishing grades#2245

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -152,6 +152,15 @@ class AssignmentsController < ApplicationController
     response.headers["X-FRAME-OPTIONS"] = "ALLOW-FROM #{session[:lms_domain]}"
   end
 
+  def publish_grades
+    set_assignment
+    @assignment.update(grades_published: true)
+    respond_to do |format|
+      format.html { redirect_to @group, notice: t("publish_grades_successfull") }
+      format.json { head :no_content }
+    end
+  end
+
   private
 
     # Use callbacks to share common setup or constraints between actions.

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -160,7 +160,7 @@ class AssignmentsController < ApplicationController
     if Flipper.enabled?(:lms_integration, current_user) && session[:is_lti]
       assignment.projects.each do |project|
         grade = Grade.find_by(project_id: grade_params[project.id],
-        assignment_id: grade_params[assignment.id])
+                              assignment_id: grade_params[assignment.id])
         score = grade.to_f / 100 # conversion to 0-0.100 scale as per IMS Global specification
         LtiScoreSubmission.new(
           assignment: assignment,

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -153,13 +153,14 @@ class AssignmentsController < ApplicationController
   end
 
   def publish_grades
-    assignment =  Assignment.includes(:projects).find(params[:id])
+    assignment = Assignment.includes(:projects).find(params[:id])
     assignment.update(grades_published: true)
-    
+
     # Passing all the grades to LMS if LTI integration is enabled
     if Flipper.enabled?(:lms_integration, current_user) && session[:is_lti]
       assignment.projects.each do |project|
-        grade = Grade.find_by(project_id: grade_params[project.id], assignment_id: grade_params[assignment.id])
+        grade = Grade.find_by(project_id: grade_params[project.id],
+        assignment_id: grade_params[assignment.id])
         score = grade.to_f / 100 # conversion to 0-0.100 scale as per IMS Global specification
         LtiScoreSubmission.new(
           assignment: assignment,

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -153,8 +153,23 @@ class AssignmentsController < ApplicationController
   end
 
   def publish_grades
-    set_assignment
-    @assignment.update(grades_published: true)
+    assignment =  Assignment.includes(:projects).find(params[:id])
+    assignment.update(grades_published: true)
+    
+    # Passing all the grades to LMS if LTI integration is enabled
+    if Flipper.enabled?(:lms_integration, current_user) && session[:is_lti]
+      assignment.projects.each do |project|
+        grade = Grade.find_by(project_id: grade_params[project.id], assignment_id: grade_params[assignment.id])
+        score = grade.to_f / 100 # conversion to 0-0.100 scale as per IMS Global specification
+        LtiScoreSubmission.new(
+          assignment: assignment,
+          lis_result_sourced_id: project.lis_result_sourced_id,
+          score: score,
+          lis_outcome_service_url: session[:lis_outcome_service_url]
+        ).call # LTI score submission, see app/helpers/lti_helper.rb
+      end
+    end
+
     respond_to do |format|
       format.html { redirect_to @group, notice: t("publish_grades_successfull") }
       format.json { head :no_content }

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -22,8 +22,8 @@ class GradesController < ApplicationController
 
     assignment = Assignment.find(grade_params[:assignment_id])
 
-    if (Flipper.enabled?(:lms_integration, current_user) && session[:is_lti] 
-      && assignment.grades_published?)
+    if (Flipper.enabled?(:lms_integration, current_user) && session[:is_lti] &&
+      assignment.grades_published?)
       # pass grade back to the LMS if session is LTI
       project = Project.find(grade_params[:project_id])
       assignment = Assignment.find(grade_params[:assignment_id])

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -20,7 +20,9 @@ class GradesController < ApplicationController
     @grade.user_id = current_user.id
     @grade.remarks = remarks
 
-    if Flipper.enabled?(:lms_integration, current_user) && session[:is_lti]
+    assignment = Assignment.find(grade_params[:assignment_id])
+
+    if Flipper.enabled?(:lms_integration, current_user) && session[:is_lti] && assignment.grades_published?
       # pass grade back to the LMS if session is LTI
       project = Project.find(grade_params[:project_id])
       assignment = Assignment.find(grade_params[:assignment_id])

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -22,7 +22,8 @@ class GradesController < ApplicationController
 
     assignment = Assignment.find(grade_params[:assignment_id])
 
-    if Flipper.enabled?(:lms_integration, current_user) && session[:is_lti] && assignment.grades_published?
+    if (Flipper.enabled?(:lms_integration, current_user) && session[:is_lti] 
+      && assignment.grades_published?)
       # pass grade back to the LMS if session is LTI
       project = Project.find(grade_params[:project_id])
       assignment = Assignment.find(grade_params[:assignment_id])

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -23,7 +23,7 @@ class GradesController < ApplicationController
     assignment = Assignment.find(grade_params[:assignment_id])
 
     if Flipper.enabled?(:lms_integration, current_user) && session[:is_lti] &&
-      assignment.grades_published?
+       assignment.grades_published?
       # pass grade back to the LMS if session is LTI
       project = Project.find(grade_params[:project_id])
       assignment = Assignment.find(grade_params[:assignment_id])

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -22,8 +22,8 @@ class GradesController < ApplicationController
 
     assignment = Assignment.find(grade_params[:assignment_id])
 
-    if (Flipper.enabled?(:lms_integration, current_user) && session[:is_lti] &&
-      assignment.grades_published?)
+    if Flipper.enabled?(:lms_integration, current_user) && session[:is_lti] &&
+      assignment.grades_published?
       # pass grade back to the LMS if session is LTI
       project = Project.find(grade_params[:project_id])
       assignment = Assignment.find(grade_params[:assignment_id])

--- a/app/views/assignments/show.html.erb
+++ b/app/views/assignments/show.html.erb
@@ -152,6 +152,13 @@
                     <%= button_tag t("assignments.assignment_data.remove"), id: "grade-form-remove", class: "btn ml-3 primary-delete-button" %>
                   </div>
                 </div>
+                <div>
+                  <% if (@assignment.grades_published?) %>
+                    <button type="button" class="btn btn-secondary mt-4" disabled><%= t("grades_published") %></button>
+                  <% else %>
+                    <%= button_to t("publish_grades"), publish_grades_group_assignment_path(@group, @assignment), method: "put", class: "btn primary-button mt-4" %>
+                  <% end %>
+                </div>
               <% end %>
             <% end %>
           <% end %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -156,7 +156,7 @@
             </td>
             <% unless policy(@group).admin_access? %>
               <td>
-                <% if policy(assignment).show_grades? && project_assignment.present? && assignment.grades_published?%>
+                <% if policy(assignment).show_grades? && project_assignment.present? && assignment.grades_published? %>
                   <div class="groups-assignment-details">
                     <div class="groups-no-assignment-submission-text">
                       <h6>
@@ -288,7 +288,7 @@
                   <tr>
                     <th class="groups-collapsed-table-head groups-assignment-details"><%= t("groups.show.assignment.assignment_table_head.grade") %></th>
                     <td>
-                      <% if policy(assignment).show_grades? && project_assignment.present? && assignment.grades_published?%>
+                      <% if policy(assignment).show_grades? && project_assignment.present? && assignment.grades_published? %>
                         <div class="groups-assignment-details">
                           <div class="groups-no-assignment-submission-text">
                             <h6>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -156,7 +156,7 @@
             </td>
             <% unless policy(@group).admin_access? %>
               <td>
-                <% if policy(assignment).show_grades? && project_assignment.present? %>
+                <% if policy(assignment).show_grades? && project_assignment.present? && assignment.grades_published?%>
                   <div class="groups-assignment-details">
                     <div class="groups-no-assignment-submission-text">
                       <h6>
@@ -288,7 +288,7 @@
                   <tr>
                     <th class="groups-collapsed-table-head groups-assignment-details"><%= t("groups.show.assignment.assignment_table_head.grade") %></th>
                     <td>
-                      <% if policy(assignment).show_grades? && project_assignment.present? %>
+                      <% if policy(assignment).show_grades? && project_assignment.present? && assignment.grades_published?%>
                         <div class="groups-assignment-details">
                           <div class="groups-no-assignment-submission-text">
                             <h6>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,6 +25,9 @@ en:
   reopen: "Reopen"
   close : "Close"
   not_available: "N.A."
+  publish_grades: "Publish Grades"
+  grades_published: "Grades Published"
+  publish_grades_successfull: "Grades have been published successfully."
 # Used in distance_of_time_in_words(), distance_of_time_in_words_to_now(), time_ago_in_words()
   datetime:
     distance_in_words:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -25,6 +25,9 @@ hi:
   reopen: "फिर से खोले"
   close: "बंद करे"
   not_available: "उपलब्ध नहीं है"
+   publish_grades: "ग्रेड प्रकाशित करें"
+  grades_published: "ग्रेड पहले ही प्रकाशित हो चुके हैं"
+  publish_grades_successfull: "ग्रेड सफलतापूर्वक प्रकाशित हो गए हैं।"
   # Used in distance_of_time_in_words(), distance_of_time_in_words_to_now(), time_ago_in_words()
   datetime:
     distance_in_words:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -25,7 +25,7 @@ hi:
   reopen: "फिर से खोले"
   close: "बंद करे"
   not_available: "उपलब्ध नहीं है"
-   publish_grades: "ग्रेड प्रकाशित करें"
+  publish_grades: "ग्रेड प्रकाशित करें"
   grades_published: "ग्रेड पहले ही प्रकाशित हो चुके हैं"
   publish_grades_successfull: "ग्रेड सफलतापूर्वक प्रकाशित हो गए हैं।"
   # Used in distance_of_time_in_words(), distance_of_time_in_words_to_now(), time_ago_in_words()

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,11 @@ Rails.application.routes.draw do
   # resources :assignment_submissions
   resources :group_members, only: %i[create destroy]
   resources :groups, except: %i[index] do
-    resources :assignments, except: %i[index]
+    resources :assignments, except: %i[index] do
+      member do
+        put "publish_grades", to: "assignments#publish_grades", as: "publish_grades"
+      end
+    end
     member do
       get "invite/:token", to: "groups#group_invite", as: "invite"
       put :generate_token

--- a/db/migrate/20220201062919_add_grades_published_to_assignments.rb
+++ b/db/migrate/20220201062919_add_grades_published_to_assignments.rb
@@ -1,0 +1,5 @@
+class AddGradesPublishedToAssignments < ActiveRecord::Migration[6.1]
+  def change
+    add_column :assignments, :grades_published, :boolean, :default => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_08_142725) do
+ActiveRecord::Schema.define(version: 2022_02_01_062919) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,6 +76,7 @@ ActiveRecord::Schema.define(version: 2021_12_08_142725) do
     t.json "restrictions", default: "[]"
     t.string "lti_consumer_key"
     t.string "lti_shared_secret"
+    t.boolean "grades_published", default: false
     t.index ["group_id"], name: "index_assignments_on_group_id"
   end
 


### PR DESCRIPTION
Fixes #2245 

#### Describe the changes you have made in this PR -
Added a button for publishing grades of assignments. Unless the "Publish Grades" option is selected, grades would not be visible to the group members. Once the grades are published by the group mentor they will be visible to the group members. The group mentor can change the grades even after publishing them.
### Screenshots of the changes (If any) -

![not_published](https://user-images.githubusercontent.com/34854802/152158530-c9f4438f-334a-480d-97a1-e165f550a118.png)


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
