### PR TITLE
Fixed Issue where Example page was not responsive

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -123,7 +123,7 @@
 
   p {
     max-height: 30px;
-    max-width: 160px;
+    max-width: 150px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;


### PR DESCRIPTION
Fixes #2857 
- Circuit Cards on https://circuitverse.org/examples was not responsive between 992 and 1199px
-

#### Describe the changes you have made in this PR -
- fixed the width of the circuit-card-name to 150px as the de-alignment of the view icon was caused due to the inadequate space when the window was resized b/w 992 and 1199px.

### Screenshots of the changes (If any) -
Before:
![Screenshot 2022-02-02 144055](https://user-images.githubusercontent.com/95632583/152162801-ecd53ca9-bddc-40c4-a273-289ff513ab43.png)
After:
![Screenshot 2022-02-02 144017](https://user-images.githubusercontent.com/95632583/152162838-58ac8897-9635-467f-a446-74ce5d068fce.png)




Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
