### PR TITLE
hotfix: Remove custom tooltips due to jquery-ui errors

### DIFF
--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -700,12 +700,6 @@
 <script type="text/javascript" src="/js/metadata.json"></script>
 
 <script>
-  $(document).tooltip({
-    show: null,
-    track: true,
-    hide: false,
-    tooltipClass: "custom-tooltip-styling",
-});
 
 $(function(){
     $(".btn-group-toggle").twbsToggleButtons();


### PR DESCRIPTION
Removes custom tooltips because of jquery-ui errors

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
