### PR TITLE
Aligned the copyright text at the center.

### DIFF
--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -79,5 +79,6 @@
 
   p {
     font-size: 15px;
+    text-align: center;
   }
 }


### PR DESCRIPTION
Fixes #2899 

#### The text at the bottom of the footer was misaligned on the left side, traditionally it should be in the middle. 

### Screenshot:
![Screenshot (20)](https://user-images.githubusercontent.com/92917582/152586776-ab3c73cf-8579-45ef-b64d-1c4bd13fb7d5.png)