### PR TITLE
Styling Changes on About-Us Page

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -75,23 +75,28 @@
 .social-card {
   background-color: $card-green;
   box-shadow: 0 2px 7px $shadow-black;
-  display: inline-block;
-  height: 89px;
-  margin: 50px 7px 40px;
+  justify-content: space-evenly;
+  height: 105px;
+  margin: 50px 40px;
   opacity: .89;
   padding: 15px;
   transition: box-shadow .2s ease-in;
-  width: 300px;
-
+  width: 325px;
   &:hover {
     box-shadow: 0 7px 7px $shadow-black;
   }
 }
-
 .social-card-image {
   float: left;
 }
-
+.social-card-container{
+  display: flex;
+  justify-content: center;
+}
+.about-social-card{
+  display: flex;
+  justify-content: center;
+}
 .circuit-card {
   border: 1px solid $primary-green;
   border-radius: 0;

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -75,28 +75,33 @@
 .social-card {
   background-color: $card-green;
   box-shadow: 0 2px 7px $shadow-black;
-  justify-content: space-evenly;
   height: 105px;
+  justify-content: space-evenly;
   margin: 50px 40px;
   opacity: .89;
   padding: 15px;
   transition: box-shadow .2s ease-in;
   width: 325px;
+
   &:hover {
     box-shadow: 0 7px 7px $shadow-black;
   }
 }
+
 .social-card-image {
   float: left;
 }
-.social-card-container{
+
+.social-card-container {
   display: flex;
   justify-content: center;
 }
-.about-social-card{
+
+.about-social-card {
   display: flex;
   justify-content: center;
 }
+
 .circuit-card {
   border: 1px solid $primary-green;
   border-radius: 0;

--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -13,15 +13,15 @@
     <a class="btn primary-button" href="/privacy" target="_blank"><%= t("about.privacy_policy") %></a>
   </div>
   <div class="row center-row">
-    <div class="col-xs col-sm col-md col-lg">
-      <div class="social-card about-social-card-1">
+    <div class="col-xs col-sm col-md col-lg social-card-container">
+      <div class="social-card about-social-card">
+      <%= image_tag "SVGs/email.svg", height: "60", width: "60", alt: "Email Icon", class: "social-card-image" %>
         <a class="about-social-anchor" href="mailto:support@circuitverse.org" target="_blank">
-          <%= image_tag "SVGs/email.svg", height: "60", width: "60", alt: "Email Icon", class: "social-card-image" %>
           <h6><%= t("email_us_heading") %></h6>
           <p>support@circuitverse.org</p>
         </a>
       </div>
-      <div class="social-card about-social-card-2">
+      <div class="social-card about-social-card">
         <a class="about-social-anchor" href="<%= Rails.configuration.slack_url %>" target="_blank">
           <%= image_tag "SVGs/slack.svg", height: "60", width: "60", alt: "Slack Logo", class: "social-card-image" %>
           <h6><%= t("join_at_slack_heading") %></h6>


### PR DESCRIPTION
Fixes #2901 

#### Describe the changes you have made in this PR -
Changed the Styling Components onto the About Page which were need looking as Expected.  Added appropriate flex properties and adjusted incompatible width
### Screenshots of the changes (If any) -
![image](https://user-images.githubusercontent.com/79367883/152597088-ea48e634-bf3f-445d-bc79-8a51107f08cb.png)

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
