### PR TITLE
Fix Bug Related to the Splitter and its Prompt Window

### DIFF
--- a/simulator/src/modules/Splitter.js
+++ b/simulator/src/modules/Splitter.js
@@ -38,7 +38,7 @@ export default class Splitter extends CircuitElement {
         */
         this.rectangleObject = false;
 
-        this.bitWidthSplit = bitWidthSplit || (prompt('Enter bitWidth Split') || `${'1 '.repeat((bitWidth || 1) - 1)}1`).split(' ').filter((lambda) => lambda !== '').map((lambda) => parseInt(lambda, 10) || 1);
+        this.bitWidthSplit = bitWidthSplit || (prompt('Enter bitWidth Split') || `${'1 '.repeat((this.bitWidth || 1) - 1)}1`).split(' ').filter((lambda) => lambda !== '').map((lambda) => parseInt(lambda, 10) || 1);
         this.splitCount = this.bitWidthSplit.length;
 
         this.setDimensions(10, (this.splitCount - 1) * 10 + 10);

--- a/simulator/src/modules/Splitter.js
+++ b/simulator/src/modules/Splitter.js
@@ -38,7 +38,7 @@ export default class Splitter extends CircuitElement {
         */
         this.rectangleObject = false;
 
-        this.bitWidthSplit = bitWidthSplit || (prompt('Enter bitWidth Split') || '1').split(' ').filter((lambda) => lambda !== '').map((lambda) => parseInt(lambda, 10) || 1);
+        this.bitWidthSplit = bitWidthSplit || (prompt('Enter bitWidth Split') || '1 '.repeat((bitWidth || 1) - 1) + '1').split(' ').filter((lambda) => lambda !== '').map((lambda) => parseInt(lambda, 10) || 1);
         this.splitCount = this.bitWidthSplit.length;
 
         this.setDimensions(10, (this.splitCount - 1) * 10 + 10);

--- a/simulator/src/modules/Splitter.js
+++ b/simulator/src/modules/Splitter.js
@@ -38,7 +38,7 @@ export default class Splitter extends CircuitElement {
         */
         this.rectangleObject = false;
 
-        this.bitWidthSplit = bitWidthSplit || (prompt('Enter bitWidth Split') || '1 '.repeat((bitWidth || 1) - 1) + '1').split(' ').filter((lambda) => lambda !== '').map((lambda) => parseInt(lambda, 10) || 1);
+        this.bitWidthSplit = bitWidthSplit || (prompt('Enter bitWidth Split') || `${'1 '.repeat((3 || 1) - 1)}1`).split(' ').filter((lambda) => lambda !== '').map((lambda) => parseInt(lambda, 10) || 1);
         this.splitCount = this.bitWidthSplit.length;
 
         this.setDimensions(10, (this.splitCount - 1) * 10 + 10);

--- a/simulator/src/modules/Splitter.js
+++ b/simulator/src/modules/Splitter.js
@@ -38,7 +38,7 @@ export default class Splitter extends CircuitElement {
         */
         this.rectangleObject = false;
 
-        this.bitWidthSplit = bitWidthSplit || prompt('Enter bitWidth Split').split(' ').filter((lambda) => lambda !== '').map((lambda) => parseInt(lambda, 10) || 1);
+        this.bitWidthSplit = bitWidthSplit || (prompt('Enter bitWidth Split') || '1').split(' ').filter((lambda) => lambda !== '').map((lambda) => parseInt(lambda, 10) || 1);
         this.splitCount = this.bitWidthSplit.length;
 
         this.setDimensions(10, (this.splitCount - 1) * 10 + 10);
@@ -211,7 +211,7 @@ export default class Splitter extends CircuitElement {
             var splitLabel;
             if (this.bitWidthSplit[this.splitCount - i - 1] == 1)
                 splitLabel = `${bitCount}`;
-            else 
+            else
                 splitLabel = `${bitCount}:${bitCount + this.bitWidthSplit[this.splitCount - i - 1] - 1}`;
 
             fillText2(ctx, splitLabel, 16, -20 * i + this.yOffset + 10, xx, yy, this.direction);
@@ -238,7 +238,7 @@ export default class Splitter extends CircuitElement {
             var inpLabel = this.inp1.verilogLabel;
             // Already Split Regex
             var re = /^(.*)\[(\d*):(\d*)\]$/;
-            if(re.test(inpLabel)) {
+            if (re.test(inpLabel)) {
                 var matches = inpLabel.match(re);
                 inpLabel = matches[1];
                 bitCount = parseInt(matches[3]);
@@ -262,7 +262,7 @@ export default class Splitter extends CircuitElement {
         if (!this.isSplitter) {
             res += "assign " + this.inp1.verilogLabel + " = {";
             for (var i = this.outputs.length - 1; i > 0; i--)
-            res += this.outputs[i].verilogLabel + ",";
+                res += this.outputs[i].verilogLabel + ",";
             res += this.outputs[0].verilogLabel + "};";
         }
         return res;

--- a/simulator/src/modules/Splitter.js
+++ b/simulator/src/modules/Splitter.js
@@ -38,7 +38,7 @@ export default class Splitter extends CircuitElement {
         */
         this.rectangleObject = false;
 
-        this.bitWidthSplit = bitWidthSplit || (prompt('Enter bitWidth Split') || `${'1 '.repeat((3 || 1) - 1)}1`).split(' ').filter((lambda) => lambda !== '').map((lambda) => parseInt(lambda, 10) || 1);
+        this.bitWidthSplit = bitWidthSplit || (prompt('Enter bitWidth Split') || `${'1 '.repeat((bitWidth || 1) - 1)}1`).split(' ').filter((lambda) => lambda !== '').map((lambda) => parseInt(lambda, 10) || 1);
         this.splitCount = this.bitWidthSplit.length;
 
         this.setDimensions(10, (this.splitCount - 1) * 10 + 10);


### PR DESCRIPTION
Fixes #2920

#### Describe the changes you have made in this PR -
- Fixed a bug that prevents the Splitter element from properly getting created when a user cancels the prompt window.
- As shown by the screenshot, the change will default to a `1` input if a user were to cancel the prompt window.
- A few whitespace character changes in the code

### Screenshots of the changes (If any) -
![Screen Shot 2022-02-10 at 7 53 23 PM](https://user-images.githubusercontent.com/34720343/153526278-eae1aa7e-5431-48ed-b550-8761b418ab17.png)



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
