### PR TITLE
fix: typo error in class property name

### DIFF
--- a/simulator/src/testbench.js
+++ b/simulator/src/testbench.js
@@ -54,7 +54,7 @@ export class TestbenchData {
      * Checks whether given case-group pair exists in the test
      */
     isCaseValid() {
-        if (this.currentGroup >= this.data.groups.length || this.currentGroup < 0) return false;
+        if (this.currentGroup >= this.testData.groups.length || this.currentGroup < 0) return false;
         const caseCount = this.testData.groups[this.currentGroup].inputs[0].values.length;
         if (this.currentCase >= caseCount || this.currentCase < 0) return false;
 


### PR DESCRIPTION
Fixes: #2937 
#### Describe the changes you have made in this PR -
Typographical error  :  undefined variable `this.data` inside `isCaseValid()` method to `this.testData`

```diff
- if (this.currentGroup >= this.data.groups.length || this.currentGroup < 0) return false;
+ if (this.currentGroup >= this.testData.groups.length || this.currentGroup < 0) return false;
```

