### PR TITLE
fix: change post method to put method to update notification

### DIFF
--- a/app/views/activity_notification/notifications/default/_default.html.erb
+++ b/app/views/activity_notification/notifications/default/_default.html.erb
@@ -25,13 +25,13 @@
 
 <div class='<%= "notification_#{notification.id}" %>'>
   <% if notification.unopened? %>
-    <%= link_to open_notification_path_for(notification, parameters.slice(:routing_scope, :devise_default_routes).merge(reload: false)), method: :post, remote: true, class: "unopened_wrapper" do %>
+    <%= link_to open_notification_path_for(notification, parameters.slice(:routing_scope, :devise_default_routes).merge(reload: false)), method: :put, remote: true, class: "unopened_wrapper" do %>
       <div class="unopned_circle"></div>
       <div class="unopned_description_wrapper">
         <p class="unopned_description">Open</p>
       </div>
     <% end %>
-    <%= link_to open_notification_path_for(notification, parameters.slice(:routing_scope, :devise_default_routes).merge(move: true)), method: :post do %>
+    <%= link_to open_notification_path_for(notification, parameters.slice(:routing_scope, :devise_default_routes).merge(move: true)), method: :put do %>
       <%= yield :notification_content %>
     <% end %>
     <div class="unopened_wrapper"></div>

--- a/app/views/activity_notification/notifications/default/_default_without_grouping.html.erb
+++ b/app/views/activity_notification/notifications/default/_default_without_grouping.html.erb
@@ -18,13 +18,13 @@
 
 <div class='<%= "notification_#{notification.id}" %>'>
   <% if notification.unopened? %>
-    <%= link_to open_notification_path_for(notification, parameters.slice(:with_group_members, :routing_scope, :devise_default_routes).merge(reload: false)), method: :post, remote: true, class: "unopened_wrapper" do %>
+    <%= link_to open_notification_path_for(notification, parameters.slice(:with_group_members, :routing_scope, :devise_default_routes).merge(reload: false)), method: :put, remote: true, class: "unopened_wrapper" do %>
       <div class="unopned_circle"></div>
       <div class="unopned_description_wrapper">
         <p class="unopned_description">Open</p>
       </div>
     <% end %>
-    <%= link_to open_notification_path_for(notification, parameters.slice(:routing_scope, :devise_default_routes).merge(move: true)), method: :post do %>
+    <%= link_to open_notification_path_for(notification, parameters.slice(:routing_scope, :devise_default_routes).merge(move: true)), method: :put do %>
       <%= yield :notification_content %>
     <% end %>
     <div class="unopened_wrapper"></div>


### PR DESCRIPTION
Fixes #2939 

#### Describe the changes you have made in this PR -

- Change method to update unread message from Post to Put

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
