### PR TITLE
fixed: Undoing in sub-circuit after removing an input/output node in main circuit crashes the simulator

### DIFF
--- a/simulator/src/subcircuit.js
+++ b/simulator/src/subcircuit.js
@@ -159,7 +159,7 @@ export default class SubCircuit extends CircuitElement {
                 );
                 this.inputNodes[i].parent = this;
                 this.inputNodes[i].layout_id =
-                    subcircuitScope.Input[i].layoutProperties.id;
+                    subcircuitScope.Input[i]?.layoutProperties.id;
             }
             for (var i = 0; i < this.savedData.outputNodes.length; i++) {
                 this.outputNodes.push(
@@ -167,7 +167,7 @@ export default class SubCircuit extends CircuitElement {
                 );
                 this.outputNodes[i].parent = this;
                 this.outputNodes[i].layout_id =
-                    subcircuitScope.Output[i].layoutProperties.id;
+                    subcircuitScope.Output[i]?.layoutProperties.id;
             }
             if (this.version == "1.0") {
                 // For backward compatibility
@@ -217,14 +217,14 @@ export default class SubCircuit extends CircuitElement {
      */
     makeConnections() {
         for (let i = 0; i < this.inputNodes.length; i++) {
-            this.localScope.Input[i].output1.connectWireLess(
+            this.localScope.Input[i]?.output1.connectWireLess(
                 this.inputNodes[i]
             );
             this.localScope.Input[i].output1.subcircuitOverride = true;
         }
 
         for (let i = 0; i < this.outputNodes.length; i++) {
-            this.localScope.Output[i].inp1.connectWireLess(this.outputNodes[i]);
+            this.localScope.Output[i]?.inp1.connectWireLess(this.outputNodes[i]);
             this.outputNodes[i].subcircuitOverride = true;
         }
     }
@@ -234,13 +234,13 @@ export default class SubCircuit extends CircuitElement {
      */
     removeConnections() {
         for (let i = 0; i < this.inputNodes.length; i++) {
-            this.localScope.Input[i].output1.disconnectWireLess(
+            this.localScope.Input[i]?.output1.disconnectWireLess(
                 this.inputNodes[i]
             );
         }
 
         for (let i = 0; i < this.outputNodes.length; i++) {
-            this.localScope.Output[i].inp1.disconnectWireLess(
+            this.localScope.Output[i]?.inp1.disconnectWireLess(
                 this.outputNodes[i]
             );
         }
@@ -469,7 +469,7 @@ export default class SubCircuit extends CircuitElement {
         if (subcircuitScope.timeStamp > this.lastUpdated) {
             this.reBuildCircuit();
         }
-        
+
         // Should this be done here or only when this.reBuildCircuit() is called?
         {
             this.localScope.reset();
@@ -481,7 +481,7 @@ export default class SubCircuit extends CircuitElement {
     }
 
     /**
-     * Procedure after a element is clicked inside a subcircuit 
+     * Procedure after a element is clicked inside a subcircuit
     **/
     click() {
         var elementClicked = this.getElementHover();
@@ -509,7 +509,7 @@ export default class SubCircuit extends CircuitElement {
             }
         }
     }
-    
+
     /**
       * Sets the elements' wasClicked property in the subcircuit to false
     **/
@@ -635,7 +635,7 @@ export default class SubCircuit extends CircuitElement {
         ctx.beginPath();
         rect2(ctx, -this.leftDimensionX, -this.upDimensionY, this.leftDimensionX + this.rightDimensionX, this.upDimensionY + this.downDimensionY, this.x, this.y, [this.direction, 'RIGHT'][+this.directionFixed]);
         if(!this.elementHover) {
-            if ((this.hover && !simulationArea.shiftDown) || simulationArea.lastSelected === this || simulationArea.multipleObjectSelections.contains(this)) 
+            if ((this.hover && !simulationArea.shiftDown) || simulationArea.lastSelected === this || simulationArea.multipleObjectSelections.contains(this))
                 ctx.fillStyle = colors["hover_select"];
         }
         ctx.fill();


### PR DESCRIPTION
Fixes #2688 

#### Describe the changes you have made in this PR -

Deleting a node(output or input) in the main circuit and then trying to undo in sub-circuit, throw an error that is due to the uncaught exception when the circuit tries to restore a node to the subcircuit when it is not supposed to have a node.

This exception can be caught by using the optional chaining operator for reading the properties of sub-circuit input and output nodes in the subcircuit.js file

### Screenshots of the changes (If any) -
In this example, the main circuit having input and output nodes connected with wire and a sub-circuit with the main circuit and also has input and output node connected...

https://user-images.githubusercontent.com/76155456/154482859-af64b32e-336b-42a8-98cb-0aa468fbb714.mov


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
