### PR TITLE
fix: Test-bench crashes on `Redo`

### DIFF
--- a/simulator/src/data/redo.js
+++ b/simulator/src/data/redo.js
@@ -32,6 +32,7 @@ export default function redo(scope = globalScope) {
     tempScope.history = scope.history;
     tempScope.id = scope.id;
     tempScope.name = scope.name;
+    tempScope.testbenchData = scope.testbenchData;
     scopeList[scope.id] = tempScope;
     globalScope = tempScope;
     globalScope.ox = backupOx;


### PR DESCRIPTION
Fixes #2947 

#### Describe the changes you have made in this PR -
Test-bench crashes on `Redo`, this is bcoz we didn't restore the testbench data from the current scope.
We need to restore testbenchData from the current scope to the `Redo` scope.

```diff
+tempScope.testbenchData = scope.testbenchData;
```