### PR TITLE
Wrong links#2932

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -35,7 +35,7 @@
         <a class="nav-link navbar-item navbar-text <%= request.path == '/teachers' ? 'active' : '' %>" href="/teachers"><%= t("layout.link_to_teachers") %></a>
       </li>
       <li class="nav-item px-1">
-        <a class="nav-link navbar-item navbar-text <%= request.path == '/blog' ? 'active' : '' %>" href="https://blog.circuitverse.org/"target="_blank"><%= t("layout.link_to_blog") %></a>
+        <a class="nav-link navbar-item navbar-text <%= request.path == '/blog' ? 'active' : '' %>" href="https://blog.circuitverse.org/" target="_blank"><%= t("layout.link_to_blog") %></a>
       </li>
       <li class="nav-item px-1">
         <a class="nav-link navbar-item navbar-text <%= request.path == '/about' ? 'active' : '' %>" href="/about"><%= t("layout.link_to_about") %></a>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -35,7 +35,7 @@
         <a class="nav-link navbar-item navbar-text <%= request.path == '/teachers' ? 'active' : '' %>" href="/teachers"><%= t("layout.link_to_teachers") %></a>
       </li>
       <li class="nav-item px-1">
-        <a class="nav-link navbar-item navbar-text <%= request.path == '/blog' ? 'active' : '' %>" href="https://blog.circuitverse.org/" target="_blank"><%= t("layout.link_to_blog") %></a>
+        <a class="nav-link navbar-item navbar-text <%= request.path == '/blog' ? 'active' : '' %>" href="https://blog.circuitverse.org/"target="_blank"><%= t("layout.link_to_blog") %></a>
       </li>
       <li class="nav-item px-1">
         <a class="nav-link navbar-item navbar-text <%= request.path == '/about' ? 'active' : '' %>" href="/about"><%= t("layout.link_to_about") %></a>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -35,7 +35,7 @@
         <a class="nav-link navbar-item navbar-text <%= request.path == '/teachers' ? 'active' : '' %>" href="/teachers"><%= t("layout.link_to_teachers") %></a>
       </li>
       <li class="nav-item px-1">
-        <a class="nav-link navbar-item navbar-text <%= request.path == '/blog' ? 'active' : '' %>" href="https://blog.circuitverse.org/"><%= t("layout.link_to_blog") %></a>
+        <a class="nav-link navbar-item navbar-text <%= request.path == '/blog' ? 'active' : '' %>" href="https://blog.circuitverse.org/" target="_blank"><%= t("layout.link_to_blog") %></a>
       </li>
       <li class="nav-item px-1">
         <a class="nav-link navbar-item navbar-text <%= request.path == '/about' ? 'active' : '' %>" href="/about"><%= t("layout.link_to_about") %></a>

--- a/config/locales/views/groups/en.yml
+++ b/config/locales/views/groups/en.yml
@@ -12,7 +12,7 @@ en:
       title: "CircuitVerse - New Group"
       main_heading: "NEW GROUP"
       main_description_html: "Groups can be used by mentors to set projects for and give grades to students.
-        You can find the documentation <a class='anchor-text' href='https://docs.circuitverse.org/#/chapter2/2cvforeducators' target='_blank'>here</a>."
+        You can find the documentation <a class='anchor-text' href='https://docs.circuitverse.org/#/chapter2/2cvforeducators'target='_blank'>here</a>."
     show:
       edit_name_btn: "Edit Name"
       mentor_name_heading: "Mentor:"

--- a/config/locales/views/groups/en.yml
+++ b/config/locales/views/groups/en.yml
@@ -12,7 +12,7 @@ en:
       title: "CircuitVerse - New Group"
       main_heading: "NEW GROUP"
       main_description_html: "Groups can be used by mentors to set projects for and give grades to students.
-        You can find the documentation <a class='anchor-text' href='https://docs.circuitverse.org/#/groups' target='_blank'>here</a>."
+        You can find the documentation <a class='anchor-text' href='https://docs.circuitverse.org/#/chapter2/2cvforeducators' target='_blank'>here</a>."
     show:
       edit_name_btn: "Edit Name"
       mentor_name_heading: "Mentor:"

--- a/config/locales/views/groups/en.yml
+++ b/config/locales/views/groups/en.yml
@@ -12,7 +12,7 @@ en:
       title: "CircuitVerse - New Group"
       main_heading: "NEW GROUP"
       main_description_html: "Groups can be used by mentors to set projects for and give grades to students.
-        You can find the documentation <a class='anchor-text' href='https://docs.circuitverse.org/#/chapter2/2cvforeducators'target='_blank'>here</a>."
+        You can find the documentation <a class='anchor-text' href='https://docs.circuitverse.org/#/chapter2/2cvforeducators' target='_blank'>here</a>."
     show:
       edit_name_btn: "Edit Name"
       mentor_name_heading: "Mentor:"

--- a/config/locales/views/groups/hi.yml
+++ b/config/locales/views/groups/hi.yml
@@ -12,7 +12,7 @@ hi:
       title: "सर्किटवर्स - नया समूह"
       main_heading: "नया समूह"
       main_description_html: "छात्रों के लिए प्रोजेक्ट सेट करने और ग्रेड देने के लिए मेंटर्स द्वारा समूहों का उपयोग किया जा सकता है।
-         आप डॉक्यूमेंटेशन <a class='anchor-text' href='https://docs.circuitverse.org/#/chapter2/2cvforeducators'target='_blank'>यहां</a> पढ़ सकते हैं।"
+         आप डॉक्यूमेंटेशन <a class='anchor-text' href='https://docs.circuitverse.org/#/chapter2/2cvforeducators' target='_blank'>यहां</a> पढ़ सकते हैं।"
     show:
       edit_name_btn: "नाम एडिट करें"
       mentor_name_heading: "मेंटर"

--- a/config/locales/views/groups/hi.yml
+++ b/config/locales/views/groups/hi.yml
@@ -12,7 +12,7 @@ hi:
       title: "सर्किटवर्स - नया समूह"
       main_heading: "नया समूह"
       main_description_html: "छात्रों के लिए प्रोजेक्ट सेट करने और ग्रेड देने के लिए मेंटर्स द्वारा समूहों का उपयोग किया जा सकता है।
-         आप डॉक्यूमेंटेशन <a class='anchor-text' href='https://docs.circuitverse.org/#/chapter2/2cvforeducators' target='_blank'>यहां</a> पढ़ सकते हैं।"
+         आप डॉक्यूमेंटेशन <a class='anchor-text' href='https://docs.circuitverse.org/#/chapter2/2cvforeducators'target='_blank'>यहां</a> पढ़ सकते हैं।"
     show:
       edit_name_btn: "नाम एडिट करें"
       mentor_name_heading: "मेंटर"

--- a/config/locales/views/groups/hi.yml
+++ b/config/locales/views/groups/hi.yml
@@ -12,7 +12,7 @@ hi:
       title: "सर्किटवर्स - नया समूह"
       main_heading: "नया समूह"
       main_description_html: "छात्रों के लिए प्रोजेक्ट सेट करने और ग्रेड देने के लिए मेंटर्स द्वारा समूहों का उपयोग किया जा सकता है।
-         आप डॉक्यूमेंटेशन <a class='anchor-text' href='https://docs.circuitverse.org/#/groups' target='_blank'>यहां</a> पढ़ सकते हैं।"
+         आप डॉक्यूमेंटेशन <a class='anchor-text' href='https://docs.circuitverse.org/#/chapter2/2cvforeducators' target='_blank'>यहां</a> पढ़ सकते हैं।"
     show:
       edit_name_btn: "नाम एडिट करें"
       mentor_name_heading: "मेंटर"


### PR DESCRIPTION
Fixes #2932 

#### Issue
There's a wrong link provided on the new group webpage(Documentation link), which opens the 404 error page, i.e. that the page does not exist.
The blog webpage is opening on the same tab and not the new tab. As of suppose we again want to go to the home page or any other webpage of the CircuitVerse website, now we can only move through the browser history arrows and not from the website itself as, the blog webpage is inherited from the Blog repository and the page's header shows the content for blog webpage and not for the CircuitVerse website.

**To Reproduce**
Steps to reproduce the behavior:

Documentation
1. Go to [https://circuitverse.org/groups/new](url)
2. Click on [here](https://docs.circuitverse.org/#/groups)
3. See error

Blog
1. Go to [https://circuitverse.org](url)
2. Click on [Blog](https://blog.circuitverse.org/)
3. See error

#### Describe the changes you have made in this PR -
The documentation link is corrected. The Blog page is made to open on the new tab, as to differentiate the blog webpage from the CircuitVerse website .

**Videos**

**Documentation**

Before 

https://user-images.githubusercontent.com/84590758/153941712-208f0ebf-9425-40cb-9c3b-3ec459de7e30.mp4


After

https://user-images.githubusercontent.com/84590758/153941750-1d7c1e76-4c9b-4bd8-a839-683d379c7f5f.mp4



**Blog**

Before

https://user-images.githubusercontent.com/84590758/153941783-937fc5ee-184a-4144-ade6-d7cff20379c1.mp4


After

https://user-images.githubusercontent.com/84590758/153941823-e147252e-1417-4230-9278-550bc4893de4.mp4
