### PR TITLE
fix: Collaborator Page "View>More" button redirect broken link

### DIFF
--- a/app/views/users/circuitverse/index.html.erb
+++ b/app/views/users/circuitverse/index.html.erb
@@ -230,13 +230,14 @@
     $("#projectModal").on("show.bs.modal", function(e) {
         let projectSlug = $(e.relatedTarget).data('currentproject').slug;
         let projectId = $(e.relatedTarget).data('currentproject').id;
+        let authorId = $(e.relatedTarget).data('currentproject').author_id;
         var id = projectSlug ? projectSlug : projectId;
         $(e.currentTarget).find('#project-launch-button').attr("href",
         "/simulator/edit/" + id);
         $(e.currentTarget).find('#project-fork-button').attr("href",
         "/projects/create_fork/" + projectId.toString());
         $(e.currentTarget).find('#project-more-button').attr("href",
-        "/users/" + <%= @user.id.to_s %> + "/projects/" + id);
+        "/users/" + authorId + "/projects/" + id);
     });
   });
 </script>


### PR DESCRIPTION
Fixes #2488 

#### Describe the changes you have made in this PR -
This PR fixes the broken link of the "View>More" button on the "Collaborated Circuits" page, previously the link was redirecting the user to a non-existing page; now, it successfully redirects to the details page of the shared circuit.

### Screenshots of the changes (If any) -

https://user-images.githubusercontent.com/61188295/155665322-e1806296-b57e-4e99-99c6-c1b61f2098c5.mp4





Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
