### PR TITLE
fix: fallback to nickname or email when name isn't available from oauth

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -72,8 +72,9 @@ class User < ApplicationRecord
   def self.from_omniauth(access_token)
     data = access_token.info
     user = User.where(email: data["email"]).first
+    name = data["name"] || data["nickname"] || data["email"]
     # Uncomment the section below if you want users to be created if they don't exist
-    user ||= User.create(name: data["name"],
+    user ||= User.create(name: name,
                          email: data["email"],
                          password: Devise.friendly_token[0, 20],
                          provider: access_token.provider,


### PR DESCRIPTION
Fixes #2555

#### Describe the changes you have made in this PR -
Fallback to user's nickname (Github username) or email if name isn't available while user is created via omniauth.

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 