### PR TITLE
fix: XSS vulnerability by changing typeahead gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ gem "sunspot_rails"
 gem "will_paginate", "~> 3.3.1"
 gem "will_paginate-bootstrap"
 
-gem "bootstrap-typeahead-rails"
+gem 'twitter-typeahead-rails'
 gem "country_select", "~> 6.0"
 gem "geocoder"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,8 +119,6 @@ GEM
     bindex (0.8.1)
     bootsnap (1.9.3)
       msgpack (~> 1.0)
-    bootstrap-typeahead-rails (0.10.5.1)
-      railties (>= 3.0)
     bugsnag (6.24.2)
       concurrent-ruby (~> 1.0)
     builder (3.2.4)
@@ -622,6 +620,10 @@ GEM
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
+    twitter-typeahead-rails (0.11.1)
+      actionpack (>= 3.1)
+      jquery-rails
+      railties (>= 3.1)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     tzinfo-data (1.2021.1)
@@ -669,7 +671,6 @@ DEPENDENCIES
   ahoy_matey
   aws-sdk-rails
   bootsnap
-  bootstrap-typeahead-rails
   bugsnag (~> 6.24)
   byebug
   capybara (~> 3.36)
@@ -748,6 +749,7 @@ DEPENDENCIES
   sunspot_solr
   terser
   turbolinks (~> 5)
+  twitter-typeahead-rails
   tzinfo-data
   web-console (>= 3.3.0)
   webdrivers (~> 5.0)

--- a/app/assets/javascripts/application_sprockets.js
+++ b/app/assets/javascripts/application_sprockets.js
@@ -14,7 +14,7 @@
 //= require jquery
 //= require rails-ujs
 //= require commontator/application
-//= require bootstrap-typeahead-rails
+//= require twitter/typeahead.min
 //= require bootstrap/dist/js/bootstrap.min.js
 //= require restrictElements.js
 //= require time.js

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,7 +1,7 @@
 @import "theme";
 @import "bootstrap/scss/bootstrap";
 @import 'bootstrap-tagsinput/dist/bootstrap-tagsinput.css';
-@import 'bootstrap-typeahead-rails';
+@import 'typehead';
 @import "font-awesome-sprockets";
 @import "font-awesome";
 @import 'trumbowyg/dist/ui/trumbowyg.min';

--- a/app/assets/stylesheets/typehead.scss
+++ b/app/assets/stylesheets/typehead.scss
@@ -1,198 +1,223 @@
+$default-shadow: rgba(0, 0, 0, .075);
+$warning-typeahead: #8a6d3b;
+$warning-typeahead-focus: #66512c;
+$warning-focus-border: #c0a16b;
+$success-typeahead: #3c763d;
+$success-typeahead-focus: #2b542c;
+$success-focus-border: #67b168;
+$error-typeahead: #a94442;
+$error-typeahead-focus: #843534;
+$error-focus-border: #ce8483;
+$typeahead-hint: #999;
+$typeahead-input-bg: #eee;
+$typehead-menu-bg: #fff;
+$typehead-hover-color: #262626;
+$typeahead-hover-bg: #f5f5f5;
+
 .has-warning .twitter-typeahead .tt-input,
 .has-warning .twitter-typeahead .tt-hint {
-  border-color: #8a6d3b;
-  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  border-color: $warning-typeahead;
+  box-shadow: inset 0 1px 1px $default-shadow;
 }
+
 .has-warning .twitter-typeahead .tt-input:focus,
 .has-warning .twitter-typeahead .tt-hint:focus {
-  border-color: #66512c;
-  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #c0a16b;
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #c0a16b;
+  border-color: $warning-typeahead-focus;
+  box-shadow: inset 0 1px 1px $default-shadow, 0 0 6px $warning-focus-border;
 }
+
 .has-error .twitter-typeahead .tt-input,
 .has-error .twitter-typeahead .tt-hint {
-  border-color: #a94442;
-  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  border-color: $error-typeahead;
+  box-shadow: inset 0 1px 1px $default-shadow;
 }
+
 .has-error .twitter-typeahead .tt-input:focus,
 .has-error .twitter-typeahead .tt-hint:focus {
-  border-color: #843534;
-  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ce8483;
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ce8483;
+  border-color: $error-typeahead-focus;
+  box-shadow: inset 0 1px 1px $default-shadow, 0 0 6px $error-focus-border;
 }
+
 .has-success .twitter-typeahead .tt-input,
 .has-success .twitter-typeahead .tt-hint {
-  border-color: #3c763d;
-  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  border-color: $success-typeahead;
+  box-shadow: inset 0 1px 1px $default-shadow;
 }
+
 .has-success .twitter-typeahead .tt-input:focus,
 .has-success .twitter-typeahead .tt-hint:focus {
-  border-color: #2b542c;
-  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #67b168;
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #67b168;
+  border-color: $success-typeahead-focus;
+  box-shadow: inset 0 1px 1px $default-shadow, 0 0 6px $success-focus-border;
 }
+
 .input-group .twitter-typeahead:first-child .tt-input,
 .input-group .twitter-typeahead:first-child .tt-hint {
   border-bottom-left-radius: 4px;
   border-top-left-radius: 4px;
   width: 100%;
 }
+
 .input-group .twitter-typeahead:last-child .tt-input,
 .input-group .twitter-typeahead:last-child .tt-hint {
   border-bottom-right-radius: 4px;
   border-top-right-radius: 4px;
   width: 100%;
 }
+
 .input-group.input-group-sm .twitter-typeahead .tt-input,
 .input-group.input-group-sm .twitter-typeahead .tt-hint {
-  height: 30px;
-  padding: 5px 10px;
-  font-size: 12px;
-  line-height: 1.5;
   border-radius: 3px;
+  font-size: 12px;
+  height: 30px;
+  line-height: 1.5;
+  padding: 5px 10px;
 }
+
 select.input-group.input-group-sm .twitter-typeahead .tt-input,
 select.input-group.input-group-sm .twitter-typeahead .tt-hint {
   height: 30px;
   line-height: 30px;
 }
+
 textarea.input-group.input-group-sm .twitter-typeahead .tt-input,
 textarea.input-group.input-group-sm .twitter-typeahead .tt-hint,
 select[multiple].input-group.input-group-sm .twitter-typeahead .tt-input,
 select[multiple].input-group.input-group-sm .twitter-typeahead .tt-hint {
   height: auto;
 }
-.input-group.input-group-sm
-  .twitter-typeahead:not(:first-child):not(:last-child)
-  .tt-input,
-.input-group.input-group-sm
-  .twitter-typeahead:not(:first-child):not(:last-child)
-  .tt-hint {
+
+.input-group.input-group-sm.twitter-typeahead:not(:first-child):not(:last-child).tt-input,
+.input-group.input-group-sm.twitter-typeahead:not(:first-child):not(:last-child).tt-hint {
   border-radius: 0;
 }
+
 .input-group.input-group-sm .twitter-typeahead:first-child .tt-input,
 .input-group.input-group-sm .twitter-typeahead:first-child .tt-hint {
   border-bottom-left-radius: 3px;
-  border-top-left-radius: 3px;
   border-bottom-right-radius: 0;
+  border-top-left-radius: 3px;
   border-top-right-radius: 0;
 }
+
 .input-group.input-group-sm .twitter-typeahead:last-child .tt-input,
 .input-group.input-group-sm .twitter-typeahead:last-child .tt-hint {
   border-bottom-left-radius: 0;
-  border-top-left-radius: 0;
   border-bottom-right-radius: 3px;
+  border-top-left-radius: 0;
   border-top-right-radius: 3px;
 }
+
 .input-group.input-group-lg .twitter-typeahead .tt-input,
 .input-group.input-group-lg .twitter-typeahead .tt-hint {
-  height: 46px;
-  padding: 10px 16px;
-  font-size: 18px;
-  line-height: 1.33;
   border-radius: 6px;
+  font-size: 18px;
+  height: 46px;
+  line-height: 1.33;
+  padding: 10px 16px;
 }
+
 select.input-group.input-group-lg .twitter-typeahead .tt-input,
 select.input-group.input-group-lg .twitter-typeahead .tt-hint {
   height: 46px;
   line-height: 46px;
 }
+
 textarea.input-group.input-group-lg .twitter-typeahead .tt-input,
 textarea.input-group.input-group-lg .twitter-typeahead .tt-hint,
 select[multiple].input-group.input-group-lg .twitter-typeahead .tt-input,
 select[multiple].input-group.input-group-lg .twitter-typeahead .tt-hint {
   height: auto;
 }
-.input-group.input-group-lg
-  .twitter-typeahead:not(:first-child):not(:last-child)
-  .tt-input,
-.input-group.input-group-lg
-  .twitter-typeahead:not(:first-child):not(:last-child)
-  .tt-hint {
+
+.input-group.input-group-lg.twitter-typeahead:not(:first-child):not(:last-child).tt-input,
+.input-group.input-group-lg.twitter-typeahead:not(:first-child):not(:last-child).tt-hint {
   border-radius: 0;
 }
+
 .input-group.input-group-lg .twitter-typeahead:first-child .tt-input,
 .input-group.input-group-lg .twitter-typeahead:first-child .tt-hint {
   border-bottom-left-radius: 6px;
-  border-top-left-radius: 6px;
   border-bottom-right-radius: 0;
+  border-top-left-radius: 6px;
   border-top-right-radius: 0;
 }
+
 .input-group.input-group-lg .twitter-typeahead:last-child .tt-input,
 .input-group.input-group-lg .twitter-typeahead:last-child .tt-hint {
   border-bottom-left-radius: 0;
-  border-top-left-radius: 0;
   border-bottom-right-radius: 6px;
+  border-top-left-radius: 0;
   border-top-right-radius: 6px;
 }
+
 .twitter-typeahead {
   width: 100%;
+
+  &.tt-hint {
+    color: $typeahead-hint;
+  }
+
+  &.tt-input {
+    z-index: 2;
+  }
 }
+
 .input-group .twitter-typeahead {
-  display: table-cell !important;
+  display: table-cell;
 }
-.twitter-typeahead .tt-hint {
-  color: #999999;
-}
-.twitter-typeahead .tt-input {
-  z-index: 2;
-}
+
 .twitter-typeahead .tt-input[disabled],
 .twitter-typeahead .tt-input[readonly],
 fieldset[disabled] .twitter-typeahead .tt-input {
+  background-color: $typeahead-input-bg;
   cursor: not-allowed;
-  background-color: #eeeeee !important;
 }
+
 .tt-dropdown-menu,
 .tt-menu {
+  background-clip: padding-box;
+  background-color: $typehead-menu-bg;
+  border: 1px solid;
+  border-radius: 4px;
+  font-size: 14px;
+  left: 0;
+  list-style: none;
+  margin: 2px 0 0;
+  min-width: 160px;
+  padding: 5px 0;
   position: absolute;
   top: 100%;
-  left: 0;
-  z-index: 1000;
-  min-width: 160px;
   width: 100%;
-  padding: 5px 0;
-  margin: 2px 0 0;
-  list-style: none;
-  font-size: 14px;
-  background-color: #ffffff;
-  border: 1px solid #cccccc;
-  border: 1px solid rgba(0, 0, 0, 0.15);
-  border-radius: 4px;
-  -webkit-box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
-  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
-  background-clip: padding-box;
-  *border-right-width: 2px;
-  *border-bottom-width: 2px;
+  z-index: 1000;
 }
+
 .tt-dropdown-menu .tt-suggestion,
 .tt-menu .tt-suggestion {
-  display: block;
-  padding: 3px 20px;
   clear: both;
+  display: block;
   font-weight: normal;
   line-height: 1.42857143;
-  color: #333333;
+  padding: 3px 20px;
 }
+
 .tt-dropdown-menu .tt-suggestion.tt-cursor,
 .tt-menu .tt-suggestion.tt-cursor,
 .tt-dropdown-menu .tt-suggestion:hover,
 .tt-menu .tt-suggestion:hover {
+  background-color: $typeahead-hover-bg;
+  color: $typehead-hover-color;
   cursor: pointer;
-  text-decoration: none;
   outline: 0;
-  background-color: #f5f5f5;
-  color: #262626;
+  text-decoration: none;
 }
+
 .tt-dropdown-menu .tt-suggestion.tt-cursor a,
 .tt-menu .tt-suggestion.tt-cursor a,
 .tt-dropdown-menu .tt-suggestion:hover a,
 .tt-menu .tt-suggestion:hover a {
-  color: #262626;
+  color: $typehead-hover-color;
 }
+
 .tt-dropdown-menu .tt-suggestion p,
 .tt-menu .tt-suggestion p {
   margin: 0;

--- a/app/assets/stylesheets/typehead.scss
+++ b/app/assets/stylesheets/typehead.scss
@@ -73,17 +73,42 @@ $typeahead-hover-bg: #f5f5f5;
   padding: 5px 10px;
 }
 
-select.input-group.input-group-sm .twitter-typeahead .tt-input,
-select.input-group.input-group-sm .twitter-typeahead .tt-hint {
-  height: 30px;
-  line-height: 30px;
+select {
+  &.input-group.input-group-sm .twitter-typeahead .tt-input,
+  &.input-group.input-group-sm .twitter-typeahead .tt-hint {
+    height: 30px;
+    line-height: 30px;
+  }
+
+  &[multiple] {
+    &.input-group.input-group-sm .twitter-typeahead .tt-input,
+    &.input-group.input-group-sm .twitter-typeahead .tt-hint {
+      height: auto;
+    }
+
+    &.input-group.input-group-lg .twitter-typeahead .tt-input,
+    &.input-group.input-group-lg .twitter-typeahead .tt-hint {
+      height: auto;
+    }
+  }
+
+  &.input-group.input-group-lg .twitter-typeahead .tt-input,
+  &.input-group.input-group-lg .twitter-typeahead .tt-hint {
+    height: 46px;
+    line-height: 46px;
+  }
 }
 
-textarea.input-group.input-group-sm .twitter-typeahead .tt-input,
-textarea.input-group.input-group-sm .twitter-typeahead .tt-hint,
-select[multiple].input-group.input-group-sm .twitter-typeahead .tt-input,
-select[multiple].input-group.input-group-sm .twitter-typeahead .tt-hint {
-  height: auto;
+textarea {
+  &.input-group.input-group-sm .twitter-typeahead .tt-input,
+  &.input-group.input-group-sm .twitter-typeahead .tt-hint {
+    height: auto;
+  }
+
+  &.input-group.input-group-lg .twitter-typeahead .tt-input,
+  &.input-group.input-group-lg .twitter-typeahead .tt-hint {
+    height: auto;
+  }
 }
 
 .input-group.input-group-sm.twitter-typeahead:not(:first-child):not(:last-child).tt-input,
@@ -114,19 +139,6 @@ select[multiple].input-group.input-group-sm .twitter-typeahead .tt-hint {
   height: 46px;
   line-height: 1.33;
   padding: 10px 16px;
-}
-
-select.input-group.input-group-lg .twitter-typeahead .tt-input,
-select.input-group.input-group-lg .twitter-typeahead .tt-hint {
-  height: 46px;
-  line-height: 46px;
-}
-
-textarea.input-group.input-group-lg .twitter-typeahead .tt-input,
-textarea.input-group.input-group-lg .twitter-typeahead .tt-hint,
-select[multiple].input-group.input-group-lg .twitter-typeahead .tt-input,
-select[multiple].input-group.input-group-lg .twitter-typeahead .tt-hint {
-  height: auto;
 }
 
 .input-group.input-group-lg.twitter-typeahead:not(:first-child):not(:last-child).tt-input,
@@ -167,10 +179,16 @@ select[multiple].input-group.input-group-lg .twitter-typeahead .tt-hint {
 }
 
 .twitter-typeahead .tt-input[disabled],
-.twitter-typeahead .tt-input[readonly],
-fieldset[disabled] .twitter-typeahead .tt-input {
+.twitter-typeahead .tt-input[readonly] {
   background-color: $typeahead-input-bg;
   cursor: not-allowed;
+}
+
+fieldset {
+  &[disabled].twitter-typeahead .tt-input {
+    background-color: $typeahead-input-bg;
+    cursor: not-allowed;
+  }
 }
 
 .tt-dropdown-menu,

--- a/app/assets/stylesheets/typehead.scss
+++ b/app/assets/stylesheets/typehead.scss
@@ -1,0 +1,199 @@
+.has-warning .twitter-typeahead .tt-input,
+.has-warning .twitter-typeahead .tt-hint {
+  border-color: #8a6d3b;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+}
+.has-warning .twitter-typeahead .tt-input:focus,
+.has-warning .twitter-typeahead .tt-hint:focus {
+  border-color: #66512c;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #c0a16b;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #c0a16b;
+}
+.has-error .twitter-typeahead .tt-input,
+.has-error .twitter-typeahead .tt-hint {
+  border-color: #a94442;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+}
+.has-error .twitter-typeahead .tt-input:focus,
+.has-error .twitter-typeahead .tt-hint:focus {
+  border-color: #843534;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ce8483;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ce8483;
+}
+.has-success .twitter-typeahead .tt-input,
+.has-success .twitter-typeahead .tt-hint {
+  border-color: #3c763d;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+}
+.has-success .twitter-typeahead .tt-input:focus,
+.has-success .twitter-typeahead .tt-hint:focus {
+  border-color: #2b542c;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #67b168;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #67b168;
+}
+.input-group .twitter-typeahead:first-child .tt-input,
+.input-group .twitter-typeahead:first-child .tt-hint {
+  border-bottom-left-radius: 4px;
+  border-top-left-radius: 4px;
+  width: 100%;
+}
+.input-group .twitter-typeahead:last-child .tt-input,
+.input-group .twitter-typeahead:last-child .tt-hint {
+  border-bottom-right-radius: 4px;
+  border-top-right-radius: 4px;
+  width: 100%;
+}
+.input-group.input-group-sm .twitter-typeahead .tt-input,
+.input-group.input-group-sm .twitter-typeahead .tt-hint {
+  height: 30px;
+  padding: 5px 10px;
+  font-size: 12px;
+  line-height: 1.5;
+  border-radius: 3px;
+}
+select.input-group.input-group-sm .twitter-typeahead .tt-input,
+select.input-group.input-group-sm .twitter-typeahead .tt-hint {
+  height: 30px;
+  line-height: 30px;
+}
+textarea.input-group.input-group-sm .twitter-typeahead .tt-input,
+textarea.input-group.input-group-sm .twitter-typeahead .tt-hint,
+select[multiple].input-group.input-group-sm .twitter-typeahead .tt-input,
+select[multiple].input-group.input-group-sm .twitter-typeahead .tt-hint {
+  height: auto;
+}
+.input-group.input-group-sm
+  .twitter-typeahead:not(:first-child):not(:last-child)
+  .tt-input,
+.input-group.input-group-sm
+  .twitter-typeahead:not(:first-child):not(:last-child)
+  .tt-hint {
+  border-radius: 0;
+}
+.input-group.input-group-sm .twitter-typeahead:first-child .tt-input,
+.input-group.input-group-sm .twitter-typeahead:first-child .tt-hint {
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+.input-group.input-group-sm .twitter-typeahead:last-child .tt-input,
+.input-group.input-group-sm .twitter-typeahead:last-child .tt-hint {
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+  border-bottom-right-radius: 3px;
+  border-top-right-radius: 3px;
+}
+.input-group.input-group-lg .twitter-typeahead .tt-input,
+.input-group.input-group-lg .twitter-typeahead .tt-hint {
+  height: 46px;
+  padding: 10px 16px;
+  font-size: 18px;
+  line-height: 1.33;
+  border-radius: 6px;
+}
+select.input-group.input-group-lg .twitter-typeahead .tt-input,
+select.input-group.input-group-lg .twitter-typeahead .tt-hint {
+  height: 46px;
+  line-height: 46px;
+}
+textarea.input-group.input-group-lg .twitter-typeahead .tt-input,
+textarea.input-group.input-group-lg .twitter-typeahead .tt-hint,
+select[multiple].input-group.input-group-lg .twitter-typeahead .tt-input,
+select[multiple].input-group.input-group-lg .twitter-typeahead .tt-hint {
+  height: auto;
+}
+.input-group.input-group-lg
+  .twitter-typeahead:not(:first-child):not(:last-child)
+  .tt-input,
+.input-group.input-group-lg
+  .twitter-typeahead:not(:first-child):not(:last-child)
+  .tt-hint {
+  border-radius: 0;
+}
+.input-group.input-group-lg .twitter-typeahead:first-child .tt-input,
+.input-group.input-group-lg .twitter-typeahead:first-child .tt-hint {
+  border-bottom-left-radius: 6px;
+  border-top-left-radius: 6px;
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+.input-group.input-group-lg .twitter-typeahead:last-child .tt-input,
+.input-group.input-group-lg .twitter-typeahead:last-child .tt-hint {
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+  border-bottom-right-radius: 6px;
+  border-top-right-radius: 6px;
+}
+.twitter-typeahead {
+  width: 100%;
+}
+.input-group .twitter-typeahead {
+  display: table-cell !important;
+}
+.twitter-typeahead .tt-hint {
+  color: #999999;
+}
+.twitter-typeahead .tt-input {
+  z-index: 2;
+}
+.twitter-typeahead .tt-input[disabled],
+.twitter-typeahead .tt-input[readonly],
+fieldset[disabled] .twitter-typeahead .tt-input {
+  cursor: not-allowed;
+  background-color: #eeeeee !important;
+}
+.tt-dropdown-menu,
+.tt-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 1000;
+  min-width: 160px;
+  width: 100%;
+  padding: 5px 0;
+  margin: 2px 0 0;
+  list-style: none;
+  font-size: 14px;
+  background-color: #ffffff;
+  border: 1px solid #cccccc;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  border-radius: 4px;
+  -webkit-box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+  background-clip: padding-box;
+  *border-right-width: 2px;
+  *border-bottom-width: 2px;
+}
+.tt-dropdown-menu .tt-suggestion,
+.tt-menu .tt-suggestion {
+  display: block;
+  padding: 3px 20px;
+  clear: both;
+  font-weight: normal;
+  line-height: 1.42857143;
+  color: #333333;
+}
+.tt-dropdown-menu .tt-suggestion.tt-cursor,
+.tt-menu .tt-suggestion.tt-cursor,
+.tt-dropdown-menu .tt-suggestion:hover,
+.tt-menu .tt-suggestion:hover {
+  cursor: pointer;
+  text-decoration: none;
+  outline: 0;
+  background-color: #f5f5f5;
+  color: #262626;
+}
+.tt-dropdown-menu .tt-suggestion.tt-cursor a,
+.tt-menu .tt-suggestion.tt-cursor a,
+.tt-dropdown-menu .tt-suggestion:hover a,
+.tt-menu .tt-suggestion:hover a {
+  color: #262626;
+}
+.tt-dropdown-menu .tt-suggestion p,
+.tt-menu .tt-suggestion p {
+  margin: 0;
+}

--- a/app/views/users/circuitverse/edit.html.erb
+++ b/app/views/users/circuitverse/edit.html.erb
@@ -96,7 +96,7 @@
   });
 
   bloodhound.initialize();
-  
+
   $(searchSelector).typeahead(null, {
     displayKey: 'name',
     source: bloodhound.ttAdapter()

--- a/app/views/users/circuitverse/edit.html.erb
+++ b/app/views/users/circuitverse/edit.html.erb
@@ -1,8 +1,6 @@
 
 <% content_for :title, t("users.circuitverse.edit_profile.title", name: @profile.name ) %>
 
-<link href="/css/typeahead.min.css" rel="stylesheet">
-
 <div class="container projects-new-container">
   <div class="row center-row">
     <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
@@ -84,13 +82,21 @@
   var searchSelector = 'input.typeahead';
   var bloodhound = new Bloodhound({
     datumTokenizer: function (d) {
-    return Bloodhound.tokenizers.whitespace(d.value);
-  },
+      return Bloodhound.tokenizers.whitespace(d.value);
+    },
     queryTokenizer: Bloodhound.tokenizers.whitespace,
-    remote: '/users/educational_institute/typeahead/%QUERY',
+    remote: {
+      url: '/users/educational_institute/typeahead/',
+      prepare: function(query, settings) {
+        settings.url += encodeURI(query)
+        return settings
+      }
+    },
     limit: 50
   });
+
   bloodhound.initialize();
+  
   $(searchSelector).typeahead(null, {
     displayKey: 'name',
     source: bloodhound.ttAdapter()


### PR DESCRIPTION
Fixes #2797

#### Describe the changes you have made in this PR -
- Replaced `bootstrap-typeahead-rails` by `twitter-typeahead-rails`
- Configure bloodhound as per new gem

### Screenshots of the changes (If any) -
- UI changes as per new gem
![image](https://user-images.githubusercontent.com/56310902/156010136-e8a96be7-974c-4823-92bc-f0b8a835e16e.png)

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
