### PR TITLE
fix: XSS vulnerability by replacing typeahead gem and sanitising results

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,6 @@ gem "sunspot_rails"
 gem "will_paginate", "~> 3.3.1"
 gem "will_paginate-bootstrap"
 
-gem "bootstrap-typeahead-rails"
 gem "country_select", "~> 6.0"
 gem "geocoder"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,8 +119,6 @@ GEM
     bindex (0.8.1)
     bootsnap (1.9.3)
       msgpack (~> 1.0)
-    bootstrap-typeahead-rails (0.10.5.1)
-      railties (>= 3.0)
     bugsnag (6.24.2)
       concurrent-ruby (~> 1.0)
     builder (3.2.4)
@@ -670,7 +668,6 @@ DEPENDENCIES
   ahoy_matey
   aws-sdk-rails
   bootsnap
-  bootstrap-typeahead-rails
   bugsnag (~> 6.24)
   byebug
   capybara (~> 3.36)

--- a/app/assets/javascripts/application_sprockets.js
+++ b/app/assets/javascripts/application_sprockets.js
@@ -14,7 +14,8 @@
 //= require jquery
 //= require rails-ujs
 //= require commontator/application
-//= require bootstrap-typeahead-rails
+//= require @tarekraafat/autocomplete.js/dist/autoComplete.min.js
+//= require dompurify/dist/purify.min.js
 //= require bootstrap/dist/js/bootstrap.min.js
 //= require restrictElements.js
 //= require time.js

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,7 +1,7 @@
 @import "theme";
 @import "bootstrap/scss/bootstrap";
 @import 'bootstrap-tagsinput/dist/bootstrap-tagsinput.css';
-@import 'bootstrap-typeahead-rails';
+@import 'autoComplete';
 @import "font-awesome-sprockets";
 @import "font-awesome";
 @import 'trumbowyg/dist/ui/trumbowyg.min';

--- a/app/assets/stylesheets/autoComplete.scss
+++ b/app/assets/stylesheets/autoComplete.scss
@@ -1,0 +1,65 @@
+$slight-grey: rgba(123, 123, 123, .1);
+
+.autoComplete_wrapper {
+  position: relative;
+}
+
+.autocomplete {
+  border: 1px solid $black;
+  border-radius: 4px;
+  font-size: 1rem;
+  outline: 0;
+  padding-left: 10px;
+}
+
+.autocomplete-list {
+  background-color: $white;
+  border: 1px solid $black;
+  border-radius: 4px;
+  left: 0;
+  margin: .5rem 0 0;
+  outline: 0;
+  overflow-y: scroll;
+  padding: 0;
+  position: absolute;
+  right: 0;
+  z-index: 1000;
+}
+
+.autocomplete-list-item {
+  background-color: $white;
+  border-radius: 3px;
+  color: footer-dark-grey;
+  font-size: 16px;
+  list-style: none;
+  overflow: hidden;
+  padding: 10px 20px;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  &::selection {
+    background-color: rgba($white, 0);
+    color: rgba($white, 0);
+  }
+
+  &:hover {
+    background-color: $slight-grey;
+    cursor: pointer;
+  }
+
+  &[aria-selected="true"] {
+    background-color: $slight-grey;
+  }
+
+  mark {
+    background-color: transparent;
+    color: $primary-green;
+    font-weight: 700;
+
+    &::selection {
+      background-color: rgba($white, 0);
+      color: rgba($white, 0);
+    }
+  }
+}

--- a/app/views/users/circuitverse/edit.html.erb
+++ b/app/views/users/circuitverse/edit.html.erb
@@ -1,8 +1,6 @@
 
 <% content_for :title, t("users.circuitverse.edit_profile.title", name: @profile.name ) %>
 
-<link href="/css/typeahead.min.css" rel="stylesheet">
-
 <div class="container projects-new-container">
   <div class="row center-row">
     <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
@@ -32,7 +30,7 @@
           </div>
           <div class="field form-group">
             <h6><%= f.label :educational_institute %></h6>
-            <%= f.text_field :educational_institute, { class: "typeahead form-control form-input", autocomplete:"off" } %>
+            <%= f.text_field :educational_institute, { class: "autocomplete form-control form-input", autocomplete:"off" } %>
           </div>
           <div class="field form-group">
             <h6><%= f.label :locale %></h6>
@@ -81,18 +79,51 @@
   }
 </script>
 <script>
-  var searchSelector = 'input.typeahead';
-  var bloodhound = new Bloodhound({
-    datumTokenizer: function (d) {
-    return Bloodhound.tokenizers.whitespace(d.value);
-  },
-    queryTokenizer: Bloodhound.tokenizers.whitespace,
-    remote: '/users/educational_institute/typeahead/%QUERY',
-    limit: 50
+  const SELECTOR = '.autocomplete';
+  DOMPurify.setConfig({ ALLOWED_TAGS: [] });
+  const purify = dt => String(DOMPurify.sanitize(String(dt))).trim();
+
+  const autoCompleteJS = new autoComplete({
+    selector: SELECTOR,
+    data: {
+      src: async function(query) {
+        try {
+          const response = await fetch(
+            `/users/educational_institute/typeahead/${encodeURIComponent(query)}`
+          );
+
+          if (!response.ok) {
+            throw new Error('Invalid Query');
+          }
+
+          const data = await response.json();
+          const filtered = [];
+          let purifiedData;
+
+          for (const result of data) {
+            purifiedData = purify(result.name);
+            if (purifiedData !== '') {
+              filtered.push({ name: purifiedData });
+            }
+          }
+          return filtered;
+        } catch (error) {
+          return error;
+        }
+      },
+      keys: ['name']
+    },
+    resultsList: {
+      class: 'autocomplete-list'
+    },
+    resultItem: {
+      class: 'autocomplete-list-item',
+    }
   });
-  bloodhound.initialize();
-  $(searchSelector).typeahead(null, {
-    displayKey: 'name',
-    source: bloodhound.ttAdapter()
+
+  $(SELECTOR).on('selection', function(event) {
+    const feedback = event.detail;
+    const selection = feedback.selection.value[feedback.selection.key];
+    autoCompleteJS.input.value = selection;
   });
 </script>

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.4",
     "@hotwired/stimulus": "^3.0.1",
+    "@tarekraafat/autocomplete.js": "^10.2.6",
     "banana-i18n": "^2.3.2",
     "better-docs": "^2.7.1",
     "bootstrap": "^4.6.1",
@@ -40,6 +41,7 @@
     "css-loader": "^6.5.1",
     "css-vars": "^2.4.0",
     "dom-to-image": "^2.6.0",
+    "dompurify": "^2.3.6",
     "driver.js": "^0.9.8",
     "esbuild": "^0.14.23",
     "esbuild-plugin-sass": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -544,6 +544,11 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@tarekraafat/autocomplete.js@^10.2.6":
+  version "10.2.6"
+  resolved "https://registry.yarnpkg.com/@tarekraafat/autocomplete.js/-/autocomplete.js-10.2.6.tgz#c25a35b09cd5af15ee2941950d5ae52a79b77abf"
+  integrity sha512-M3awL75YTQVHev4XlWGRKJalwVG3MGgtNnbRdtNipcyMcAV1sfkireBM8BKL/vhFhrus+6/5KZfj/DJDu8X0mg==
+
 "@tsconfig/node10@^1.0.7":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
@@ -1502,6 +1507,11 @@ dom-to-image@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/dom-to-image/-/dom-to-image-2.6.0.tgz#8a503608088c87b1c22f9034ae032e1898955867"
   integrity sha1-ilA2CAiMh7HCL5A0rgMuGJiVWGc=
+
+dompurify@^2.3.6:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.3.6.tgz#2e019d7d7617aacac07cbbe3d88ae3ad354cf875"
+  integrity sha512-OFP2u/3T1R5CEgWCEONuJ1a5+MFKnOYpkywpUSxv/dj1LeBT1erK+JwM7zK0ROy2BRhqVCf0LRw/kHqKuMkVGg==
 
 dot-prop@^5.1.0, dot-prop@^5.2.0:
   version "5.3.0"


### PR DESCRIPTION
Fixes #2797

#### Describe the changes you have made in this PR -
- Replaced `bootstrap-typeahead-rails` with npm package `autoComplete.js`
- Installed dompurify package for sanitisation
- typeahead results for educational institute are sanitized before displaying 

This is a PR with the requested changes mentioned in PR #2965 

### Screenshots of the changes (If any) -
![image](https://user-images.githubusercontent.com/56310902/156571140-64f5ca50-0150-41de-8200-faa4a667b7fa.png)
![image](https://user-images.githubusercontent.com/56310902/156571325-63ceec16-d4cf-4d8d-a63f-9143bcf36fc3.png)



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
