### PR TITLE
Fix: Timing diagram size

### DIFF
--- a/simulator/src/css/main.stylesheet.css
+++ b/simulator/src/css/main.stylesheet.css
@@ -908,6 +908,7 @@ div.icon img {
 
 #plotArea {
   padding: 3px;
+  width: 100%;
 }
 
 #verilogEditorPanel {

--- a/simulator/src/plotArea.js
+++ b/simulator/src/plotArea.js
@@ -119,8 +119,6 @@ const plotArea = {
         if (oldHeight == this.height && oldWidth == this.width) return;
         this.canvas.width = this.width;
         this.canvas.height = this.height;
-        document.getElementById('plotArea').style.height = this.canvas.height / this.DPR;
-        document.getElementById('plotArea').style.width = this.canvas.width / this.DPR;
         this.plot();
     },
     // Setup function, called on page load
@@ -205,8 +203,9 @@ const plotArea = {
         }
     },
     render() {
-        var width = this.width;
-        var height = this.height;
+        var { width, height } = this;
+        this.canvas.height = height;
+        this.canvas.width = width;
         var endTime = this.getCurrentTime();
         // Reset canvas
         this.clear();
@@ -384,11 +383,12 @@ const plotArea = {
     // Driver function to render and update
     plot() {
         if (embed) return;
-        if (globalScope.Flag.length == 0) {
-            this.canvas.width = this.canvas.height = 0;
+        if (globalScope.Flag.length === 0) {
+            this.canvas.width = 0;
+            this.canvas.height = 0;
             return;
         }
-        
+
         this.update();
         this.render();
     },


### PR DESCRIPTION
Fixes #3001

#### Describe the changes you have made in this PR -
- Removed inline style changes to canvas element plotArea
- Adjusted such that plotArea's width is 100% by default
- Adjustment of width and height are made via canvas properties

### Screenshots of the changes (If any) -

https://user-images.githubusercontent.com/56310902/156890949-c7a07402-5659-40db-a66e-f2c3a4a010d7.mp4


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
