### PR TITLE
updated the Copyright text for the mailer

### DIFF
--- a/config/locales/views/layouts/en.yml
+++ b/config/locales/views/layouts/en.yml
@@ -27,7 +27,7 @@ en:
       language: "Language"
     mailer:
       join_us: "Join Us"
-      copyright_text: "Copyright © 2021 CircuitVerse. All rights reserved. For any issues, reach out to us support@circuitverse.org"
+      copyright_text: "Copyright © %{time_current_year} CircuitVerse, All rights reserved."
       unsubscribe_email_notifications: "Unsubscribe from email notifications"
     simulator:
       title: "CircuitVerse - Digital Circuit Simulator online"


### PR DESCRIPTION
Fixes #

Updated the Copyright Text from `Copyright © 2021 CircuitVerse. All rights reserved. For any issues, reach out to us support@circuitverse.org` to `Copyright © %{time_current_year} CircuitVerse, All rights reserved.`
