### PR TITLE
fix: backup last state of simulator before undo/redo

### DIFF
--- a/simulator/src/data/backupCircuit.js
+++ b/simulator/src/data/backupCircuit.js
@@ -67,7 +67,7 @@ export function scheduleBackup(scope = globalScope) {
 
         // condition to check node deletion(sub-circuits)
         // true -  empty scope.history
-        if (scope.history.length > 0 && scope.allNodes?.length !== JSON.parse(scope.history[scope.history.length - 1]).allNodes?.length) scope.history = [];
+        if (scope.history.length > 0 && scope.allNodes.length !== JSON.parse(scope.history[scope.history.length - 1]).allNodes.length) scope.history = [];
     }
 
     return backup;

--- a/simulator/src/data/backupCircuit.js
+++ b/simulator/src/data/backupCircuit.js
@@ -64,6 +64,10 @@ export function scheduleBackup(scope = globalScope) {
         scope.history = [];
         scope.timeStamp = new Date().getTime();
         projectSavedSet(false);
+
+        // condition to check node deletion(sub-circuits)
+        // true -  empty scope.history
+        if (scope.history.length > 0 && scope.allNodes?.length !== JSON.parse(scope.history[scope.history.length - 1]).allNodes?.length) scope.history = [];
     }
 
     return backup;

--- a/simulator/src/data/redo.js
+++ b/simulator/src/data/redo.js
@@ -17,10 +17,15 @@ import { scheduleBackup } from './backupCircuit';
  * @exports redo
  */
 export default function redo(scope = globalScope) {
-    // backup last state of simulator before redo
-    scheduleBackup();
     if (layoutModeGet()) return;
     if (scope.history.length === 0) return;
+    const history = JSON.parse(scope.history[scope.history.length - 1]);
+    const topNode = history.allNodes[history.allNodes.length - 1];
+    if (topNode.history !== scope.allNodes[scope.allNodes.length - 1].history || topNode.y !== scope.allNodes[scope.allNodes.length - 1].y) {
+        // backup last state of the simulator
+        scheduleBackup()
+        if (scope.history.length === 0) return;
+    }
     const backupOx = globalScope.ox;
     const backupOy = globalScope.oy;
     const backupScale = globalScope.scale;

--- a/simulator/src/data/redo.js
+++ b/simulator/src/data/redo.js
@@ -23,7 +23,7 @@ export default function redo(scope = globalScope) {
     const topNode = history.allNodes[history.allNodes.length - 1];
     if (topNode.history !== scope.allNodes[scope.allNodes.length - 1].history || topNode.y !== scope.allNodes[scope.allNodes.length - 1].y) {
         // backup last state of the simulator
-        scheduleBackup()
+        scheduleBackup();
         if (scope.history.length === 0) return;
     }
     const backupOx = globalScope.ox;

--- a/simulator/src/data/redo.js
+++ b/simulator/src/data/redo.js
@@ -9,6 +9,7 @@ import Scope, { scopeList } from '../circuit';
 import { loadScope } from './load';
 import { updateRestrictedElementsInScope } from '../restrictedElementDiv';
 import { forceResetNodesSet } from '../engine';
+import { scheduleBackup } from './backupCircuit';
 /**
  * Function called to generate a prompt to save an image
  * @param {Scope=} - the circuit in which we want to call redo
@@ -16,6 +17,8 @@ import { forceResetNodesSet } from '../engine';
  * @exports redo
  */
 export default function redo(scope = globalScope) {
+    // backup last state of simulator before redo
+    scheduleBackup();
     if (layoutModeGet()) return;
     if (scope.history.length === 0) return;
     const backupOx = globalScope.ox;

--- a/simulator/src/data/redo.js
+++ b/simulator/src/data/redo.js
@@ -21,7 +21,7 @@ export default function redo(scope = globalScope) {
     if (scope.history.length === 0) return;
     const history = JSON.parse(scope.history[scope.history.length - 1]);
     const topNode = history.allNodes[history.allNodes.length - 1];
-    if (topNode.history !== scope.allNodes[scope.allNodes.length - 1].history || topNode.y !== scope.allNodes[scope.allNodes.length - 1].y) {
+    if (topNode.y !== scope.allNodes[scope.allNodes.length - 1].y || topNode.x !== scope.allNodes[scope.allNodes.length - 1].x) {
         // backup last state of the simulator
         scheduleBackup();
         if (scope.history.length === 0) return;

--- a/simulator/src/data/undo.js
+++ b/simulator/src/data/undo.js
@@ -17,10 +17,10 @@ import { scheduleBackup } from './backupCircuit';
  * @exports undo
  */
 export default function undo(scope = globalScope) {
-    // backup last state of simulator before undo
-    scheduleBackup();
     if (layoutModeGet()) return;
     if (scope.backups.length < 2) return;
+    // backup upto last state of simulator
+    scheduleBackup();
     const backupOx = globalScope.ox;
     const backupOy = globalScope.oy;
     const backupScale = globalScope.scale;

--- a/simulator/src/data/undo.js
+++ b/simulator/src/data/undo.js
@@ -9,6 +9,7 @@ import Scope, { scopeList } from '../circuit';
 import { loadScope } from './load';
 import { updateRestrictedElementsInScope } from '../restrictedElementDiv';
 import { forceResetNodesSet } from '../engine';
+import { scheduleBackup } from './backupCircuit';
 /**
  * Function called to generate a prompt to save an image
  * @param {Scope=} - the circuit in which we want to call undo
@@ -16,6 +17,8 @@ import { forceResetNodesSet } from '../engine';
  * @exports undo
  */
 export default function undo(scope = globalScope) {
+    // backup last state of simulator before undo
+    scheduleBackup();
     if (layoutModeGet()) return;
     if (scope.backups.length < 2) return;
     const backupOx = globalScope.ox;


### PR DESCRIPTION
Fixes #3014 

#### Describe the changes you have made in this PR -

fixed to backup up to the last state of the simulator workspace, so that while undoing and redoing we not lose the last working state.

we can perform a backup before every `undo` and `redo` by calling `scheduleBackup()` function, to make sure that we have backup up to the last working state of the user project.

Problems Fixed:

- Update upto the last state of the simulator before `Undo`.
- Check the last state of the simulator before `Redo`. 
