### PR TITLE
Add arm64 support for docker builld

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -91,7 +91,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64
+          platforms: linux/amd64, linux/arm64
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
 

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,4 +1,4 @@
-FROM ruby:3.1.2 as builder
+FROM --platform=$BUILDPLATFORM ruby:3.1.2 as builder
 
 RUN curl -fsSL https://deb.nodesource.com/setup_14.x | bash -
 RUN apt-get update -qq && apt-get install -y --no-install-recommends --auto-remove nodejs imagemagick
@@ -31,7 +31,7 @@ RUN rm -rf node_modules  spec
 
 RUN bundle exec bootsnap precompile --gemfile app/ lib/
 
-FROM ruby:3.1.2-slim as app
+FROM --platform=$BUILDPLATFORM ruby:3.1.2-slim as app
 
 COPY --from=builder /usr/src/app /usr/src/app
 


### PR DESCRIPTION
This PR is to add arm64 support for docker image make circuitverse image accessible from Mac M1 and arm based linux distributions