### PR TITLE
fix: import theme file breaks custom theme dialog

### DIFF
--- a/simulator/src/themer/customThemer.js
+++ b/simulator/src/themer/customThemer.js
@@ -1,3 +1,5 @@
+/* eslint-disable import/prefer-default-export */
+/* eslint-disable import/no-cycle */
 import { dots } from '../canvasApi';
 import themeOptions from './themes';
 import updateThemeForStyle from './themer';
@@ -39,44 +41,60 @@ const getCustomThemeCard = () => {
 };
 
 /**
-* Create Custom Color Themes Dialog
-*/
+ * Create Custom Color Themes Dialog
+ */
 export const CustomColorThemes = () => {
     $('#CustomColorThemesDialog').empty();
     $('#CustomColorThemesDialog').append(getCustomThemeCard());
     $('#CustomColorThemesDialog').dialog({
         resizable: false,
         close() {
-            themeOptions['Custom Theme'] = JSON.parse(localStorage.getItem('Custom Theme')) || themeOptions['Default Theme']; // hack for closing dialog box without saving
+            themeOptions['Custom Theme'] = JSON.parse(localStorage.getItem('Custom Theme'))
+                || themeOptions['Default Theme']; // hack for closing dialog box without saving
             // Rollback to previous theme
             updateThemeForStyle(localStorage.getItem('theme'));
             updateBG();
         },
-        buttons: [{
-            text: 'Apply Theme',
-            click() {
-                // update theme to Custom Theme
-                localStorage.setItem('theme', 'Custom Theme');
-                // add Custom theme to custom theme object
-                localStorage.setItem('Custom Theme', JSON.stringify(themeOptions['Custom Theme']));
-                $('.set').removeClass('set');
-                $('.selected').addClass('set');
-                $(this).dialog('close');
+        buttons: [
+            {
+                text: 'Apply Theme',
+                click() {
+                    // update theme to Custom Theme
+                    localStorage.setItem('theme', 'Custom Theme');
+                    // add Custom theme to custom theme object
+                    localStorage.setItem(
+                        'Custom Theme',
+                        JSON.stringify(themeOptions['Custom Theme']),
+                    );
+                    $('.set').removeClass('set');
+                    $('.selected').addClass('set');
+                    $(this).dialog('close');
+                },
             },
-        }, {
-            text: 'Import Theme',
-            click() {
-                $('#importThemeFile').click();
+            {
+                text: 'Import Theme',
+                click() {
+                    $('#importThemeFile').click();
+                },
             },
-        }, {
-            text: 'Export Theme',
-            click() {
-                const dlAnchorElem = document.getElementById('downloadThemeFile');
-                dlAnchorElem.setAttribute('href', `data:text/json;charset=utf-8,${encodeURIComponent(JSON.stringify(themeOptions['Custom Theme']))}`);
-                dlAnchorElem.setAttribute('download', 'CV_CustomTheme.json');
-                dlAnchorElem.click();
+            {
+                text: 'Export Theme',
+                click() {
+                    const dlAnchorElem = document.getElementById('downloadThemeFile');
+                    dlAnchorElem.setAttribute(
+                        'href',
+                        `data:text/json;charset=utf-8,${encodeURIComponent(
+                            JSON.stringify(themeOptions['Custom Theme']),
+                        )}`,
+                    );
+                    dlAnchorElem.setAttribute(
+                        'download',
+                        'CV_CustomTheme.json',
+                    );
+                    dlAnchorElem.click();
+                },
             },
-        }],
+        ],
     });
 
     $('#CustomColorThemesDialog').focus();
@@ -84,14 +102,17 @@ export const CustomColorThemes = () => {
     /**
      * To preview the changes
      */
-    $('.customColorInput').on('input', (e) => {
-        customTheme[e.target.name].color = e.target.value;
-        customTheme[e.target.name].ref.forEach((property) => {
-            themeOptions['Custom Theme'][property] = e.target.value;
+    function setColorEvent() {
+        $('.customColorInput').on('input', (e) => {
+            customTheme[e.target.name].color = e.target.value;
+            customTheme[e.target.name].ref.forEach((property) => {
+                themeOptions['Custom Theme'][property] = e.target.value;
+            });
+            updateThemeForStyle('Custom Theme');
+            updateBG();
         });
-        updateThemeForStyle('Custom Theme');
-        updateBG();
-    });
+    }
+    setColorEvent();
 
     // hack for updating current theme to the saved custom theme
     setTimeout(() => {
@@ -100,9 +121,9 @@ export const CustomColorThemes = () => {
     }, 50);
 
     /**
-    * Read JSON file and
-    * set Custom theme to the Content of the JSON file
-    *  */
+     * Read JSON file and
+     * set Custom theme to the Content of the JSON file
+     *  */
     function receivedText(e) {
         const lines = JSON.parse(e.target.result);
         customTheme = CreateAbstraction(lines);
@@ -113,6 +134,7 @@ export const CustomColorThemes = () => {
         // update colors in dialog box
         $('#CustomColorThemesDialog').empty();
         $('#CustomColorThemesDialog').append(getCustomThemeCard());
+        setColorEvent();
     }
 
     /**


### PR DESCRIPTION
Fixes #2923 

#### Changes I made in this PR -
The issue was caused because the event listener responsible to update the colors/theme on the simulator page was stopping to work after importing a json file for setting a custom theme. Therefore I added the event listener inside another function which is called automatically when the exported function `CustomColorThemes` is called in order to set the event listener. Now I am using this same function signature to call and reset the event listener every time a new custom theme file is imported, inside the function `receivedText`

### Screencast -
Basically proof that it works...

https://user-images.githubusercontent.com/52719271/170951656-2c6edba4-5d4d-416f-b6a2-4990f2db715f.mp4

