### PR TITLE
fix: educational institution whitespace issue

### DIFF
--- a/app/decorators/profile_decorator.rb
+++ b/app/decorators/profile_decorator.rb
@@ -10,7 +10,7 @@ class ProfileDecorator < SimpleDelegator
   end
 
   def educational_institute
-    profile.educational_institute || "Not Entered"
+    profile.educational_institute.strip == "" ? "Not Entered" : profile.educational_institute.strip
   end
 
   def country_name


### PR DESCRIPTION
Fixes #2848 

#### Changes I made in this PR -

This line of code speaks for itself...
```diff
// ./app/decorators/profile_decorator.rb
def educational_institute
-   profile.educational_institute || "Not Entered"
+   profile.educational_institute.strip == "" ? "Not Entered" : profile.educational_institute.strip
end
```

### Screencast -
Basically proof that it works...

https://user-images.githubusercontent.com/52719271/171791457-68eac9af-911f-4aee-b45b-1a4d07d04315.mp4


