### PR TITLE
typo-fix-CONTRIBUTING-README #3163

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Please note:  If you wanted to work on an issue, let us know by leaving a commen
 - [good first issue](https://github.com/CircuitVerse/CircuitVerse/labels/good%20first%20issue) labeled issues are meant for newer developers.
 - [feature](https://github.com/CircuitVerse/CircuitVerse/labels/%F0%9F%8C%9F%20feature) labeled issues are meant to propose new features.
 - [bugs](https://github.com/CircuitVerse/CircuitVerse/labels/%F0%9F%90%9E%20bug) labeled issues are meant to have errors in existing code base.
-- [domumentation](https://github.com/CircuitVerse/CircuitVerse/labels/documentation) labeled issues are meant to have typo errors in documentation.
+- [documentation](https://github.com/CircuitVerse/CircuitVerse/labels/documentation) labeled issues are meant to have typo errors in documentation.
 - [Simulator](https://github.com/CircuitVerse/CircuitVerse/labels/simulator) issues are meant specifically in the scope of circuitverse simulator.
 - [platform](https://github.com/CircuitVerse/CircuitVerse/labels/platform) labeled issues are meant specifically in the scope of circuitverse website.
 - `difficulty: easy` issues are usually confined to isolated areas of existing code.


### PR DESCRIPTION
I have fixed the typo in CONTRIBUTING.md file

**Before :-**
![Contributing](https://user-images.githubusercontent.com/72146088/172055896-8b3a6646-745e-4f0a-b2f4-cd6c1d2397d8.JPG)

**After :-**
![NewContri](https://user-images.githubusercontent.com/72146088/172055989-0e89c909-b0e1-4324-adff-0440d118813c.JPG)

