### PR TITLE
fix: Issue of connect only "r" input to SRFlipFlop crash simulator

### DIFF
--- a/simulator/src/sequential/SRflipFlop.js
+++ b/simulator/src/sequential/SRflipFlop.js
@@ -117,7 +117,7 @@ export default class SRflipFlop extends CircuitElement {
         ctx.font = '20px Raleway';
         ctx.fillStyle = colors['input_text'];
         ctx.textAlign = 'center';
-        fillText(ctx, this.state.toString(16), xx, yy + 5);
+        this.state ? fillText(ctx, this.state.toString(16), xx, yy + 5) : fillText(ctx, '0', xx, yy + 5);
         ctx.fill();
     }
 }


### PR DESCRIPTION
Fixes #3187 

#### Describe the changes you have made in this PR -
Solved the issue of connecting only R input to SR Flip flop throws an error : TypeError: Cannot read properties of undefined (reading 'toString')

### Screenshots of the changes (If any) -
![Screenshot (444)](https://user-images.githubusercontent.com/89515816/174055002-8ca6d1a5-d73e-4cb2-acad-8ab145f3c2e6.png)


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
