### PR TITLE
fix(test):updated mailer copyright text properly

### DIFF
--- a/config/locales/views/layouts/en.yml
+++ b/config/locales/views/layouts/en.yml
@@ -27,7 +27,7 @@ en:
       language: "Language"
     mailer:
       join_us: "Join Us"
-      copyright_text: "Copyright © 2021 CircuitVerse. All rights reserved. For any issues, reach out to us support@circuitverse.org"
+      copyright_text: "Copyright © %{time_current_year} CircuitVerse, All rights reserved."
       unsubscribe_email_notifications: "Unsubscribe from email notifications"
     simulator:
       title: "CircuitVerse - Digital Circuit Simulator online"


### PR DESCRIPTION
Fixes #
Fixed the mailer copy right text by adding some elements and removing some texts as stated in the issue

#### Describe the changes you have made in this PR -
Previously, mailer copyright text was like this "Copyright © 2021 CircuitVerse. All rights reserved. For any issues, reach out to us support@circuitverse.org" which was replaced by new correct text as stated in the issue "Copyright © %{time_current_year} CircuitVerse, All rights reserved."

### Screenshots of the changes (If any) -
![image](https://user-images.githubusercontent.com/79035986/175836623-57a400c4-52ba-4df0-ac83-0c8dae73314e.png)




Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
