### PR TITLE
fixed : Pundit deprecation message issue#3208 

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::V1::BaseController < ActionController::API
-  include Pundit
+  include Pundit::Authorization
   include CustomErrors
   include ActionController::RequestForgeryProtection
   protect_from_forgery with: :exception, if: lambda {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
-  include Pundit
+  include Pundit::Authorization
   protect_from_forgery with: :exception
 
   before_action :store_user_location!, if: :storable_location?


### PR DESCRIPTION
Fixes #3208 

#### Describe the changes you have made in this PR 
- Replaced `include Pundit` with `include Pundit::Authorization` which was showing error in terminal during server runtime

### Screenshots of the changes -
- This what it was showing during running server ( before ) . Used `grep` command to specifically target the error `DEPRECATION WARNING: 'include Pundit' is deprecated. Please use 'include Pundit::Authorization' instead`

![before(include pundit)](https://user-images.githubusercontent.com/64253632/181191413-85627a76-c004-422c-93e5-a74aa8584d7c.png)

- Fixed ( after ). After replacing `include Pundit` with `include Pundit::Authorization` no error received in the terminal
![after(include Pundit::Authorization)](https://user-images.githubusercontent.com/64253632/181191432-4fde6d77-9b90-440f-b0dd-b6b86762056a.png)


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
