### PR TITLE
fix(style): aligns checkbox with remember me

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -62,6 +62,14 @@
 .right-shift {
   margin-left: 30px;
 }
+.session-primary-checkbox {
+  h6 {
+    display: inline;
+    margin-bottom: 0;
+    margin-left: 0;
+    margin-right: 10px;
+  }
+}
 
 .users-text-container {
   margin-top: 20px;

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -36,9 +36,10 @@
         </div>
         <% if devise_mapping.rememberable? -%>
           <div class="form-group newproject-checkbox">
-            <label class="primary-checkpoint-container users-primary-checkpoint"><h6 class="right-shift"><%= t("users.sessions.remember_me") %></h6>
+            <label class="primary-checkpoint-container users-primary-checkpoint session-primary-checkbox">
               <%= f.check_box :remember_me %>
               <div class="primary-checkpoint"></div>
+              <h6 class="right-shift"><%= t("users.sessions.remember_me") %></h6>
             </label>
           </div>
         <% end -%>


### PR DESCRIPTION
Fixes #3252 

**Changes:**

1.  Aligned checkbox with its "remember me" label.

**Screenshot**
<img width="545" alt="Screenshot 2022-08-05 at 12 33 02 PM" src="https://user-images.githubusercontent.com/74744046/183021110-31b49203-e6a8-4fda-b473-1205f50cbc6c.png">
