### PR TITLE
fix(groups): prevent users from adding whitespace to group name

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -98,7 +98,7 @@ class GroupsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def group_params
-      params.require(:group).permit(:name, :primary_mentor_id)
+      params.require(:group).permit(:name, :primary_mentor_id).each_value(&:strip!)
     end
 
     def check_show_access

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -98,7 +98,7 @@ class GroupsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def group_params
-      params.require(:group).permit(:name, :primary_mentor_id).each_value(&:strip!)
+      params.require(:group).permit(:name, :primary_mentor_id)
     end
 
     def check_show_access

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -2,7 +2,7 @@
 
 class Group < ApplicationRecord
   has_secure_token :group_token
-  validates :name, length: { minimum: 1 }
+  validates :name, length: { minimum: 1 }, presence: true
   belongs_to :primary_mentor, class_name: "User"
   has_many :group_members, dependent: :destroy
   has_many :users, through: :group_members


### PR DESCRIPTION
Fixes #2855 

#### Describe the changes you have made in this PR -

### Screenshots of the changes (If any) -

![trying to create group name with whitespace](https://user-images.githubusercontent.com/41837037/190867482-599cddf9-9780-4523-aa5f-d44a4492457d.gif)

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
