### PR TITLE
fix: add colon after deadlines in the assignments section

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -98,7 +98,7 @@ class GroupsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def group_params
-      params.require(:group).permit(:name, :primary_mentor_id)
+      params.require(:group).permit(:name, :primary_mentor_id).each_value(&:strip!)
     end
 
     def check_show_access

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -98,7 +98,7 @@ class GroupsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def group_params
-      params.require(:group).permit(:name, :primary_mentor_id).each_value(&:strip!)
+      params.require(:group).permit(:name, :primary_mentor_id)
     end
 
     def check_show_access

--- a/app/views/assignments/show.html.erb
+++ b/app/views/assignments/show.html.erb
@@ -21,7 +21,7 @@
         <div class="assignments-data">
           <p><%= t("assignments.assignment_data.name_html", name: @assignment.name) %></p>
           <p><%= t("assignments.assignment_data.group_html", group_name: @assignment.group.name) %></p>
-          <p><strong><%= t("assignments.deadline") %></strong><span class="assignments-deadline" data-year=<%= deadline_year(@assignment) %>
+          <p><strong><%= t("assignments.deadline") %></strong> <span class="assignments-deadline" data-year=<%= deadline_year(@assignment) %>
             data-month=<%= deadline_month(@assignment) %> data-day=<%= deadline_day(@assignment) %>
             data-hour=<%= deadline_hour(@assignment) %> data-minute=<%= deadline_minute(@assignment) %>
             data-second=<%= deadline_second(@assignment) %>><%= @assignment.deadline %></span></p>

--- a/app/views/assignments/show.html.erb
+++ b/app/views/assignments/show.html.erb
@@ -21,7 +21,7 @@
         <div class="assignments-data">
           <p><%= t("assignments.assignment_data.name_html", name: @assignment.name) %></p>
           <p><%= t("assignments.assignment_data.group_html", group_name: @assignment.group.name) %></p>
-          <p><strong><%= t("assignments.deadline") %></strong> <span class="assignments-deadline" data-year=<%= deadline_year(@assignment) %>
+          <p><strong><%= t("assignments.deadline") %> </strong><span class="assignments-deadline" data-year=<%= deadline_year(@assignment) %>
             data-month=<%= deadline_month(@assignment) %> data-day=<%= deadline_day(@assignment) %>
             data-hour=<%= deadline_hour(@assignment) %> data-minute=<%= deadline_minute(@assignment) %>
             data-second=<%= deadline_second(@assignment) %>><%= @assignment.deadline %></span></p>


### PR DESCRIPTION
Fixes #3409 

#### Describe the changes you have made in this PR -
I have added a space after the `deadline` text
