### PR TITLE
fix: navbar items & logo placement to make them vertically center aligned

### DIFF
--- a/app/assets/stylesheets/navbar.scss
+++ b/app/assets/stylesheets/navbar.scss
@@ -6,6 +6,11 @@
   z-index: 100;
 }
 
+.navbar-brand {
+  padding: 0;
+  margin-top: 5px;
+}
+
 .navbar-logo {
   height: 70px;
   padding-top: 5px;
@@ -15,6 +20,9 @@
   height: 40px;
   position: relative;
   width: 40px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
 
   .search-icon {
     cursor: pointer;
@@ -47,6 +55,20 @@
   &:focus {
     outline: none;
   }
+}
+
+.nav-item {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.nav-link {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
 }
 
 .navbar-simulator-text {
@@ -197,6 +219,10 @@
   .navbar-search-icon-onexpand {
     display: none;
   }
+
+  .nav-item {
+    align-items: flex-start;
+  }
 }
 
 @media (max-width: 768px) {
@@ -211,6 +237,10 @@
 
   .navbar-search-bar-select {
     width: 50px;
+  }
+
+  .nav-item {
+    align-items: flex-start;
   }
 }
 
@@ -232,5 +262,9 @@
   .navbar-logo {
     height: 60px;
     padding-top: 10px;
+  }
+
+  .nav-item {
+    align-items: flex-start;
   }
 }

--- a/app/assets/stylesheets/navbar.scss
+++ b/app/assets/stylesheets/navbar.scss
@@ -7,8 +7,8 @@
 }
 
 .navbar-brand {
-  padding: 0;
   margin-top: 5px;
+  padding: 0;
 }
 
 .navbar-logo {
@@ -17,12 +17,12 @@
 }
 
 .navbar-search-icon-container {
+  align-items: center;
+  display: flex;
+  flex-direction: row;
   height: 40px;
   position: relative;
   width: 40px;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
 
   .search-icon {
     cursor: pointer;
@@ -58,17 +58,17 @@
 }
 
 .nav-item {
+  align-items: center;
   display: flex;
   flex-direction: column;
   justify-content: center;
-  align-items: center;
 }
 
 .nav-link {
+  align-items: center;
   display: flex;
   flex-direction: row;
   justify-content: center;
-  align-items: center;
 }
 
 .navbar-simulator-text {

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -455,7 +455,6 @@
   font-size: 20px;
   margin-left: 10px;
   margin-right: 10px;
-  margin-top: 10px;
 }
 
 .nb-notification {


### PR DESCRIPTION
Fixes #3455 

#### Describe the changes you have made in this PR -
Added display: flex to `nav-item` class. Then added justify-content property accordingly.

### Screenshots of the changes (If any) -
![image](https://user-images.githubusercontent.com/55531939/210163427-46adca63-7793-4886-ac71-b543a6358191.png)
![image](https://user-images.githubusercontent.com/55531939/210163429-3bae5962-1b42-48d9-9c73-b35d55e00969.png)
![image](https://user-images.githubusercontent.com/55531939/210163432-0900d4b1-edc6-43d5-b232-6a6f816fecc7.png)
