### PR TITLE
fix(group_spec): code snippet to insert option in select rewritten

### DIFF
--- a/spec/system/group_spec.rb
+++ b/spec/system/group_spec.rb
@@ -36,9 +36,7 @@ describe "Group management", type: :system do
     click_button "+ Add Members"
     execute_script "document.getElementById('addmemberModal').style.display='block'"
     execute_script "document.getElementById('addmemberModal').style.opacity=1"
-    execute_script "var new_email = document.createElement('option')
-                    new_email.innerHTML = 'example@gmail.com'
-                    document.getElementById('group_member_emails').appendChild(new_email)"
+    execute_script "document.getElementById('group_member_emails').insertAdjacentHTML('beforeend', '<option>example@gmail.com</option>')"
     select "example@gmail.com", from: "group_member[emails][]"
     execute_script "document.getElementById('group_email_input').click()"
     click_button "Add members"

--- a/spec/system/group_spec.rb
+++ b/spec/system/group_spec.rb
@@ -36,7 +36,8 @@ describe "Group management", type: :system do
     click_button "+ Add Members"
     execute_script "document.getElementById('addmemberModal').style.display='block'"
     execute_script "document.getElementById('addmemberModal').style.opacity=1"
-    execute_script "document.getElementById('group_member_emails').insertAdjacentHTML('beforeend', '<option>example@gmail.com</option>')"
+    execute_script "document.getElementById('group_member_emails')\
+.insertAdjacentHTML('beforeend', '<option>example@gmail.com</option>')"
     select "example@gmail.com", from: "group_member[emails][]"
     execute_script "document.getElementById('group_email_input').click()"
     click_button "Add members"


### PR DESCRIPTION
Fixes #3443 
Locate changes around line 39

#### Describe the changes you have made in this PR -
I have updated the code snippet to insert email option in select  in group_spec.rb.

**Latest Code Snippet**
```
document.getElementById('group_member_emails').insertAdjacentHTML('beforeend', '<option>example@gmail.com</option>')
```

**Previously it was**
```
var new_email = document.createElement('option')
new_email.innerHTML = 'example@gmail.com'
document.getElementById('group_member_emails').appendChild(new_email)
```

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
