### PR TITLE
fixes: Pagination is not in the center of the page #3469

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -7,7 +7,7 @@ html {
 }
 
 body {
-  font-family: 'Inter';
+  font-family: "Inter";
   padding-top: 90px;
 }
 
@@ -144,8 +144,14 @@ body {
     }
   }
 }
+
 .pagination .page-link {
   white-space: nowrap;
+}
+
+.pagination{
+  display: flex;
+  justify-content: center;
 }
 
 @media (max-width: 992px) {
@@ -155,7 +161,9 @@ body {
   }
 
   .pagination {
-    display: block;
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
     max-width: none;
     overflow-x: visible;
     padding: 0;


### PR DESCRIPTION
Fixes #3469 

fixed the pagination and made it placed in the center as described in #3469 
I have also used "flex-wrap: wrap" so the pagination should be responsive for the smaller screens.

### Screenshots of the changes (If any) -
![users-op](https://user-images.githubusercontent.com/86093112/211211097-e7244d4f-e8ae-4585-a204-618e84108d1a.png)
![projects-op](https://user-images.githubusercontent.com/86093112/211211100-a034dd09-7dea-4972-ba31-9d148c9cb693.png)
