### PR TITLE
fix: fixed the navbar vertical height

### DIFF
--- a/app/assets/stylesheets/navbar.scss
+++ b/app/assets/stylesheets/navbar.scss
@@ -1,11 +1,11 @@
 .navbar {
   background-color: $white;
+  padding-top: 0;
+  padding-bottom: 0;
   position: fixed;
   top: 0;
   width: 100%;
   z-index: 100;
-  padding-top: 0px;
-  padding-bottom: 0px;
 }
 
 .navbar-logo {

--- a/app/assets/stylesheets/navbar.scss
+++ b/app/assets/stylesheets/navbar.scss
@@ -4,6 +4,8 @@
   top: 0;
   width: 100%;
   z-index: 100;
+  padding-top: 0px;
+  padding-bottom: 0px;
 }
 
 .navbar-logo {
@@ -108,7 +110,7 @@
   margin-top: 0;
   padding: 20px;
   position: fixed;
-  top: 96px;
+  top: 80px;
   width: 100%;
   z-index: 90;
 }

--- a/app/assets/stylesheets/navbar.scss
+++ b/app/assets/stylesheets/navbar.scss
@@ -1,7 +1,7 @@
 .navbar {
   background-color: $white;
-  padding-top: 0;
   padding-bottom: 0;
+  padding-top: 0;
   position: fixed;
   top: 0;
   width: 100%;


### PR DESCRIPTION
Fixes #3509

now Navigation Bar is not covering much area

#### Describe the changes you have made in this PR -

the vertical margin of the navigation bar has been set to Zero and the navigation search menu which appears on clicking the search option , is moved a little up to align with the navigation bar


### Screenshots of the changes (If any) -

![im](https://user-images.githubusercontent.com/91966855/213907334-4df9cfd9-c4a9-44b8-8654-b3d5d9ba36c1.png)




Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
