### PR TITLE
fix: added extra margin to social icons

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -100,8 +100,8 @@
 
 .users-social-links {
   height: 50px;
-  margin-left: 20px;
-  margin-right: 20px;
+  margin-left: 15px;
+  margin-right: 15px;
   padding-top: 10px;
   width: 40px;
 

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -100,8 +100,8 @@
 
 .users-social-links {
   height: 50px;
-  margin-left: 5px;
-  margin-right: 5px;
+  margin-left: 20px;
+  margin-right: 20px;
   padding-top: 10px;
   width: 40px;
 


### PR DESCRIPTION
Fixes #3514 

#### Describe the changes you have made in this PR -

added extra margin to social icons in the login page

### Screenshots of the changes (If any) -

![Screenshot from 2023-01-22 22-21-42](https://user-images.githubusercontent.com/91966855/213928143-22ef1183-5132-43c2-8bc8-0f3e0894970c.png)

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
