### PR TITLE
Copyright line align at the center

### DIFF
--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -76,6 +76,7 @@
 
 .footer-copyright-text {
   padding-top: 15px;
+  text-align: center;
 
   p {
     font-size: 15px;

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -74,7 +74,7 @@
       </div>
     </div>
     <div class="row">
-      <div class="col-12 text-white text-left footer-copyright-text">
+      <div class="col-12 text-white text-center footer-copyright-text">
   <p><%= t("layout.footer.copyright_text",time_current_year: Time.current.year) %></p>
       </div>
     </div>


### PR DESCRIPTION
Fixes #
#3520
#### Describe the changes you have made in this PR -
Earlier copyright  line was align at the left i made it to  align at center

### Screenshots of the changes (If any) -
![pullrequest](https://user-images.githubusercontent.com/95420063/214277439-1b2dd3da-96cd-487f-9970-e46383a9c333.png)





Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
