### PR TITLE
Add pending triage by default for all issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: "🐞 Bug report"
 about: Create a report to help us improve
 title: ''
-labels: "🐞 bug"
+labels: ["🐞 bug", "pending triage"]
 assignees: ''
 
 ---


### PR DESCRIPTION
Improve issue workflow by Adding `pending triage`  label to new issues. Members of @CircuitVerse/issues-team or @CircuitVerse/circuitverse-core-team can remove this label and assign an appropriate label or close the issue 