### PR TITLE
feat(ui): replace svg with user avatar , add avatar in the group cards & fix the stylings

### DIFF
--- a/app/assets/stylesheets/groups.scss
+++ b/app/assets/stylesheets/groups.scss
@@ -220,14 +220,15 @@
 
 .groups-members-card-avatar{
   img {
-    height: 60px;
-    padding: 10px 0 8px 0;
-    width: 40px;
-    transform: translateX(-5px);
+    height: 50px;
+    margin-bottom: 10px;
+    width: 50px;
+    border-radius: 50%;
+    transform: translate(-5px,5px);
     transition: all .5s;
 
     &:hover{
-      transform: scale(2.25);
+      transform: scale(2);
     }
   }
 }

--- a/app/assets/stylesheets/groups.scss
+++ b/app/assets/stylesheets/groups.scss
@@ -196,7 +196,8 @@
 .groups-members-card-details-non-admin {
   align-items: center;
   display: flex;
-  transform: translate(0px, -15px);
+  transform: translate(0, -15px);
+  
   i {
     margin-right: 15px;
     padding-bottom: 0;

--- a/app/assets/stylesheets/groups.scss
+++ b/app/assets/stylesheets/groups.scss
@@ -221,9 +221,9 @@
 
 .groups-members-card-avatar {
   img {
-	  border-radius: 50%;
+    border-radius: 50%;
     height: 50px;
-	  margin-bottom: 10px;
+    margin-bottom: 10px;
     transform: translate(-5px, 5px);
     transition: all .5s;
     width: 50px;

--- a/app/assets/stylesheets/groups.scss
+++ b/app/assets/stylesheets/groups.scss
@@ -174,8 +174,9 @@
   background-color: $card-green;
   border: 1px solid $secondary-green;
   display: inline-block;
-  height: 70px;
+  height: 90px;
   margin: 10px;
+  margin-bottom: 20px;
   padding: 15px;
   width: 200px;
   white-space: nowrap;
@@ -196,11 +197,11 @@
 .groups-members-card-details-non-admin {
   align-items: center;
   display: flex;
-  transform: translate(0, -15px);
+  padding-top: 0;
   
   i {
     margin-right: 15px;
-    padding-bottom: 0;
+    padding-bottom: 15px;
   }
 
   .groups-members-card-name-container {
@@ -220,9 +221,9 @@
 
 .groups-members-card-avatar {
   img {
-    border-radius: 50%;
+	  border-radius: 50%;
     height: 50px;
-    margin-bottom: 10px;
+	  margin-bottom: 10px;
     transform: translate(-5px, 5px);
     transition: all .5s;
     width: 50px;

--- a/app/assets/stylesheets/groups.scss
+++ b/app/assets/stylesheets/groups.scss
@@ -196,8 +196,7 @@
 .groups-members-card-details-non-admin {
   align-items: center;
   display: flex;
-  padding-top: 0;
-  
+  transform: translate(0px, -15px);
   i {
     margin-right: 15px;
     padding-bottom: 0;

--- a/app/assets/stylesheets/groups.scss
+++ b/app/assets/stylesheets/groups.scss
@@ -183,13 +183,13 @@
 
 .groups-members-card-details {
   padding-right: 0;
-  padding-top: 20px;
+  padding-top: 5px;
   text-align: left;
 
   i {
-    margin-right: 3px;
-    margin-top: 0;
-    padding-bottom: 5px;
+    margin-right: 10px;
+    margin-top: 20px;
+    padding-bottom: 20px;
   }
 }
 
@@ -218,13 +218,29 @@
   }
 }
 
+.groups-members-card-avatar{
+  img {
+    height: 60px;
+    padding: 10px 0 8px 0;
+    width: 40px;
+    transform: translateX(-5px);
+    transition: all .5s;
+
+    &:hover{
+      transform: scale(2.25);
+    }
+  }
+}
+
 .groups-members-card-name-container {
   display: inline-block;
-  height: 25px;
-  max-width: 110px;
+  height: 30px;
+  max-width: 92px;
   overflow: hidden;
   padding-top: 1px;
+  white-space: nowrap;
   text-overflow: ellipsis;
+  vertical-align: middle;
 }
 
 .groups-members-card-name {
@@ -265,17 +281,17 @@
 //breakpoints
 @media (max-width: 1200px) {
   .groups-members-scroll-row {
-    max-width: 920px;
+    max-width: 930px;
   }
 
   .groups-members-card {
-    width: 350px;
+    width: 320px;
   }
 }
 
 @media (max-width: 992px) {
   .groups-members-scroll-row {
-    max-width: 610px;
+    max-width: 680px;
   }
 }
 

--- a/app/assets/stylesheets/groups.scss
+++ b/app/assets/stylesheets/groups.scss
@@ -220,15 +220,14 @@
 
 .groups-members-card-avatar {
   img {
+    border-radius: 50%;
     height: 50px;
     margin-bottom: 10px;
-    width: 50px;
-    border-radius: 50%;
-    transform: translate(-5px,5px);
+    transform: translate(-5px, 5px);
     transition: all .5s;
-    width: 40px;
+    width: 50px;
 
-    &:hover{
+    &:hover {
       transform: scale(2);
     }
   }

--- a/app/views/groups/_group_members.html.erb
+++ b/app/views/groups/_group_members.html.erb
@@ -3,13 +3,19 @@
     <div class="<%= membersCardViewer(group) %>">
       <div class="row">
         <div class="<%= membersCardViewerDetail(group) %>">
-          <i class="fa fa-user"></i>
+          <span class="groups-members-card-avatar">
+          <% if member.user.profile_picture.present? %>
+          <%= image_tag(member.user.profile_picture.url, alt: member.user.name, title: "#{member.user.name}\n#{member.user.email}") %>
+          <% else %>
+          <i class="fa fa-user default-profile-icon"></i>
+          <% end %>
+          </span>
           <div class="groups-members-card-name-container">
             <span class="tooltiptext"><%= member.user.name %></span>
-            <%= link_to member.user.name, member.user, class: "groups-members-card-name" %>
+            <%= link_to member.user.name, member.user, class: "groups-members-card-name", title: "view profile of #{member.user.name}" %>
           </div>
           <% if policy(group).admin_access? %>
-            <p class="groups-members-card-email"><%= member.user.email %></p>
+            <p class="groups-members-card-email" title="<%= member.user.email %>"><%= member.user.email %></p>
           <% end %>
         </div>
         <% if policy(group).admin_access? %>

--- a/app/views/groups/_group_members.html.erb
+++ b/app/views/groups/_group_members.html.erb
@@ -5,8 +5,7 @@
         <div class="<%= membersCardViewerDetail(group) %>">
           <span class="groups-members-card-avatar">
           <% if member.user.profile_picture.present? %>
-          <%= image_tag(member.user.profile_picture.url, alt: member.user.name, title: "#{member.user.name}\n#{member.user.email}") %>
-          <% else %>
+          <%= link_to image_tag(member.user.profile_picture.url, alt: member.user.name, title: "#{member.user.name}\n#{member.user.email}"), user_path(member.user.id) %>          <% else %>
           <i class="fa fa-user default-profile-icon"></i>
           <% end %>
           </span>

--- a/app/views/groups/_group_mentors.html.erb
+++ b/app/views/groups/_group_mentors.html.erb
@@ -5,8 +5,7 @@
         <div class="<%= membersCardViewerDetail(group) %>">
         <span class="groups-members-card-avatar">
         <% if member.user.profile_picture.present? %>
-        <%= image_tag(member.user.profile_picture.url, alt: member.user.name, title: "#{member.user.name}\n#{member.user.email}") %>
-        <% else %>
+        <%= link_to image_tag(member.user.profile_picture.url, alt: member.user.name, title: "#{member.user.name}\n#{member.user.email}"), user_path(member.user.id) %>        <% else %>
         <i class="fa fa-user"></i>
         <% end %>
         </span>

--- a/app/views/groups/_group_mentors.html.erb
+++ b/app/views/groups/_group_mentors.html.erb
@@ -3,13 +3,19 @@
     <div class="<%= membersCardViewer(group) %>">
       <div class="row">
         <div class="<%= membersCardViewerDetail(group) %>">
-          <i class="fa fa-user"></i>
+        <span class="groups-members-card-avatar">
+        <% if member.user.profile_picture.present? %>
+        <%= image_tag(member.user.profile_picture.url, alt: member.user.name, title: "#{member.user.name}\n#{member.user.email}") %>
+        <% else %>
+        <i class="fa fa-user"></i>
+        <% end %>
+        </span>
           <div class="groups-members-card-name-container">
             <span class="tooltiptext"><%= member.user.name %></span>
-            <%= link_to member.user.name, member.user, class: "groups-members-card-name" %>
+            <%= link_to member.user.name, member.user, class: "groups-members-card-name", title: "view profile of #{member.user.name}" %>
           </div>
           <% if policy(group).admin_access? %>
-            <p class="groups-members-card-email"><%= member.user.email %></p>
+            <p class="groups-members-card-email" title="<%= member.user.email %>"><%= member.user.email %></p>
           <% end %>
         </div>
         <% if policy(group).admin_access? %>


### PR DESCRIPTION
Fixes #3622

#### Describe the changes you have made in this PR -

1. replace default svg with user profile image.
2. fix the overlapping of cards under 1200px
3. fix text overflow issue due to changing from svg to img
4. add name , email display on hover (necessary because text overflow hides full name and its quite annoying to open profile every time to see full name or email)
5. add image scaling on hover over image (only works on image not on default svg)

### Screenshots of the changes (If any) -
1. replace default svg with user profile image.

![image](https://user-images.githubusercontent.com/96580571/221918821-71e65b3e-d0ba-470d-a9af-72f260565377.png)

2. fix the overlapping of cards under 1200px 

- before:

![image](https://user-images.githubusercontent.com/96580571/221919115-98d2cff8-2df7-487f-8f19-8640e1bc9c96.png)
![image](https://user-images.githubusercontent.com/96580571/221919132-ea699e4f-6804-41a6-b99e-42b0e1ba2061.png)

- after:

![image](https://user-images.githubusercontent.com/96580571/221919200-16be5c41-48eb-458a-abcf-34317d934747.png)
![image](https://user-images.githubusercontent.com/96580571/221919206-dc44c32b-123a-4e93-9898-407fb15769ee.png)

5. add image scaling on hover over image (only works on image not on default svg)

![image](https://user-images.githubusercontent.com/96580571/221919296-49d5ddeb-4724-4e66-855b-89ab165de071.png)


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
