### PR TITLE
Removed extra space above Footer

### DIFF
--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -1,5 +1,5 @@
 .footer-empty-div {
-  height: 250px;
+  height: 40px;
 }
 
 .footer-container-fluid {


### PR DESCRIPTION
.footer-empty-div now have the height from 250px to 40px

Fixes :  Access Empty Space above the Footer has been reduced to 40px

Before : 

![before](https://user-images.githubusercontent.com/105926192/222088820-6d02c955-0500-4291-8146-566c74c61381.png)


After:


![after](https://user-images.githubusercontent.com/105926192/222089009-010d7190-d475-4c84-a78a-e22577e89951.png)
