### PR TITLE
Fixing extra space in project card on search page and description column in project page

### DIFF
--- a/app/assets/stylesheets/projects.scss
+++ b/app/assets/stylesheets/projects.scss
@@ -105,7 +105,8 @@
 }
 
 .projects-details-description {
-  height: 150px;
+  max-height: 150px;
+  margin-bottom: 10px;
   margin-top: -8px;
   overflow-y: auto;
   padding-top: 0;

--- a/app/assets/stylesheets/search.scss
+++ b/app/assets/stylesheets/search.scss
@@ -98,7 +98,7 @@
 }
 
 .search-project-description {
-  height: 300px;
+  max-height: 300px;
   margin-left: 15px;
   overflow-y: auto;
   text-align: left;


### PR DESCRIPTION
Fixes #3630

### Changes Made:
- Description field of project card in search page has given max-height:300px rather than height.
![Screen Shot 2023-03-02 at 00 13 41](https://user-images.githubusercontent.com/89572340/222244509-a247799c-e9b4-4225-9973-e238a86baa0a.png)

- Similarly description field of project page has given max-height rather than height.
![Screen Shot 2023-03-02 at 00 14 18](https://user-images.githubusercontent.com/89572340/222244545-1de9acee-991a-47cd-857e-eebdf13b3bfd.png)


