### PR TITLE
Removed black box around social links in the footer section

### DIFF
--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -32,7 +32,6 @@
 }
 
 .bounce-out-on-hover {
-  box-shadow: 0 0 1px $black;
   display: inline-block;
   transform: perspective(1px) translateZ(0);
   transition-duration: .5s;


### PR DESCRIPTION
Fixes #3642 

#### Describe the changes you have made in this PR -
Removed the box-shadow property from bounce-out-on-hover class

### Screenshots of the changes (If any) -
![Screenshot from 2023-03-03 22-55-38](https://user-images.githubusercontent.com/108523406/222787335-d73f7c85-b070-403a-a32b-955bc3a55fea.png)



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
