### PR TITLE
#3689 - Footer Having Square Blocks In Social handles.

### DIFF
--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -32,7 +32,7 @@
 }
 
 .bounce-out-on-hover {
-  box-shadow: 0 0 1px $black;
+  // box-shadow: 0 0 1px $black;
   display: inline-block;
   transform: perspective(1px) translateZ(0);
   transition-duration: .5s;


### PR DESCRIPTION
Fixes # https://github.com/CircuitVerse/CircuitVerse/issues/3689

#### Describe the changes you have made in this PR -
According to Issue #3689 , the social elements have a square border that is 1 px wide and solid black in colour, which may lead to a poor user interface. So, this PR enables it to do away with the square border and enhance the Interface.

### Screenshots of the changes (If any) -

![image](https://user-images.githubusercontent.com/85166079/226704909-c3ea7392-2cb0-42d2-9616-3090acb136d4.png)



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
