### PR TITLE
fix: footer gap

### DIFF
--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -1,5 +1,5 @@
 .footer-empty-div {
-  height: 250px;
+  height: 60px;
 }
 
 .footer-container-fluid {


### PR DESCRIPTION
Fixes #3621

There is an additional space above the footer. I fix it by just reducing the height of the `footer-empty-div` in `footer.scss` file.

## Screenshots of the changes 

Before

![image](https://github.com/CircuitVerse/CircuitVerse/assets/93199036/532970af-b5cf-453e-aaf5-296a5a7aeb85)

After

![image](https://github.com/CircuitVerse/CircuitVerse/assets/93199036/4e154bc6-5cf9-4d93-95de-acf8b1e019e5)



