### PR TITLE
feat(gsoc): add vue simulator as git submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 test_results
 
 public/assets/
+public/simulatorvue
 
 /config/database.yml
 /config/secrets.yml

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cv-frontend-vue"]
+	path = cv-frontend-vue
+	url = https://github.com/CircuitVerse/cv-frontend-vue.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "cv-frontend-vue"]
 	path = cv-frontend-vue
 	url = https://github.com/CircuitVerse/cv-frontend-vue.git
+	branch = main # update with the branch from which you want to fetch the updates

--- a/app/controllers/vuesimulator_controller.rb
+++ b/app/controllers/vuesimulator_controller.rb
@@ -10,7 +10,7 @@ class VuesimulatorController < ApplicationController
 
   private
 
-  def sanitize(html)
-    ActionController::Base.helpers.sanitize(html)
-  end
+    def sanitize(html)
+      ActionController::Base.helpers.sanitize(html)
+    end
 end

--- a/app/controllers/vuesimulator_controller.rb
+++ b/app/controllers/vuesimulator_controller.rb
@@ -3,9 +3,9 @@
 
 class VuesimulatorController < ApplicationController
   def simulatorvue
-    html = File.read(Rails.root.join("public", "simulatorvue", "index.html"))
+    html = File.read(Rails.root.join('public', 'simulatorvue', 'index.html'))
     sanitized_html = sanitize(html)
-    render html: sanitized_html.html_safe, layout: false
+    render html: sanitized_html, layout: false
   end
 
   private

--- a/app/controllers/vuesimulator_controller.rb
+++ b/app/controllers/vuesimulator_controller.rb
@@ -1,0 +1,6 @@
+class VuesimulatorController < ApplicationController
+    def simulatorvue
+        html = File.read(Rails.root.join("public","simulatorvue","index.html"))
+        render html: html.html_safe, layout: false
+    end
+end

--- a/app/controllers/vuesimulator_controller.rb
+++ b/app/controllers/vuesimulator_controller.rb
@@ -1,6 +1,16 @@
+# app/controllers/vuesimulator_controller.rb
+# frozen_string_literal: true
+
 class VuesimulatorController < ApplicationController
-    def simulatorvue
-        html = File.read(Rails.root.join("public","simulatorvue","index.html"))
-        render html: html.html_safe, layout: false
-    end
+  def simulatorvue
+    html = File.read(Rails.root.join("public", "simulatorvue", "index.html"))
+    sanitized_html = sanitize(html)
+    render html: sanitized_html.html_safe, layout: false
+  end
+
+  private
+
+  def sanitize(html)
+    ActionController::Base.helpers.sanitize(html)
+  end
 end

--- a/app/controllers/vuesimulator_controller.rb
+++ b/app/controllers/vuesimulator_controller.rb
@@ -3,7 +3,7 @@
 
 class VuesimulatorController < ApplicationController
   def simulatorvue
-    html = File.read(Rails.root.join('public', 'simulatorvue', 'index.html'))
+    html = File.read(Rails.root("public/simulatorvue/index.html"))
     sanitized_html = sanitize(html)
     render html: sanitized_html, layout: false
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -105,6 +105,10 @@ Rails.application.routes.draw do
 
   mount Commontator::Engine => "/commontator"
 
+  #vue simulator
+  # get "/simulatorvue" to "vuesimulator#simulatorvue"
+  get "/simulatorvue/*path", to: "vuesimulator#simulatorvue"
+
   # simulator
   scope "/simulator" do
     get "/:id", to: "simulator#show", as: "simulator"

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -42,6 +42,7 @@ const vuePlugin = {
     name: 'vuePlugin',
     setup(build) {
         build.onStart(() => {
+            // eslint-disable-next-line no-console
             console.log(`Building Vue site: ${new Date(Date.now()).toLocaleString()}`);
             buildVue();
         });


### PR DESCRIPTION
Fixes #3768 

### Describe the changes you have made in this PR -

#### UPDATE 1:

- [x] add [cv-frontend-vue](https://github.com/CircuitVerse/cv-frontend-vue) repository as a git submodule in this repository

####UPDATE 2:

- [x] add routing to the static build file of vue simulator in routes.rb and controller for the same.

#### UPDATE 3:

- [x] added submodule update , npm install and npm run build command for the vue simulator in esbuild

- [x] added rebuild of vue simulator by pressing `r` or `R` form the console instead of restarting

### Screenshots of the changes (If any) -
N/A

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
