### PR TITLE
Creation of new api endpoints in api/v1 format for vue simulator & jwt setup for main site

### DIFF
--- a/app/controllers/api/v1/authentication_controller.rb
+++ b/app/controllers/api/v1/authentication_controller.rb
@@ -7,9 +7,9 @@ class Api::V1::AuthenticationController < Api::V1::BaseController
   def login
     @user = User.find_by!(email: params[:email])
     if @user&.valid_password?(params[:password])
-      token = JsonWebToken.encode(
+      token = JsonWebToken.encode({
         user_id: @user.id, username: @user.name, email: @user.email
-      )
+      })
       render json: { token: token }, status: :accepted
     elsif @user
       api_error(status: 401, errors: "invalid credentials")
@@ -22,9 +22,9 @@ class Api::V1::AuthenticationController < Api::V1::BaseController
       api_error(status: 409, errors: "user already exists")
     else
       @user = User.create!(signup_params)
-      token = JsonWebToken.encode(
+      token = JsonWebToken.encode({
         user_id: @user.id, username: @user.name, email: @user.email
-      )
+      })
       render json: { token: token }, status: :created
     end
   end
@@ -32,9 +32,9 @@ class Api::V1::AuthenticationController < Api::V1::BaseController
   # POST api/v1/oauth/login
   def oauth_login
     @user = User.find_by!(email: @oauth_user["email"])
-    token = JsonWebToken.encode(
+    token = JsonWebToken.encode({
       user_id: @user.id, username: @user.name, email: @user.email
-    )
+    })
     render json: { token: token }, status: :accepted
   end
 
@@ -48,9 +48,9 @@ class Api::V1::AuthenticationController < Api::V1::BaseController
         # @user has validation errors
         api_error(status: 422, errors: @user.errors)
       else
-        token = JsonWebToken.encode(
+        token = JsonWebToken.encode({
           user_id: @user.id, username: @user.name, email: @user.email
-        )
+        })
         render json: { token: token }, status: :created
       end
     end

--- a/app/controllers/api/v1/authentication_controller.rb
+++ b/app/controllers/api/v1/authentication_controller.rb
@@ -7,9 +7,7 @@ class Api::V1::AuthenticationController < Api::V1::BaseController
   def login
     @user = User.find_by!(email: params[:email])
     if @user&.valid_password?(params[:password])
-      token = JsonWebToken.encode({
-        user_id: @user.id, username: @user.name, email: @user.email
-      })
+      token = JsonWebToken.encode({ user_id: @user.id, username: @user.name, email: @user.email })
       render json: { token: token }, status: :accepted
     elsif @user
       api_error(status: 401, errors: "invalid credentials")
@@ -22,9 +20,7 @@ class Api::V1::AuthenticationController < Api::V1::BaseController
       api_error(status: 409, errors: "user already exists")
     else
       @user = User.create!(signup_params)
-      token = JsonWebToken.encode({
-        user_id: @user.id, username: @user.name, email: @user.email
-      })
+      token = JsonWebToken.encode({ user_id: @user.id, username: @user.name, email: @user.email })
       render json: { token: token }, status: :created
     end
   end
@@ -32,9 +28,7 @@ class Api::V1::AuthenticationController < Api::V1::BaseController
   # POST api/v1/oauth/login
   def oauth_login
     @user = User.find_by!(email: @oauth_user["email"])
-    token = JsonWebToken.encode({
-      user_id: @user.id, username: @user.name, email: @user.email
-    })
+    token = JsonWebToken.encode({ user_id: @user.id, username: @user.name, email: @user.email })
     render json: { token: token }, status: :accepted
   end
 
@@ -48,9 +42,7 @@ class Api::V1::AuthenticationController < Api::V1::BaseController
         # @user has validation errors
         api_error(status: 422, errors: @user.errors)
       else
-        token = JsonWebToken.encode({
-          user_id: @user.id, username: @user.name, email: @user.email
-        })
+        token = JsonWebToken.encode({ user_id: @user.id, username: @user.name, email: @user.email })
         render json: { token: token }, status: :created
       end
     end

--- a/app/controllers/api/v1/simulator_controller.rb
+++ b/app/controllers/api/v1/simulator_controller.rb
@@ -9,13 +9,13 @@ class Api::V1::SimulatorController < Api::V1::BaseController
   before_action :set_user_project, only: %i[update]
   before_action :check_view_access, only: %i[data]
   before_action :check_edit_access, only: %i[edit update]
-  # skip_before_action :verify_authenticity_token, only: %i[data create update verilog_cv]
+  # skip_before_action :verify_authenticity_token, only: %i[data create update verilogcv]
 
   def self.policy_class
     ProjectPolicy
   end
 
-  # Get api/v1/simulator/:id/edit
+  # GET api/v1/simulator/:id/edit
   def edit
     render json: Api::V1::UserSerializer.new(current_user)
   end
@@ -30,7 +30,7 @@ class Api::V1::SimulatorController < Api::V1::BaseController
     end
   end
 
-  # POST api/v1/simulator/update_data
+  # PATCH api/v1/simulator/update
   def update
     build_project_datum
     update_project_params
@@ -43,7 +43,7 @@ class Api::V1::SimulatorController < Api::V1::BaseController
     end
   end
 
-  # POST api/v1/simulator/create_data
+  # POST api/v1/simulator/create
   def create
     @project = Project.new
     @project.build_project_datum.data = sanitize_data(@project, params[:data])
@@ -85,8 +85,8 @@ class Api::V1::SimulatorController < Api::V1::BaseController
     end
   end
 
-  # POST api/v1/simulator/verilog_cv
-  def verilog_cv
+  # POST api/v1/simulator/verilogcv
+  def verilogcv
     url = "#{ENV.fetch('YOSYS_PATH', 'http://127.0.0.1:3040')}/getJSON"
     response = HTTP.post(url, json: { code: params[:code] })
     render json: response.to_s, status: response.code

--- a/app/controllers/api/v1/simulator_controller.rb
+++ b/app/controllers/api/v1/simulator_controller.rb
@@ -4,20 +4,24 @@ class Api::V1::SimulatorController < Api::V1::BaseController
   include SimulatorHelper
   include ActionView::Helpers::SanitizeHelper
 
-  before_action :authenticate_user!, only: %i[update edit]
-  before_action :set_project, only: %i[show edit]
-  before_action :check_view_access, only: %i[show]
+  before_action :authenticate_user!, only: %i[create update edit]
+  before_action :set_project, only: %i[data edit]
   before_action :set_user_project, only: %i[update]
+  before_action :check_view_access, only: %i[data]
   before_action :check_edit_access, only: %i[edit update]
-  # skip_before_action :verify_authenticity_token, only: %i[show update]
+  # skip_before_action :verify_authenticity_token, only: %i[data create update verilog_cv]
+
+  def self.policy_class
+    ProjectPolicy
+  end
 
   # Get api/v1/simulator/:id/edit
   def edit
     render json: Api::V1::UserSerializer.new(current_user)
   end
 
-  # GET api/v1/simulator/:id
-  def show
+  # GET api/v1/simulator/:id/data
+  def data
     @data = ProjectDatum.find_by(project: @project)
     if @data
       render json: @data.data, status: :ok
@@ -26,7 +30,7 @@ class Api::V1::SimulatorController < Api::V1::BaseController
     end
   end
 
-  # POST api/v1/simulator/update
+  # POST api/v1/simulator/update_data
   def update
     build_project_datum
     update_project_params
@@ -39,8 +43,8 @@ class Api::V1::SimulatorController < Api::V1::BaseController
     end
   end
 
-  # POST api/v1/simulator/create
-  def create_data
+  # POST api/v1/simulator/create_data
+  def create
     @project = Project.new
     @project.build_project_datum.data = sanitize_data(@project, params[:data])
     @project.name = sanitize(params[:name])
@@ -57,7 +61,6 @@ class Api::V1::SimulatorController < Api::V1::BaseController
       render json: { status: "error", errors: @project.errors.full_messages }, status: :unprocessable_entity
     end
   end
-
 
   # POST api/v1/simulator/post_issue
   def post_issue

--- a/app/controllers/api/v1/simulator_controller.rb
+++ b/app/controllers/api/v1/simulator_controller.rb
@@ -45,22 +45,22 @@ class Api::V1::SimulatorController < Api::V1::BaseController
       @project.build_project_datum unless ProjectDatum.exists?(project_id: @project.id)
       @project.project_datum.data = sanitize_data(@project, params[:data])
     end
-  
+
     def update_project_params
       @image_file = return_image_file(params[:image])
       @project.image_preview = @image_file
       @project.name = sanitize(params[:name])
     end
-  
+
     def handle_image_file_cleanup
       @image_file.close
       File.delete(@image_file) if check_to_delete(params[:image])
     end
-  
+
     def set_project
       @project = Project.friendly.find(params[:id])
     end
-  
+
     # FIXME: remove this logic after fixing production data
     # def set_user_project
     #   @project = current_user.projects.friendly.find_by(id: params[:id]) || Project.friendly.find(params[:id])
@@ -68,11 +68,11 @@ class Api::V1::SimulatorController < Api::V1::BaseController
     def set_user_project
       @project = current_user.projects.friendly.find(params[:id])
     end
-  
+
     def check_edit_access
       authorize @project, :check_edit_access?
     end
-  
+
     def check_view_access
       authorize @project, :check_view_access?
     end

--- a/app/controllers/api/v1/simulator_controller.rb
+++ b/app/controllers/api/v1/simulator_controller.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+class Api::V1::SimulatorController < Api::V1::BaseController
+  include SimulatorHelper
+  include ActionView::Helpers::SanitizeHelper
+
+  before_action :authenticate_user!, only: %i[update edit update_image]
+  before_action :set_project, only: %i[show edit]
+  before_action :check_view_access, only: %i[show]
+  before_action :set_user_project, only: %i[update update_image]
+  before_action :check_edit_access, only: %i[edit update update_image]
+  skip_before_action :verify_authenticity_token, only: %i[show update]
+
+  # Get api/v1/simulator/:id/edit
+  def edit
+    render json: Api::V1::UserSerializer.new(current_user)
+  end
+
+  # GET api/v1/simulator/:id
+  def show
+    @data = ProjectDatum.find_by(project: @project)
+    if @data
+      render json: @data.data, status: :ok
+    else
+      render json: { errors: "Data not found for the specified project." }, status: :not_found
+    end
+  end
+
+  # POST api/v1/simulator/update
+  def update
+    @project.build_project_datum unless ProjectDatum.exists?(project_id: @project.id)
+    @project.project_datum.data = sanitize_data(@project, params[:data])
+
+    image_file = return_image_file(params[:image])
+
+    @project.image_preview = image_file
+    @project.name = sanitize(params[:name])
+
+    if @project.save && @project.project_datum.save
+      image_file.close
+      File.delete(image_file) if check_to_delete(params[:image])
+
+      render json: { status: "success", project: @project }, status: :ok
+    else
+      render json: { status: "error", errors: @project.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+    def set_project
+      @project = Project.friendly.find(params[:id])
+    end
+
+    # FIXME: remove this logic after fixing production data
+    # def set_user_project
+    #   @project = current_user.projects.friendly.find_by(id: params[:id]) || Project.friendly.find(params[:id])
+    # end
+    def set_user_project
+      @project = current_user.projects.friendly.find(params[:id])
+    end
+
+    def check_edit_access
+      authorize @project, :check_edit_access?
+    end
+
+    def check_view_access
+      authorize @project, :check_view_access?
+    end
+end

--- a/app/controllers/api/v1/simulator_controller.rb
+++ b/app/controllers/api/v1/simulator_controller.rb
@@ -4,12 +4,12 @@ class Api::V1::SimulatorController < Api::V1::BaseController
   include SimulatorHelper
   include ActionView::Helpers::SanitizeHelper
 
-  before_action :authenticate_user!, only: %i[update edit update_image]
+  before_action :authenticate_user!, only: %i[update edit]
   before_action :set_project, only: %i[show edit]
   before_action :check_view_access, only: %i[show]
-  before_action :set_user_project, only: %i[update update_image]
-  before_action :check_edit_access, only: %i[edit update update_image]
-  skip_before_action :verify_authenticity_token, only: %i[show update]
+  before_action :set_user_project, only: %i[update]
+  before_action :check_edit_access, only: %i[edit update]
+  # skip_before_action :verify_authenticity_token, only: %i[show update]
 
   # Get api/v1/simulator/:id/edit
   def edit
@@ -28,18 +28,11 @@ class Api::V1::SimulatorController < Api::V1::BaseController
 
   # POST api/v1/simulator/update
   def update
-    @project.build_project_datum unless ProjectDatum.exists?(project_id: @project.id)
-    @project.project_datum.data = sanitize_data(@project, params[:data])
-
-    image_file = return_image_file(params[:image])
-
-    @project.image_preview = image_file
-    @project.name = sanitize(params[:name])
+    build_project_datum
+    update_project_params
 
     if @project.save && @project.project_datum.save
-      image_file.close
-      File.delete(image_file) if check_to_delete(params[:image])
-
+      handle_image_file_cleanup
       render json: { status: "success", project: @project }, status: :ok
     else
       render json: { status: "error", errors: @project.errors.full_messages }, status: :unprocessable_entity
@@ -48,23 +41,39 @@ class Api::V1::SimulatorController < Api::V1::BaseController
 
   private
 
-    def set_project
-      @project = Project.friendly.find(params[:id])
-    end
+  def build_project_datum
+    @project.build_project_datum unless ProjectDatum.exists?(project_id: @project.id)
+    @project.project_datum.data = sanitize_data(@project, params[:data])
+  end
 
-    # FIXME: remove this logic after fixing production data
-    # def set_user_project
-    #   @project = current_user.projects.friendly.find_by(id: params[:id]) || Project.friendly.find(params[:id])
-    # end
-    def set_user_project
-      @project = current_user.projects.friendly.find(params[:id])
-    end
+  def update_project_params
+    @image_file = return_image_file(params[:image])
+    @project.image_preview = @image_file
+    @project.name = sanitize(params[:name])
+  end
 
-    def check_edit_access
-      authorize @project, :check_edit_access?
-    end
+  def handle_image_file_cleanup
+    @image_file.close
+    File.delete(@image_file) if check_to_delete(params[:image])
+  end
 
-    def check_view_access
-      authorize @project, :check_view_access?
-    end
+  def set_project
+    @project = Project.friendly.find(params[:id])
+  end
+
+  # FIXME: remove this logic after fixing production data
+  # def set_user_project
+  #   @project = current_user.projects.friendly.find_by(id: params[:id]) || Project.friendly.find(params[:id])
+  # end
+  def set_user_project
+    @project = current_user.projects.friendly.find(params[:id])
+  end
+
+  def check_edit_access
+    authorize @project, :check_edit_access?
+  end
+
+  def check_view_access
+    authorize @project, :check_view_access?
+  end
 end

--- a/app/controllers/api/v1/simulator_controller.rb
+++ b/app/controllers/api/v1/simulator_controller.rb
@@ -41,39 +41,39 @@ class Api::V1::SimulatorController < Api::V1::BaseController
 
   private
 
-  def build_project_datum
-    @project.build_project_datum unless ProjectDatum.exists?(project_id: @project.id)
-    @project.project_datum.data = sanitize_data(@project, params[:data])
-  end
-
-  def update_project_params
-    @image_file = return_image_file(params[:image])
-    @project.image_preview = @image_file
-    @project.name = sanitize(params[:name])
-  end
-
-  def handle_image_file_cleanup
-    @image_file.close
-    File.delete(@image_file) if check_to_delete(params[:image])
-  end
-
-  def set_project
-    @project = Project.friendly.find(params[:id])
-  end
-
-  # FIXME: remove this logic after fixing production data
-  # def set_user_project
-  #   @project = current_user.projects.friendly.find_by(id: params[:id]) || Project.friendly.find(params[:id])
-  # end
-  def set_user_project
-    @project = current_user.projects.friendly.find(params[:id])
-  end
-
-  def check_edit_access
-    authorize @project, :check_edit_access?
-  end
-
-  def check_view_access
-    authorize @project, :check_view_access?
-  end
+    def build_project_datum
+      @project.build_project_datum unless ProjectDatum.exists?(project_id: @project.id)
+      @project.project_datum.data = sanitize_data(@project, params[:data])
+    end
+  
+    def update_project_params
+      @image_file = return_image_file(params[:image])
+      @project.image_preview = @image_file
+      @project.name = sanitize(params[:name])
+    end
+  
+    def handle_image_file_cleanup
+      @image_file.close
+      File.delete(@image_file) if check_to_delete(params[:image])
+    end
+  
+    def set_project
+      @project = Project.friendly.find(params[:id])
+    end
+  
+    # FIXME: remove this logic after fixing production data
+    # def set_user_project
+    #   @project = current_user.projects.friendly.find_by(id: params[:id]) || Project.friendly.find(params[:id])
+    # end
+    def set_user_project
+      @project = current_user.projects.friendly.find(params[:id])
+    end
+  
+    def check_edit_access
+      authorize @project, :check_edit_access?
+    end
+  
+    def check_view_access
+      authorize @project, :check_view_access?
+    end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -23,7 +23,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
           value: token,
           httponly: true,
           secure: Rails.env.production?,
-          same_site: :strict,
+          same_site: :strict
         }
       end
     end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -11,11 +11,22 @@ class Users::RegistrationsController < Devise::RegistrationsController
   #   super
   # end
 
-  # POST /resource
-  # def create
-  #   super
-  # end
+# POST /resource
+def create
+  super do |user|
+    if user.persisted? # Ensure that user is saved in database
+      # Generate JWT token
+      token = JsonWebToken.encode({
+        user_id: user.id, username: user.name, email: user.email 
+      })
 
+      # Set JWT token as cookie
+      cookies[:cvt] = { value: token, httponly: true }
+    end
+  end
+end
+
+  
   # GET /resource/edit
   # def edit
   #   super

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -11,22 +11,24 @@ class Users::RegistrationsController < Devise::RegistrationsController
   #   super
   # end
 
-# POST /resource
-def create
-  super do |user|
-    if user.persisted? # Ensure that user is saved in database
-      # Generate JWT token
-      token = JsonWebToken.encode({
-        user_id: user.id, username: user.name, email: user.email 
-      })
+  # POST /resource
+  def create
+    super do |user|
+      if user.persisted?
+        # Generate JWT token
+        token = JsonWebToken.encode({ user_id: user.id, username: user.name, email: user.email }, remember_me: false)
 
-      # Set JWT token as cookie
-      cookies[:cvt] = { value: token, httponly: true }
+        # Set JWT token as cookie
+        cookies[:cvt] = {
+          value: token,
+          httponly: true,
+          secure: Rails.env.production?,
+          same_site: :strict,
+        }
+      end
     end
   end
-end
 
-  
   # GET /resource/edit
   # def edit
   #   super

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -17,8 +17,10 @@ class Users::SessionsController < Devise::SessionsController
       remember_me = params.dig(:user, :remember_me) == "1"
 
       # Generate JWT token
-      token = JsonWebToken.encode( { user_id: user.id, username: user.name, email: user.email },
-      remember_me: remember_me )
+      token = JsonWebToken.encode(
+        { user_id: user.id, username: user.name, email: user.email },
+        remember_me: remember_me
+      )
 
       cookie_options = {
         value: token,

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -19,22 +19,26 @@ class Users::SessionsController < Devise::SessionsController
       # Generate JWT token 
       token = JsonWebToken.encode({ user_id: user.id, username: user.name, email: user.email }, remember_me: remember_me)
 
-      Set JWT token as a secure cookie
-      cookies[:cvt] = {
+      cookie_options = {
         value: token,
         httponly: true,
         secure: Rails.env.production?,
-        same_site: :strict, # or :lax
-        expires: remember_me ? 30.days.from_now : 15.days.from_now
+        same_site: :strict # or :lax
       }
+      
+      # Set cookie expiration
+      cookie_options[:expires] = 2.weeks.from_now if remember_me
+
+      # Set JWT token as cookie
+      cookies[:cvt] = cookie_options
     end
   end
 
   # DELETE /resource/sign_out
   def destroy
     super do |user|
-    # Remove the JWT token cookie
-    cookies.delete(:cvt)
+      # Remove the JWT token cookie
+      cookies.delete(:cvt)
     end
   end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -14,18 +14,19 @@ class Users::SessionsController < Devise::SessionsController
   def create
     super do |user|
       # Check if 'Remember me' is selected
-      remember_me = params.dig(:user, :remember_me) == '1'
+      remember_me = params.dig(:user, :remember_me) == "1"
 
-      # Generate JWT token 
-      token = JsonWebToken.encode({ user_id: user.id, username: user.name, email: user.email }, remember_me: remember_me)
+      # Generate JWT token
+      token = JsonWebToken.encode( { user_id: user.id, username: user.name, email: user.email },
+      remember_me: remember_me )
 
       cookie_options = {
         value: token,
         httponly: true,
         secure: Rails.env.production?,
-        same_site: :strict # or :lax
+        same_site: :strict
       }
-      
+
       # Set cookie expiration
       cookie_options[:expires] = 2.weeks.from_now if remember_me
 
@@ -36,7 +37,7 @@ class Users::SessionsController < Devise::SessionsController
 
   # DELETE /resource/sign_out
   def destroy
-    super do |user|
+    super do
       # Remove the JWT token cookie
       cookies.delete(:cvt)
     end

--- a/app/helpers/api/v1/simulator_helper.rb
+++ b/app/helpers/api/v1/simulator_helper.rb
@@ -32,16 +32,16 @@ module Api::V1::SimulatorHelper
 
   private
 
-  def parse_scopes(scopes, saved_restricted_elements)
-    scopes.each_with_object([]) do |scope, new_scopes|
-      scope["restrictedCircuitElementsUsed"] = find_restricted_elements_used(scope, saved_restricted_elements)
-      new_scopes.push(scope)
+    def parse_scopes(scopes, saved_restricted_elements)
+      scopes.each_with_object([]) do |scope, new_scopes|
+        scope["restrictedCircuitElementsUsed"] = find_restricted_elements_used(scope, saved_restricted_elements)
+        new_scopes.push(scope)
+      end
     end
-  end
-
-  def find_restricted_elements_used(scope, saved_restricted_elements)
-    saved_restricted_elements.each_with_object([]) do |element, restricted_elements_used|
-      restricted_elements_used.push(element) if scope[element].present?
+  
+    def find_restricted_elements_used(scope, saved_restricted_elements)
+      saved_restricted_elements.each_with_object([]) do |element, restricted_elements_used|
+        restricted_elements_used.push(element) if scope[element].present?
+      end
     end
-  end
 end

--- a/app/helpers/api/v1/simulator_helper.rb
+++ b/app/helpers/api/v1/simulator_helper.rb
@@ -38,7 +38,7 @@ module Api::V1::SimulatorHelper
         new_scopes.push(scope)
       end
     end
-  
+
     def find_restricted_elements_used(scope, saved_restricted_elements)
       saved_restricted_elements.each_with_object([]) do |element, restricted_elements_used|
         restricted_elements_used.push(element) if scope[element].present?

--- a/app/helpers/api/v1/simulator_helper.rb
+++ b/app/helpers/api/v1/simulator_helper.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
+
 module Api::V1::SimulatorHelper
   def return_image_file(data_url)
-    str = data_url[("data:image/jpeg;base64,".length)..]
+    str = data_url[23..]
     if str.to_s.empty?
       path = Rails.public_path.join("images/default.png")
       image_file = File.open(path, "rb")
     else
       jpeg = Base64.decode64(str)
-      image_file = File.new("tmp/preview_#{Time.zone.now.to_f.to_s.sub(".", "")}.jpeg", "wb")
+      image_file = File.new("tmp/preview_#{Time.zone.now.to_f.to_s.sub('.', '')}.jpeg", "wb")
       image_file.write(jpeg)
     end
 
@@ -15,7 +16,7 @@ module Api::V1::SimulatorHelper
   end
 
   def check_to_delete(data_url)
-    !data_url[("data:image/jpeg;base64,".length)..].to_s.empty?
+    !data_url[23..].to_s.empty?
   end
 
   def sanitize_data(project, data)
@@ -25,18 +26,22 @@ module Api::V1::SimulatorHelper
     saved_restricted_elements = Oj.safe_load(project.assignment.restrictions)
     scopes = data["scopes"] || []
 
-    parsed_scopes = scopes.each_with_object([]) do |scope, new_scopes|
-      restricted_elements_used = []
+    data["scopes"] = parse_scopes(scopes, saved_restricted_elements)
+    data.to_json
+  end
 
-      saved_restricted_elements.each do |element|
-        restricted_elements_used.push(element) if scope[element].present?
-      end
+  private
 
-      scope["restrictedCircuitElementsUsed"] = restricted_elements_used
+  def parse_scopes(scopes, saved_restricted_elements)
+    scopes.each_with_object([]) do |scope, new_scopes|
+      scope["restrictedCircuitElementsUsed"] = find_restricted_elements_used(scope, saved_restricted_elements)
       new_scopes.push(scope)
     end
+  end
 
-    data["scopes"] = parsed_scopes
-    data.to_json
+  def find_restricted_elements_used(scope, saved_restricted_elements)
+    saved_restricted_elements.each_with_object([]) do |element, restricted_elements_used|
+      restricted_elements_used.push(element) if scope[element].present?
+    end
   end
 end

--- a/app/helpers/api/v1/simulator_helper.rb
+++ b/app/helpers/api/v1/simulator_helper.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+module Api::V1::SimulatorHelper
+  def return_image_file(data_url)
+    str = data_url[("data:image/jpeg;base64,".length)..]
+    if str.to_s.empty?
+      path = Rails.public_path.join("images/default.png")
+      image_file = File.open(path, "rb")
+    else
+      jpeg = Base64.decode64(str)
+      image_file = File.new("tmp/preview_#{Time.zone.now.to_f.to_s.sub(".", "")}.jpeg", "wb")
+      image_file.write(jpeg)
+    end
+
+    image_file
+  end
+
+  def check_to_delete(data_url)
+    !data_url[("data:image/jpeg;base64,".length)..].to_s.empty?
+  end
+
+  def sanitize_data(project, data)
+    return data if project&.assignment_id.blank? || data.blank?
+
+    data = Oj.safe_load(data)
+    saved_restricted_elements = Oj.safe_load(project.assignment.restrictions)
+    scopes = data["scopes"] || []
+
+    parsed_scopes = scopes.each_with_object([]) do |scope, new_scopes|
+      restricted_elements_used = []
+
+      saved_restricted_elements.each do |element|
+        restricted_elements_used.push(element) if scope[element].present?
+      end
+
+      scope["restrictedCircuitElementsUsed"] = restricted_elements_used
+      new_scopes.push(scope)
+    end
+
+    data["scopes"] = parsed_scopes
+    data.to_json
+  end
+end

--- a/app/lib/json_web_token.rb
+++ b/app/lib/json_web_token.rb
@@ -26,7 +26,7 @@ class JsonWebToken
   end
 
   def self.private_key
-    OpenSSL::PKey::RSA.new(File.open(Rails.root.join("config", "private.pem"), "r:UTF-8"))
+    OpenSSL::PKey::RSA.new(File.open(Rails.root.join("config", "private.pem"), "r:UTF-8"), "iammad")
   end
 
   def self.public_key

--- a/app/lib/json_web_token.rb
+++ b/app/lib/json_web_token.rb
@@ -26,7 +26,7 @@ class JsonWebToken
   end
 
   def self.private_key
-    OpenSSL::PKey::RSA.new(File.open(Rails.root.join("config", "private.pem"), "r:UTF-8"), "iammad")
+    OpenSSL::PKey::RSA.new(File.open(Rails.root.join("config", "private.pem"), "r:UTF-8"))
   end
 
   def self.public_key

--- a/app/lib/json_web_token.rb
+++ b/app/lib/json_web_token.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class JsonWebToken
-  def self.encode(payload)
-    payload.reverse_merge!(meta)
+  def self.encode(payload, remember_me: false)
+    payload.reverse_merge!(meta(remember_me))
     JWT.encode(payload, private_key, "RS256")
   end
 
@@ -11,10 +11,18 @@ class JsonWebToken
   end
 
   # Default options to be encoded in the token
-  def self.meta
+  def self.meta(remember_me)
     {
-      exp: 30.days.from_now.to_i
+      exp: expiration_time(remember_me).to_i
     }
+  end
+
+  def self.expiration_time(remember_me)
+    if remember_me
+      30.days.from_now
+    else
+      15.days.from_now
+    end
   end
 
   def self.private_key

--- a/app/lib/json_web_token.rb
+++ b/app/lib/json_web_token.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class JsonWebToken
-  def self.encode(payload, remember_me: false)
+  def self.encode(payload, remember_me: true)
     payload.reverse_merge!(meta(remember_me))
     JWT.encode(payload, private_key, "RS256")
   end
@@ -19,9 +19,9 @@ class JsonWebToken
 
   def self.expiration_time(remember_me)
     if remember_me
-      30.days.from_now
+      2.weeks.from_now
     else
-      15.days.from_now
+      1.day.from_now
     end
   end
 

--- a/app/strategies/jwt_token_strategy.rb
+++ b/app/strategies/jwt_token_strategy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class JwtTokenStrategy < Warden::Strategies::Base
   def valid?
     token.present?
@@ -17,18 +19,18 @@ class JwtTokenStrategy < Warden::Strategies::Base
 
   private
 
-  def token
-    authorization_header_token || cookie_token
-  end
+    def token
+      authorization_header_token || cookie_token
+    end
 
-  def authorization_header_token
-    pattern = /^Token /
-    header = env['HTTP_AUTHORIZATION']
-    header.gsub(pattern, '') if header&.match(pattern)
-  end
+    def authorization_header_token
+      pattern = /^Token /
+      header = env["HTTP_AUTHORIZATION"]
+      header.gsub(pattern, "") if header&.match(pattern)
+    end
 
-  def cookie_token
-    cvt_cookie = env['HTTP_COOKIE']&.split('; ')&.find { |c| c.start_with?('cvt=') }
-    cvt_cookie&.gsub('cvt=', '')
-  end
+    def cookie_token
+      cvt_cookie = env["HTTP_COOKIE"]&.split("; ")&.find { |c| c.start_with?("cvt=") }
+      cvt_cookie&.gsub("cvt=", "")
+    end
 end

--- a/app/strategies/jwt_token_strategy.rb
+++ b/app/strategies/jwt_token_strategy.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class JwtTokenStrategy < Warden::Strategies::Base
   def valid?
     token.present?
@@ -19,7 +17,18 @@ class JwtTokenStrategy < Warden::Strategies::Base
 
   private
 
-    def token
-      env["HTTP_AUTHORIZATION"].to_s.remove("Token ")
-    end
+  def token
+    authorization_header_token || cookie_token
+  end
+
+  def authorization_header_token
+    pattern = /^Token /
+    header = env['HTTP_AUTHORIZATION']
+    header.gsub(pattern, '') if header&.match(pattern)
+  end
+
+  def cookie_token
+    cvt_cookie = env['HTTP_COOKIE']&.split('; ')&.find { |c| c.start_with?('cvt=') }
+    cvt_cookie&.gsub('cvt=', '')
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -161,6 +161,8 @@ Rails.application.routes.draw do
       resources :simulator, only: %i[show] do
         collection do
           post "update", to: "simulator#update"
+          post "create_data", to: "simulator#create_data"
+          post "post_issue", to: "simulator#post_issue"
         end
         member do
           get "edit", to: "simulator#edit"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -160,13 +160,14 @@ Rails.application.routes.draw do
       patch "/notifications/mark_all_as_read", to: "notifications#mark_all_as_read"
       resources :simulator, only: %i[] do
         collection do
-          post "update", to: "simulator#update"
-          post "create_data", to: "simulator#create"
-          post "post_issue", to: "simulator#post_issue"
+          patch :update, path: "update"
+          post :create, path: "create"
+          post :post_issue, path: "post_issue"
+          post :verilogcv, path: "verilogcv"
         end
         member do
-          get "edit", to: "simulator#edit"
-          get "data", to: "simulator#data"
+          get :edit
+          get :data
         end
       end
       get "/me", to: "users#me"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -158,14 +158,15 @@ Rails.application.routes.draw do
       get "/notifications", to: "notifications#index"
       patch "/notifications/mark_as_read/:notification_id", to: "notifications#mark_as_read"
       patch "/notifications/mark_all_as_read", to: "notifications#mark_all_as_read"
-      resources :simulator, only: %i[show] do
+      resources :simulator, only: %i[] do
         collection do
           post "update", to: "simulator#update"
-          post "create_data", to: "simulator#create_data"
+          post "create_data", to: "simulator#create"
           post "post_issue", to: "simulator#post_issue"
         end
         member do
           get "edit", to: "simulator#edit"
+          get "data", to: "simulator#data"
         end
       end
       get "/me", to: "users#me"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -158,6 +158,14 @@ Rails.application.routes.draw do
       get "/notifications", to: "notifications#index"
       patch "/notifications/mark_as_read/:notification_id", to: "notifications#mark_as_read"
       patch "/notifications/mark_all_as_read", to: "notifications#mark_all_as_read"
+      resources :simulator, only: %i[show] do
+        collection do
+          post "update", to: "simulator#update"
+        end
+        member do
+          get "edit", to: "simulator#edit"
+        end
+      end
       get "/me", to: "users#me"
       post "/forgot_password", to: "users#forgot_password"
       resources :users, only: %i[index show update]

--- a/spec/requests/api/v1/simulator_controller/simulator_spec.rb
+++ b/spec/requests/api/v1/simulator_controller/simulator_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Simulators", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/api/v1/simulator_controller/simulator_spec.rb
+++ b/spec/requests/api/v1/simulator_controller/simulator_spec.rb
@@ -1,4 +1,6 @@
-require 'rails_helper'
+# frozen_string_literal: true
+
+require "rails_helper"
 
 RSpec.describe "Api::V1::Simulators", type: :request do
   describe "GET /index" do


### PR DESCRIPTION
Fixes #3778 

### Describe the changes you have made in this PR -

### creation of new api endpoints in api/v1 format

- GET api/v1/simulator/:id/edit
use: check project edit access and load simulator in edit mode accordingly
- GET api/v1/simulator/:id/data
use: get project circuit data only if project viewing access is there
- PATCH api/v1/simulator/update 
use: update circuit data for a project with edit access
- POST api/v1/simulator/create
use: create a new project with circuit data and provided name
- POST api/v1/simulator/post_issue
use: post user issues and send to slack (as per current implimentation)
- POST api/v1/simulator/verilogcv
use: send post request to yoyos server and get circuit data from verilog code

### configure jwt for CircuitVerse web to be used with vue simulator

- create and save jwt as cookie on:
   - [x] sign_up (1 day validity)
   - [x] sign_in (1 day validity if not remember me / if remember me then 2 weeks validity)
- destroy / delete saved cookie:
   - [x] sign_out ( all cases )
   - [x] browser close (when not remember me jwt gets deleted as session based cookie)

### TODO: (after review)

- [ ] spec for new apis
- [ ] documentation of new apis
- [ ] asked changes after review

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
