### PR TITLE
Fix CI issue of Docker Build in Test Environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ RUN gem install bundler
 RUN bundle install  --without production
 RUN yarn install
 
-# Remove CMAKE
 # copy source
 COPY . /circuitverse
 RUN yarn build

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ RUN curl -sL https://deb.nodesource.com/setup_14.x | bash \
  && apt-get update && apt-get install -y nodejs && rm -rf /var/lib/apt/lists/* \
  && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
  && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
- && apt-get update && apt-get install -y yarn && rm -rf /var/lib/apt/lists/*
+ && apt-get update && apt-get install -y yarn && rm -rf /var/lib/apt/lists/* \
+ && apt-get update && apt-get -y install cmake && rm -rf /var/lib/apt/lists/*
 
 COPY Gemfile /circuitverse/Gemfile
 COPY Gemfile.lock /circuitverse/Gemfile.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,6 @@ RUN bundle install  --without production
 RUN yarn install
 
 # Remove CMAKE
-RUN apt-get purge -y --auto-remove cmake
-
 # copy source
 COPY . /circuitverse
 RUN yarn build

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,9 @@ RUN gem install bundler
 RUN bundle install  --without production
 RUN yarn install
 
+# Remove CMAKE
+RUN apt-get purge -y --auto-remove cmake
+
 # copy source
 COPY . /circuitverse
 RUN yarn build

--- a/Gemfile
+++ b/Gemfile
@@ -135,7 +135,6 @@ group :development, :test do
   gem "rubocop-rspec", require: false
   gem "rbs_rails"
   gem "steep"
-  gem "undercover"
 end
 
 group :test do
@@ -148,6 +147,7 @@ group :test do
   gem "webmock"
   gem "simplecov"
   gem "simplecov-lcov"
+  gem "undercover"
   gem "undercover-checkstyle"
 end
 


### PR DESCRIPTION
#### Issue
After the recent merge of this PR #3816  , the CI checks failing to build Docker Image for test environment
undercover require rugged gem and rugged gem required `cmake` at installation time

#### Describe the changes you have made in this PR -
- Modified `Dockerfile` to install cmake and uninstall it after running `bundle install --without production`
- Move `undercover` from `development` group to `test`


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
