### PR TITLE
feat: Add RBS to CI

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -65,7 +65,9 @@ jobs:
           git fetch --no-tags
           reviewdog -reporter=github-pr-review -runners=undercover --fail-on-error
       - name: Static type checking
-        run: bundle exec steep check
+        run:  |
+          bundle exec rbs collection install
+          bundle exec steep check
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -64,6 +64,8 @@ jobs:
         run: |
           git fetch --no-tags
           reviewdog -reporter=github-pr-review -runners=undercover --fail-on-error
+      - name: Static type checking
+        run: bundle exec steep check
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/Steepfile
+++ b/Steepfile
@@ -2,7 +2,4 @@
 
 target :app do
   signature "sig"
-  meta_tags_path = Gem::Specification.find_by_name("meta-tags").gem_dir
-  rbs_files = Pathname.glob(File.join(meta_tags_path, "sig/**/*.rbs")).reject {|path| path.basename.to_s == "_rails.rbs" }
-  signature *rbs_files
 end

--- a/Steepfile
+++ b/Steepfile
@@ -2,4 +2,7 @@
 
 target :app do
   signature "sig"
+  meta_tags_path = Gem::Specification.find_by_name("meta-tags").gem_dir
+  rbs_files = Pathname.glob(File.join(meta_tags_path, "sig/**/*.rbs")).reject {|path| path.basename.to_s == "_rails.rbs" }
+  signature *rbs_files
 end

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -311,6 +311,14 @@ gems:
     revision: 87fba082504c606c03edf724cdf2e119bcd46c8c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
+- name: simplecov
+  version: '0.22'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 87fba082504c606c03edf724cdf2e119bcd46c8c
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: singleton
   version: '0'
   source:

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -2,7 +2,7 @@
 sources:
 - type: git
   name: ruby/gem_rbs_collection
-  revision: 80c41dad0190d5968841b8e892523e5031fa3eb1
+  revision: 87fba082504c606c03edf724cdf2e119bcd46c8c
   remote: https://github.com/ruby/gem_rbs_collection.git
   repo_dir: gems
 path: ".gem_rbs_collection"
@@ -12,7 +12,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 80c41dad0190d5968841b8e892523e5031fa3eb1
+    revision: 87fba082504c606c03edf724cdf2e119bcd46c8c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: actionpack
@@ -20,7 +20,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 80c41dad0190d5968841b8e892523e5031fa3eb1
+    revision: 87fba082504c606c03edf724cdf2e119bcd46c8c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: actionview
@@ -28,7 +28,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 80c41dad0190d5968841b8e892523e5031fa3eb1
+    revision: 87fba082504c606c03edf724cdf2e119bcd46c8c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activejob
@@ -36,7 +36,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 80c41dad0190d5968841b8e892523e5031fa3eb1
+    revision: 87fba082504c606c03edf724cdf2e119bcd46c8c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activemodel
@@ -44,7 +44,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 80c41dad0190d5968841b8e892523e5031fa3eb1
+    revision: 87fba082504c606c03edf724cdf2e119bcd46c8c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activerecord
@@ -52,7 +52,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 80c41dad0190d5968841b8e892523e5031fa3eb1
+    revision: 87fba082504c606c03edf724cdf2e119bcd46c8c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activestorage
@@ -60,7 +60,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 80c41dad0190d5968841b8e892523e5031fa3eb1
+    revision: 87fba082504c606c03edf724cdf2e119bcd46c8c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activesupport
@@ -68,7 +68,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 80c41dad0190d5968841b8e892523e5031fa3eb1
+    revision: 87fba082504c606c03edf724cdf2e119bcd46c8c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: ast
@@ -76,7 +76,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 80c41dad0190d5968841b8e892523e5031fa3eb1
+    revision: 87fba082504c606c03edf724cdf2e119bcd46c8c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: aws-sdk-core
@@ -84,7 +84,23 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 80c41dad0190d5968841b8e892523e5031fa3eb1
+    revision: 87fba082504c606c03edf724cdf2e119bcd46c8c
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: aws-sdk-kms
+  version: '1'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 87fba082504c606c03edf724cdf2e119bcd46c8c
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: aws-sdk-s3
+  version: '1'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 87fba082504c606c03edf724cdf2e119bcd46c8c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: aws-sdk-sqs
@@ -92,7 +108,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 80c41dad0190d5968841b8e892523e5031fa3eb1
+    revision: 87fba082504c606c03edf724cdf2e119bcd46c8c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: bcrypt
@@ -100,7 +116,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 80c41dad0190d5968841b8e892523e5031fa3eb1
+    revision: 87fba082504c606c03edf724cdf2e119bcd46c8c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: cgi
@@ -112,7 +128,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 80c41dad0190d5968841b8e892523e5031fa3eb1
+    revision: 87fba082504c606c03edf724cdf2e119bcd46c8c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: date
@@ -124,7 +140,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 80c41dad0190d5968841b8e892523e5031fa3eb1
+    revision: 87fba082504c606c03edf724cdf2e119bcd46c8c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: faraday
@@ -132,7 +148,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 80c41dad0190d5968841b8e892523e5031fa3eb1
+    revision: 87fba082504c606c03edf724cdf2e119bcd46c8c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: forwardable
@@ -144,7 +160,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 80c41dad0190d5968841b8e892523e5031fa3eb1
+    revision: 87fba082504c606c03edf724cdf2e119bcd46c8c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: hashie
@@ -152,7 +168,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 80c41dad0190d5968841b8e892523e5031fa3eb1
+    revision: 87fba082504c606c03edf724cdf2e119bcd46c8c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: i18n
@@ -160,7 +176,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 80c41dad0190d5968841b8e892523e5031fa3eb1
+    revision: 87fba082504c606c03edf724cdf2e119bcd46c8c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: io-console
@@ -176,7 +192,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 80c41dad0190d5968841b8e892523e5031fa3eb1
+    revision: 87fba082504c606c03edf724cdf2e119bcd46c8c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: kaminari-core
@@ -184,7 +200,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 80c41dad0190d5968841b8e892523e5031fa3eb1
+    revision: 87fba082504c606c03edf724cdf2e119bcd46c8c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: listen
@@ -192,7 +208,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 80c41dad0190d5968841b8e892523e5031fa3eb1
+    revision: 87fba082504c606c03edf724cdf2e119bcd46c8c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: logger
@@ -204,13 +220,9 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 80c41dad0190d5968841b8e892523e5031fa3eb1
+    revision: 87fba082504c606c03edf724cdf2e119bcd46c8c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
-- name: meta-tags
-  version: 2.16.0
-  source:
-    type: rubygems
 - name: minitest
   version: '0'
   source:
@@ -228,7 +240,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 80c41dad0190d5968841b8e892523e5031fa3eb1
+    revision: 87fba082504c606c03edf724cdf2e119bcd46c8c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: openssl
@@ -240,15 +252,19 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 80c41dad0190d5968841b8e892523e5031fa3eb1
+    revision: 87fba082504c606c03edf724cdf2e119bcd46c8c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
+- name: pathname
+  version: '0'
+  source:
+    type: stdlib
 - name: rack
   version: '2.2'
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 80c41dad0190d5968841b8e892523e5031fa3eb1
+    revision: 87fba082504c606c03edf724cdf2e119bcd46c8c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rails-dom-testing
@@ -256,7 +272,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 80c41dad0190d5968841b8e892523e5031fa3eb1
+    revision: 87fba082504c606c03edf724cdf2e119bcd46c8c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: railties
@@ -264,7 +280,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 80c41dad0190d5968841b8e892523e5031fa3eb1
+    revision: 87fba082504c606c03edf724cdf2e119bcd46c8c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rainbow
@@ -272,7 +288,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 80c41dad0190d5968841b8e892523e5031fa3eb1
+    revision: 87fba082504c606c03edf724cdf2e119bcd46c8c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rbs_rails
@@ -284,7 +300,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 80c41dad0190d5968841b8e892523e5031fa3eb1
+    revision: 87fba082504c606c03edf724cdf2e119bcd46c8c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: sidekiq
@@ -292,7 +308,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 80c41dad0190d5968841b8e892523e5031fa3eb1
+    revision: 87fba082504c606c03edf724cdf2e119bcd46c8c
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: singleton

--- a/rbs_collection.yaml
+++ b/rbs_collection.yaml
@@ -20,3 +20,5 @@ gems:
     ignore: true
   - name: steep
     ignore: true
+  - name: meta-tags
+    ignore: true

--- a/sig/vendor/meta_tags/_rails.rbs
+++ b/sig/vendor/meta_tags/_rails.rbs
@@ -1,0 +1,15 @@
+interface _ActionControllerBase
+  def render: (*untyped args) { () -> untyped } -> untyped
+end
+
+interface _ActionViewBase
+  def tag: (String name, ?Hash[String | Symbol, untyped] options, ?bool open) -> void
+
+  def content_tag: (String name, String content, ?Hash[String | Symbol, untyped] options, ?bool open) -> void
+
+  def safe_join: (Array[String], String) -> String
+
+  def truncate: (String text, ?Hash[Symbol, untyped] options) -> String
+
+  def strip_tags: (String html) -> String
+end

--- a/sig/vendor/meta_tags/meta_tags.rbs
+++ b/sig/vendor/meta_tags/meta_tags.rbs
@@ -1,0 +1,16 @@
+module MetaTags
+  def self.config: () -> Configuration
+  def self.configure: () { (Configuration) -> void } -> void
+
+  interface _Stringish
+    def to_str: () -> String
+  end
+
+  interface _Timish
+    def iso8601: () -> String
+  end
+
+  interface _MetaTagish
+    def to_meta_tags: () -> Hash[String | Symbol, untyped]
+  end
+end

--- a/sig/vendor/meta_tags/meta_tags/configuration.rbs
+++ b/sig/vendor/meta_tags/meta_tags/configuration.rbs
@@ -1,0 +1,19 @@
+module MetaTags
+  class Configuration
+    attr_accessor title_limit: Integer?
+    attr_accessor truncate_site_title_first: bool
+    attr_accessor description_limit: Integer
+    attr_accessor keywords_limit: Integer
+    attr_accessor keywords_separator: String
+    attr_accessor keywords_lowercase: bool
+    attr_accessor open_meta_tags: bool
+    attr_accessor minify_output: bool
+    attr_reader property_tags: Array[String | Symbol]
+    attr_accessor skip_canonical_links_on_noindex: bool
+
+    def initialize: () -> void
+    def default_property_tags: () -> Array[String | Symbol]
+    def open_meta_tags?: () -> bool
+    def reset_defaults!: () -> void
+  end
+end

--- a/sig/vendor/meta_tags/meta_tags/content_tag.rbs
+++ b/sig/vendor/meta_tags/meta_tags/content_tag.rbs
@@ -1,0 +1,5 @@
+module MetaTags
+  class ContentTag < Tag
+    def render: (_ActionViewBase view) -> untyped
+  end
+end

--- a/sig/vendor/meta_tags/meta_tags/controller_helper.rbs
+++ b/sig/vendor/meta_tags/meta_tags/controller_helper.rbs
@@ -1,0 +1,13 @@
+module MetaTags
+  module ControllerHelper : _ActionControllerBase
+    @page_title: String?
+    @page_description: String?
+    @page_keywords: String? | Array[String]
+
+    def render: (*untyped args) { () -> untyped } -> untyped
+
+    def set_meta_tags: (ViewHelper::meta_tags | (_MetaTagish & Object) meta_tags) -> void
+
+    def meta_tags: () -> MetaTagsCollection
+  end
+end

--- a/sig/vendor/meta_tags/meta_tags/meta_tags_collection.rbs
+++ b/sig/vendor/meta_tags/meta_tags/meta_tags_collection.rbs
@@ -1,0 +1,41 @@
+module MetaTags
+  class MetaTagsCollection
+    attr_reader meta_tags: Hash[String | Symbol, untyped]
+
+    def initialize: () -> void
+
+    def []: (String | Symbol name) -> untyped
+
+    def []=: (String | Symbol name, untyped value) -> untyped
+
+    def update: (?::Hash[String | Symbol, untyped] | (_MetaTagish & Object) object) -> Hash[String | Symbol, untyped]
+
+    def with_defaults: (?::Hash[String | Symbol, untyped] defaults) { () -> untyped } -> untyped
+
+    def full_title: (?::Hash[String | Symbol, untyped] defaults) -> String
+
+    def page_title: (?::Hash[String | Symbol, untyped] defaults) -> String
+
+    def extract: (String | Symbol name) -> untyped
+
+    def delete: (*String | Symbol names) -> void
+
+    def extract_full_title: () -> String
+
+    def extract_title: () -> Array[String | (_Stringish & Object)]
+
+    def extract_separator: () -> String
+
+    def extract_robots: () -> Hash[String, String]
+
+    def normalize_open_graph: (Hash[String | Symbol, untyped] meta_tags) -> Hash[String | Symbol, untyped]
+
+    def extract_separator_section: (String | Symbol name, String default) -> String
+
+    def extract_robots_attribute: (String | Symbol name) -> [String | Array[String | Symbol], String?]
+
+    def calculate_robots_attributes: (untyped result, untyped attributes) -> untyped
+
+    def apply_robots_value: (untyped result, untyped name, untyped value, untyped processed) -> (nil | untyped)
+  end
+end

--- a/sig/vendor/meta_tags/meta_tags/renderer.rbs
+++ b/sig/vendor/meta_tags/meta_tags/renderer.rbs
@@ -1,0 +1,50 @@
+module MetaTags
+  class Renderer
+    type meta_key = String | Symbol
+    type meta_value = Hash[meta_key, meta_value] | Array[meta_value] | meta_content
+    type meta_content = String? | Symbol | Integer | bool | (_Timish & Object) | (_Stringish & Object)
+
+    attr_reader meta_tags: MetaTagsCollection
+    attr_reader normalized_meta_tags: Hash[Symbol, meta_value]
+
+    def initialize: (MetaTagsCollection meta_tags) -> void
+
+    def render: (_ActionViewBase view) -> String
+
+    def render_charset: (Array[Tag] tags) -> void
+
+    def render_title: (Array[Tag] tags) -> void
+
+    def render_icon: (Array[Tag] tags) -> void
+
+    def render_with_normalization: (Array[Tag] tags, Symbol name) -> void
+
+    def render_noindex: (Array[Tag] tags) -> void
+
+    def render_refresh: (Array[Tag] tags) -> void
+
+    def render_alternate: (Array[Tag] tags) -> void
+
+    def render_open_search: (Array[Tag] tags) -> void
+
+    def render_links: (Array[Tag] tags) -> void
+
+    def render_canonical_link: (Array[Tag] tags) -> void
+
+    def render_hashes: (Array[Tag] tags, **untyped opts) -> void
+
+    def render_hash: (Array[Tag] tags, untyped key, **untyped opts) -> void
+
+    def render_custom: (Array[Tag] tags) -> void
+
+    def process_tree: (Array[Tag] tags, meta_key property, meta_value content, ?itemprop: meta_key? itemprop, **untyped opts) -> void
+
+    def process_hash: (Array[Tag] tags, meta_key property, Hash[meta_key, meta_value] content, **untyped opts) -> void
+
+    def process_array: (Array[Tag] tags, meta_key property, Array[meta_value] content, **untyped opts) -> void
+
+    def render_tag: (Array[Tag] tags, meta_key name, meta_content value, ?itemprop: meta_key? itemprop) -> void
+
+    def configured_name_key: (meta_key name) -> Symbol
+  end
+end

--- a/sig/vendor/meta_tags/meta_tags/tag.rbs
+++ b/sig/vendor/meta_tags/meta_tags/tag.rbs
@@ -1,0 +1,12 @@
+module MetaTags
+  class Tag
+    attr_reader name: String
+    attr_reader attributes: Hash[String | Symbol, untyped]
+
+    def initialize: (String | Symbol name, ?Hash[String | Symbol, untyped] attributes) -> void
+
+    def render: (_ActionViewBase view) -> void
+
+    def prepare_attributes: (Hash[String | Symbol, untyped] attributes) -> Hash[String | Symbol, untyped]
+  end
+end

--- a/sig/vendor/meta_tags/meta_tags/text_normalizer.rbs
+++ b/sig/vendor/meta_tags/meta_tags/text_normalizer.rbs
@@ -1,0 +1,36 @@
+module MetaTags
+  module TextNormalizer
+    extend ::MetaTags::TextNormalizer
+
+    type keyword = String? | (_Stringish & Object)
+    type keywords = keyword | Array[keywords]
+
+    def normalize_title: (String? site_title, keywords title, String separator, ?bool reverse) -> String
+
+    def normalize_description: (keyword description) -> String
+
+    def normalize_keywords: (keywords keywords) -> String
+
+    def helpers: () -> _ActionViewBase
+
+    def strip_tags: (String string) -> String
+
+    def safe_join: (Array[String] array, ?String sep) -> String
+
+    def cleanup_string: (keyword string, ?strip: bool strip) -> String
+
+    def cleanup_strings: (keywords? strings, ?strip: bool strip) -> Array[String]
+
+    def truncate: (String string, ?Integer limit, ?String natural_separator) -> String
+
+    def truncate_array: (Array[String] string_array, ?Integer? limit, ?String separator, ?String natural_separator) -> Array[String]
+
+    private
+
+    def calculate_limit_left: (Integer limit, Integer length, Array[String] result, String separator) -> untyped
+
+    def truncate_title: (String site_title, Array[String] title, String separator) -> ::Array[untyped]
+
+    def calculate_title_limits: (String site_title, Array[String] title, String separator, Integer global_limit) -> untyped
+  end
+end

--- a/sig/vendor/meta_tags/meta_tags/version.rbs
+++ b/sig/vendor/meta_tags/meta_tags/version.rbs
@@ -1,0 +1,4 @@
+module MetaTags
+  # Gem version.
+  VERSION: ::String
+end

--- a/sig/vendor/meta_tags/meta_tags/view_helper.rbs
+++ b/sig/vendor/meta_tags/meta_tags/view_helper.rbs
@@ -1,0 +1,55 @@
+module MetaTags
+  module ViewHelper : Module, _ActionViewBase
+    # type meta_tags = {
+    #     site: String?,
+    #     title: Array[String] | String?,
+    #     description: String?,
+    #     keywords: Array[String] | String?,
+    #     charset: String,
+    #     prefix: String,
+    #     separator: String,
+    #     suffix: String,
+    #     lowercase: bool,
+    #     reverse: bool,
+    #     noindex: bool | String | Array[String],
+    #     index: bool | String | Array[String],
+    #     nofollow: bool | String | Array[String],
+    #     follow: bool | String | Array[String],
+    #     noarchive: bool | String | Array[String],
+    #     canonical: String,
+    #     prev: String,
+    #     next: String,
+    #     image_src: String,
+    #     alternate: String,
+    #     amphtml: String,
+    #     manifest: String,
+    #     og: Hash[Renderer::meta_key, Renderer::meta_value],
+    #     twitter: Hash[Renderer::meta_key, Renderer::meta_value],
+    #     open_search: Hash[Renderer::meta_key, Renderer::meta_value],
+    #     article: Hash[Renderer::meta_key, Renderer::meta_value],
+    #     al: Hash[Renderer::meta_key, Renderer::meta_value],
+    #     refresh: Integer | String | nil,
+    #   } & Hash[Renderer::meta_key, Renderer::meta_value]
+    type meta_tags = Hash[Renderer::meta_key, Renderer::meta_value]
+
+    def meta_tags: () -> MetaTagsCollection
+
+    def set_meta_tags: (?meta_tags | (_MetaTagish&Object) meta_tags) -> void
+
+    def title: (?String? title, ?::String? headline) -> String
+
+    def keywords: (Array[String] | String? keywords) -> (Array[String] | String?)
+
+    def description: (String? description) -> String?
+
+    def noindex: (?String | Array[String] | bool noindex) -> (String | bool | Array[String])
+
+    def nofollow: (?String | Array[String] | bool nofollow) -> (String | bool | Array[String])
+
+    def refresh: (String? | Integer? refresh) -> (String? | Integer?)
+
+    def display_meta_tags: (?meta_tags defaults) -> String
+
+    def display_title: (?meta_tags defaults) -> String
+  end
+end


### PR DESCRIPTION
Fixes #3792

#### Describe the changes you have made in this PR -
- In rbs configuration, marked `meta-tags` to ignore, so that the rbs of meta-tags don't raise any issue
- In `sig/vendor`, added modified `rbs` of `meta-tags` gem to process it with `steep check`
- Added `steep check` in CI

For resolving the `RBS::DuplicatedMethodDefinitionError` issue for conflicting rbs definition , the maintainer of steep suggests to ignore `meta-tags` from rbs check and store modified `rbs` in sig folder for steep check.
Dicussion Thread - [ruby/rbs:1359](https://github.com/ruby/rbs/issues/1359)

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
