### PR TITLE
Fix small typos in function comments

### DIFF
--- a/simulator/src/combinationalAnalysis.js
+++ b/simulator/src/combinationalAnalysis.js
@@ -121,7 +121,7 @@ export function createCombinationalAnalysisPrompt(scope = globalScope) {
     $("#combinationalAnalysis").checkBo();
 }
 /**
- * This funciton hashes the output array and makes required JSON using
+ * This function hashes the output array and makes required JSON using
  * a BooleanMinimize class defined in Quin_Mcluskey.js var s which will
  * be output table is also initialied here
  * @param {Array} inputListNames - labels of input nodes

--- a/simulator/src/node.js
+++ b/simulator/src/node.js
@@ -221,7 +221,7 @@ export default class Node {
     }
 
     /**
-    * Funciton for saving a node
+    * Function for saving a node
     */
     saveObject() {
         if (this.type == 2) {

--- a/simulator/src/sequential/TTY.js
+++ b/simulator/src/sequential/TTY.js
@@ -50,7 +50,7 @@ export default class TTY extends CircuitElement {
 
     /**
      * @memberof TTY
-     * this funciton is used to change the size of the screen
+     * this function is used to change the size of the screen
      */
     changeRowSize(size) {
         if (size == undefined || size < 1 || size > 10) return;
@@ -63,7 +63,7 @@ export default class TTY extends CircuitElement {
 
     /**
      * @memberof TTY
-     * this funciton is used to change the size of the screen
+     * this function is used to change the size of the screen
      */
     changeColSize(size) {
         if (size == undefined || size < 20 || size > 100) return;


### PR DESCRIPTION
This commit fixes a few spelling mistakes.

Background: I'm doing a research study on function comments that may be incorrect. You can find more info and a short and optional anonymous survey [here](https://forms.office.com/e/yHv4PRXM2i).
 
Thanks for reviewing!
