### PR TITLE
fix: remove webdrivers as  selenium-webdriver v4.6+ dont require it

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -144,7 +144,6 @@ group :test do
   gem "rspec_junit_formatter"
   gem "selenium-webdriver"
   gem "shoulda-matchers"
-  gem "webdrivers", "~> 5.0", require: false
   gem "webmock"
   gem "simplecov"
   gem "simplecov-lcov"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -532,7 +532,7 @@ GEM
       railties (>= 5.2)
     reverse_markdown (2.1.1)
       nokogiri
-    rexml (3.2.5)
+    rexml (3.2.6)
     rsolr (2.2.1)
       builder (>= 2.1.2)
       faraday (>= 0.9.0)
@@ -612,7 +612,7 @@ GEM
       tilt
     securerandom (0.2.2)
     select2-rails (4.0.13)
-    selenium-webdriver (4.7.1)
+    selenium-webdriver (4.10.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -746,10 +746,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.0.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     webmock (3.14.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -879,7 +875,6 @@ DEPENDENCIES
   view_component
   vite_rails
   web-console (>= 3.3.0)
-  webdrivers (~> 5.0)
   webmock
   webpush
   will_paginate (~> 3.3.1)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,7 +8,6 @@ require File.expand_path("../config/environment", __dir__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require "rspec/rails"
 require "devise"
-require "webdrivers"
 
 # Including support files for tests
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }


### PR DESCRIPTION
#### Fixes #3926
#### Describe the changes you have made in this PR -
- In 4.6+ selenium-webdriver, webdrivers dont required, so removed it and upgraded selenium-webdriver. As this is suggested by `webdrivers` gem as well https://github.com/titusfortner/webdrivers/#update-selenium-manager
- With webdrivers is failing to resolve latest chrome release. More details can be found in this PR https://github.com/titusfortner/webdrivers/issues/247

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
