### PR TITLE
fix(typo-email): typo in email fix

### DIFF
--- a/config/locales/views/groups/en.yml
+++ b/config/locales/views/groups/en.yml
@@ -1,6 +1,6 @@
 en:
   groups:
-    add_member_description: "Enter Email IDs separated by commas/spaces or in separate lines. If users are not registered, an email ID will be sent requesting them to sign up."
+    add_member_description: "Enter Email IDs separated by commas/spaces or in separate lines. If users are not registered, an email will be sent requesting them to sign up."
     add_mentor_description_html: "<p>Mentors can:</p><ul><li>Create and delete assignments</li><li>Grade assignments</li><li>Reopen closed assignments</li></ul>"
     promote_member_confirmation: "Are you sure, you want to promote this member to a mentor?"
     demote_mentor_confirmation: "Are you sure, you want to demote this mentor to a member?"


### PR DESCRIPTION
Fixes #3968 

#### Describe the changes you have made in this PR -
I fix the typo and change to "email " instead of email ids
### Screenshots of the changes (If any) -



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
