### PR TITLE
chore: make maintenance tasks migrations safe

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,8 +42,6 @@ jobs:
       - name: Deploy with kamal
         run: |
           kamal lock release
-          kamal accessory boot yosys2digitaljs-server
-          kamal traefik boot
           kamal redeploy -vvvv --skip_push
         env:
           RAILS_SERVE_STATIC_FILES: true

--- a/db/migrate/20230825140325_change_cursor_to_string.maintenance_tasks.rb
+++ b/db/migrate/20230825140325_change_cursor_to_string.maintenance_tasks.rb
@@ -6,14 +6,18 @@ class ChangeCursorToString < ActiveRecord::Migration[6.0]
   # Ensure no Tasks are paused when this migration is deployed, or they will be resumed from the start.
   # Running tasks are able to gracefully handle this change, even if interrupted.
   def up
-    change_table(:maintenance_tasks_runs) do |t|
-      t.change(:cursor, :string)
-    end
+    safety_assured {
+      change_table(:maintenance_tasks_runs) do |t|
+        t.change(:cursor, :string)
+      end
+      }
   end
 
   def down
+    safety_assured {
     change_table(:maintenance_tasks_runs) do |t|
       t.change(:cursor, :bigint)
     end
+    }
   end
 end

--- a/db/migrate/20230825140326_remove_index_on_task_name.maintenance_tasks.rb
+++ b/db/migrate/20230825140326_remove_index_on_task_name.maintenance_tasks.rb
@@ -3,14 +3,18 @@
 # This migration comes from maintenance_tasks (originally 20210225152418)
 class RemoveIndexOnTaskName < ActiveRecord::Migration[6.0]
   def up
-    change_table(:maintenance_tasks_runs) do |t|
-      t.remove_index(:task_name)
-    end
+    safety_assured {
+      change_table(:maintenance_tasks_runs) do |t|
+        t.remove_index(:task_name)
+      end
+    }
   end
 
   def down
-    change_table(:maintenance_tasks_runs) do |t|
-      t.index(:task_name)
-    end
+   safety_assured {
+      change_table(:maintenance_tasks_runs) do |t|
+        t.index(:task_name)
+      end
+   }
   end
 end

--- a/db/migrate/20230825140329_change_runs_tick_columns_to_bigints.maintenance_tasks.rb
+++ b/db/migrate/20230825140329_change_runs_tick_columns_to_bigints.maintenance_tasks.rb
@@ -3,16 +3,20 @@
 # This migration comes from maintenance_tasks (originally 20220706101937)
 class ChangeRunsTickColumnsToBigints < ActiveRecord::Migration[6.0]
   def up
-    change_table(:maintenance_tasks_runs, bulk: true) do |t|
-      t.change(:tick_count, :bigint)
-      t.change(:tick_total, :bigint)
-    end
+    safety_assured {
+      change_table(:maintenance_tasks_runs, bulk: true) do |t|
+        t.change(:tick_count, :bigint)
+        t.change(:tick_total, :bigint)
+      end
+    }
   end
 
   def down
-    change_table(:maintenance_tasks_runs, bulk: true) do |t|
-      t.change(:tick_count, :integer)
-      t.change(:tick_total, :integer)
-    end
+   safety_assured {
+      change_table(:maintenance_tasks_runs, bulk: true) do |t|
+        t.change(:tick_count, :integer)
+        t.change(:tick_total, :integer)
+      end
+   }
   end
 end

--- a/db/migrate/20230825140330_add_index_on_task_name_and_status_to_runs.maintenance_tasks.rb
+++ b/db/migrate/20230825140330_add_index_on_task_name_and_status_to_runs.maintenance_tasks.rb
@@ -3,18 +3,20 @@
 # This migration comes from maintenance_tasks (originally 20220713131925)
 class AddIndexOnTaskNameAndStatusToRuns < ActiveRecord::Migration[6.0]
   def change
-    remove_index(
-      :maintenance_tasks_runs,
-      column: [:task_name, :created_at],
-      order: { created_at: :desc },
-      name: :index_maintenance_tasks_runs_on_task_name_and_created_at,
-    )
+    safety_assured {
+      remove_index(
+        :maintenance_tasks_runs,
+        column: [:task_name, :created_at],
+        order: { created_at: :desc },
+        name: :index_maintenance_tasks_runs_on_task_name_and_created_at,
+      )
 
-    add_index(
-      :maintenance_tasks_runs,
-      [:task_name, :status, :created_at],
-      name: :index_maintenance_tasks_runs,
-      order: { created_at: :desc },
-    )
+      add_index(
+        :maintenance_tasks_runs,
+        [:task_name, :status, :created_at],
+        name: :index_maintenance_tasks_runs,
+        order: { created_at: :desc },
+      )
+    }
   end
 end


### PR DESCRIPTION
#### Describe the changes you have made in this PR -

Marking potentially dangerous migrations introduced by [maintenance_tasks](https://github.com/Shopify/maintenance_tasks) as safe in to order to prevent exception thrown by [strong_migrations](https://github.com/ankane/strong_migrations) gem.


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
