### PR TITLE
fix(ui): fixed the overlap of follow us icons on hover

### DIFF
--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -13,9 +13,9 @@
 }
 
 .footer-column {
+  margin-bottom: 15px;
   padding-bottom: 15px;
   padding-top: 15px;
-  margin-bottom: 15px;
 }
 
 .footer-logo {

--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -15,6 +15,7 @@
 .footer-column {
   padding-bottom: 15px;
   padding-top: 15px;
+  margin-bottom: 15px;
 }
 
 .footer-logo {


### PR DESCRIPTION
Fixes #4093

#### Describe the changes you have made in this PR -
Fixed UI of footer section:  hovering on icons of follow us some part of the tooltip is going behind the copyright text.

### Screenshots of Change-
## Before
![Screenshot 2023-10-01 at 12 31 03 PM](https://github.com/CircuitVerse/CircuitVerse/assets/108923011/635b8ec2-0ae1-4401-9d23-a5eb27781680)


## After
![Screenshot 2023-10-01 at 12 32 46 PM](https://github.com/CircuitVerse/CircuitVerse/assets/108923011/91978b7b-66ee-48dd-9c02-1853e2e32944)

