### PR TITLE
fix(ui): fix social media tooltip z-index

### DIFF
--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -44,7 +44,7 @@
 .bounce-out-on-hover:active {
   transform: scale(.8);
   transition-timing-function: cubic-bezier(.47, 2.02, .31, -.36);
-  z-index:1;
+  z-index: 1;
 }
 
 .footer-links {

--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -44,6 +44,7 @@
 .bounce-out-on-hover:active {
   transform: scale(.8);
   transition-timing-function: cubic-bezier(.47, 2.02, .31, -.36);
+  z-index:1;
 }
 
 .footer-links {
@@ -102,7 +103,6 @@
   padding: .5rem;
   text-align: center;
   width: fit-content;
-
 }
 
 .bounce-out-on-hover:hover::before,

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -12,7 +12,7 @@
         <div class="row">
           <p class="mt-3 mb-0 footer-social-icon-text"><%= t("layout.footer.social_icon_text") %></p>
         </div>
-        <div class="row">
+        <div class="row mb-2" >
           <a class="bounce-out-on-hover" href="/facebook" target="_blank" data-tooltip="facebook"><%= image_tag("logos/facebook-logo.png", class: "footer-social-icon pt-2", alt: "Facebook Logo") %></a>
           <a class="bounce-out-on-hover" href="/twitter" target="_blank" data-tooltip="twitter"><%= image_tag("logos/twitter-x.png", class: "footer-social-icon pt-2", alt: "Twitter Logo") %></a>
           <a class="bounce-out-on-hover" href="/linkedin" target="_blank" data-tooltip="linkedin"><%= image_tag("logos/linkedin-logo.png", class: "footer-social-icon pt-2", alt: "LinkedIn Logo") %></a>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -12,7 +12,7 @@
         <div class="row">
           <p class="mt-3 mb-0 footer-social-icon-text"><%= t("layout.footer.social_icon_text") %></p>
         </div>
-        <div class="row mb-2" >
+        <div class="row mb-2">
           <a class="bounce-out-on-hover" href="/facebook" target="_blank" data-tooltip="facebook"><%= image_tag("logos/facebook-logo.png", class: "footer-social-icon pt-2", alt: "Facebook Logo") %></a>
           <a class="bounce-out-on-hover" href="/twitter" target="_blank" data-tooltip="twitter"><%= image_tag("logos/twitter-x.png", class: "footer-social-icon pt-2", alt: "Twitter Logo") %></a>
           <a class="bounce-out-on-hover" href="/linkedin" target="_blank" data-tooltip="linkedin"><%= image_tag("logos/linkedin-logo.png", class: "footer-social-icon pt-2", alt: "LinkedIn Logo") %></a>


### PR DESCRIPTION
Fixes #4093 

#### Describe the changes you have made in this PR -
*Added z-index to the tooltip so that they don't underlap with copyright as well as each other
*Added a small margin bottom to give space between socials and copyright text

### Screenshots of the changes (If any) -
![image](https://github.com/CircuitVerse/CircuitVerse/assets/114825004/ab5723b1-a6c5-4eaa-9b3a-bab2459a7d33)
![image](https://github.com/CircuitVerse/CircuitVerse/assets/114825004/f16682f3-00a6-4c0b-b141-f610439ea19e)




Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
