### PR TITLE
Fix: Blank 'Educational Institute' Field in User Profile.

### DIFF
--- a/app/controllers/users/circuitverse_controller.rb
+++ b/app/controllers/users/circuitverse_controller.rb
@@ -48,9 +48,9 @@ class Users::CircuitverseController < ApplicationController
     params.require(:user).permit(
       :name, :profile_picture, :country,
       :subscribed, :locale, :remove_picture, :avatar, :vuesim
-    ).tap do |whitelisted|
+    ).tap do | whitelisted |
       educational_institute = params[:user][:educational_institute].strip
-      whitelisted[:educational_institute] = educational_institute.present? ? educational_institute : "Not Entered"
+      whitelisted[:educational_institute] = educational_institute.present || "Not Entered"
     end
   end
 

--- a/app/controllers/users/circuitverse_controller.rb
+++ b/app/controllers/users/circuitverse_controller.rb
@@ -44,15 +44,12 @@ class Users::CircuitverseController < ApplicationController
 
   private
 
-  def profile_params
-    params.require(:user).permit(
-      :name, :profile_picture, :country,
-      :subscribed, :locale, :remove_picture, :avatar, :vuesim
-    ).tap do | whitelisted |
-      educational_institute = params[:user][:educational_institute].strip
-      whitelisted[:educational_institute] = educational_institute.present || "Not Entered"
+    def profile_params
+      params.require(: user).permit(: name,: profile_picture,: country,: subscribed,: locale,: remove_picture,: avatar,: vuesim).tap do |whitelisted|
+      educational_institute = params[: user][: educational_institute].strip
+      whitelisted[: educational_institute] = educational_institute.present || "Not Entered"
+      end
     end
-  end
 
     def set_user
       @profile = current_user

--- a/app/controllers/users/circuitverse_controller.rb
+++ b/app/controllers/users/circuitverse_controller.rb
@@ -44,13 +44,15 @@ class Users::CircuitverseController < ApplicationController
 
   private
 
-    def profile_params
-      params.require(: user).permit(: name,: profile_picture,: country,: subscribed,: locale,: remove_picture,: avatar,: vuesim).tap do |whitelisted|
-      educational_institute = params[: user][: educational_institute].strip
-      whitelisted[: educational_institute] = educational_institute.present || "Not Entered"
-      end
+  def profile_params
+    params.require(:user).permit(
+      :name, :profile_picture, :country, :subscribed, :locale, :remove_picture, :avatar, :vuesim
+    ).tap do |whitelisted|
+      educational_institute = params[:user][:educational_institute].strip
+      whitelisted[:educational_institute] = educational_institute.present? || "Not Entered"
     end
-
+  end
+  
     def set_user
       @profile = current_user
       @user = User.find(params[:id])

--- a/app/controllers/users/circuitverse_controller.rb
+++ b/app/controllers/users/circuitverse_controller.rb
@@ -44,10 +44,15 @@ class Users::CircuitverseController < ApplicationController
 
   private
 
-    def profile_params
-      params.require(:user).permit(:name, :profile_picture, :country, :educational_institute,
-                                   :subscribed, :locale, :remove_picture, :avatar, :vuesim)
+  def profile_params
+    params.require(:user).permit(
+      :name, :profile_picture, :country,
+      :subscribed, :locale, :remove_picture, :avatar, :vuesim
+    ).tap do |whitelisted|
+      educational_institute = params[:user][:educational_institute].strip
+      whitelisted[:educational_institute] = educational_institute.present? ? educational_institute : "Not Entered"
     end
+  end
 
     def set_user
       @profile = current_user

--- a/app/controllers/users/circuitverse_controller.rb
+++ b/app/controllers/users/circuitverse_controller.rb
@@ -44,14 +44,14 @@ class Users::CircuitverseController < ApplicationController
 
   private
 
-  def profile_params
-    params.require(:user).permit(
-      :name, :profile_picture, :country, :subscribed, :locale, :remove_picture, :avatar, :vuesim
-    ).tap do |whitelisted|
-      educational_institute = params[:user][:educational_institute].strip
-      whitelisted[:educational_institute] = educational_institute.present? || "Not Entered"
+    def profile_params
+      params.require(:user).permit(
+        :name, :profile_picture, :country, :subscribed, :locale, :remove_picture, :avatar, :vuesim
+      ).tap do |whitelisted|
+        educational_institute = params[:user][:educational_institute].strip
+        whitelisted[:educational_institute] = educational_institute.present? || "Not Entered"
+      end
     end
-  end
   
     def set_user
       @profile = current_user

--- a/app/controllers/users/circuitverse_controller.rb
+++ b/app/controllers/users/circuitverse_controller.rb
@@ -52,7 +52,7 @@ class Users::CircuitverseController < ApplicationController
         whitelisted[:educational_institute] = educational_institute.present? || "Not Entered"
       end
     end
-  
+
     def set_user
       @profile = current_user
       @user = User.find(params[:id])


### PR DESCRIPTION
Fixes #4104 

#### Describe the changes you have made in this PR -

The changes made involve the removal of `:educational_institute` from the list of permitted parameters in the `params.require(:user).permit(...)` section, and the addition of code within the tap block to handle the` :educational_institute `parameter separately. Specifically, it strips leading and trailing whitespace and sets it to "Not Entered" if it's blank or consists only of whitespace.

### Screenshots of the changes (If any) -

Note: It may take approximately 2-3 seconds to load. 

[screen-capture (4).webm](https://github.com/CircuitVerse/CircuitVerse/assets/77490034/96253bcb-df5f-4602-aab0-f4f8afb22696)


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
