### PR TITLE
fixed(ui) show  not-entered issue #4104

### DIFF
--- a/app/views/users/circuitverse/index.html.erb
+++ b/app/views/users/circuitverse/index.html.erb
@@ -41,7 +41,7 @@
         <h4 class="users-user-name"><%= @profile.name %></h4>
         <div class="search-userdetails-container">
           <p class="search-user-details-text"><%= t("users.circuitverse.member_since_html", member_since: @profile.member_since) %></p>
-          <p class="search-user-details-text"><%= t("users.circuitverse.educational_institutes_html", educational_institute: @profile.educational_institute) %></p>
+          <p class="search-user-details-text"><%= @profile.educational_institute.present? ? @profile.educational_institute : t("users.not_entered") %></p>
           <p class="search-user-details-text"><%= t("users.circuitverse.country_html", country_name: @profile.country_name) %></p>
           <% if policy(@user).edit? %>
             <a class="btn primary-button" href="<%= profile_edit_path(current_user) %>"><%= t("users.circuitverse.index.edit_details") %></a>

--- a/app/views/users/circuitverse/search.html.erb
+++ b/app/views/users/circuitverse/search.html.erb
@@ -21,7 +21,7 @@
         </div>
         <div class="col-xs-12 col-sm-12 col-md-7 col-lg-7 search-userdetails-container">
           <p class="search-user-details-text"><%= t("users.circuitverse.member_since_html", member_since: profile.member_since) %></p>
-          <p class="search-user-details-text"><%= t("users.circuitverse.educational_institutes_html", educational_institute: profile.educational_institute) %></p>
+          <p class="search-user-details-text"><%= t("users.circuitverse.educational_institutes_html", educational_institute: profile.educational_institute).presence || t("users.not_entered") %></p>
           <p class="search-user-details-text"><%= t("users.circuitverse.country_html", country_name: profile.country_name) %></p>
           <p class="search-user-details-text"><%= t("users.circuitverse.total_circuits_made_html", total_circuits: profile.total_circuits) %></p>
           <a class="btn primary-button search-user-primary-button" target="_blank" href="<%= user_path(profile) %>"><%= t("view") %></a>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,42 +24,44 @@ en:
   add_mentors: "Add mentors"
   remove: "Remove"
   reopen: "Reopen"
-  close : "Close"
+  close: "Close"
   not_available: "N.A."
-# Used in distance_of_time_in_words(), distance_of_time_in_words_to_now(), time_ago_in_words()
+  users:
+    not_entered: "Not entered"
+  # Used in distance_of_time_in_words(), distance_of_time_in_words_to_now(), time_ago_in_words()
   datetime:
     distance_in_words:
       half_a_minute: "half a minute"
       less_than_x_seconds:
-        one:   "1 second" # default was: "less than 1 second"
+        one: "1 second" # default was: "less than 1 second"
         other: "%{count} seconds" # default was: "less than %{count} seconds"
       x_seconds:
-        one:   "1 second"
+        one: "1 second"
         other: "%{count} seconds"
       less_than_x_minutes:
-        one:   "a minute" # default was: "less than a minute"
+        one: "a minute" # default was: "less than a minute"
         other: "%{count} minutes" # default was: "less than %{count} minutes"
       x_minutes:
-        one:   "1 minute"
+        one: "1 minute"
         other: "%{count} minutes"
       about_x_hours:
-        one:   "1 hour" # default was: "about 1 hour"
+        one: "1 hour" # default was: "about 1 hour"
         other: "%{count} hours" # default was: "about %{count} hours"
       x_days:
-        one:   "1 day"
+        one: "1 day"
         other: "%{count} days"
       about_x_months:
-        one:   "1 month" # default was: "about 1 month"
+        one: "1 month" # default was: "about 1 month"
         other: "%{count} months" # default was: "about %{count} months"
       x_months:
-        one:   "1 month"
+        one: "1 month"
         other: "%{count} months"
       about_x_years:
-        one:   "1 year" # default was: "about 1 year"
+        one: "1 year" # default was: "about 1 year"
         other: "%{count} years" # default was: "about %{count} years"
       over_x_years:
-        one:   "1 year" # default was: "over 1 year"
+        one: "1 year" # default was: "over 1 year"
         other: "%{count} years" # default was: "over %{count} years"
       almost_x_years:
-        one:   "1 year" # default was: "almost 1 year"
+        one: "1 year" # default was: "almost 1 year"
         other: "%{count} years" # default was: "almost %{count} years"


### PR DESCRIPTION
#4104 
I have Fixed the issue #4104 kindly review and merge the branch Thank you!

#Changes made in PR
Modified the code in the user profile view to conditionally display the educational institute information or "Not entered."
Used the translation key "users.circuitverse.educational_institutes_html" for the educational institute and the translation key "users.not_entered" for the "Not entered" message.
Added appropriate translation entries in the localization file (e.g., en.yml) to support these changes.


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
