### PR TITLE
fix: improve responsiveness of projects list page (#4108)

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -333,4 +333,7 @@
   &:hover {
     color: $white;
   }
+
+  max-width: 75%;
+  overflow: scroll;
 }

--- a/config/initializers/search_paginate_renderer.rb
+++ b/config/initializers/search_paginate_renderer.rb
@@ -1,7 +1,9 @@
 class SearchPaginateRenderer < WillPaginate::ActionView::LinkRenderer
 
   def container_attributes
-    super.except(*[:link_options])
+    attributes = super.except(*[:link_options])
+    attributes[:additional_class] = "pagination-cont"
+    return attributes
   end
 
   protected


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -
Fixed responsiveness by contolling width of search-tags and pagination in projects page and it would have solved the same problem on users page as well.

### Screenshots of the changes (If any) -



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
