### PR TITLE
fix: Improve projects responsiveness#4108

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -328,12 +328,11 @@
   border-radius: 4px;
   color: $white;
   font-weight: 500;
+  max-width: 75%;
+  overflow: scroll;
   padding: 5px;
 
   &:hover {
     color: $white;
   }
-
-  max-width: 75%;
-  overflow: scroll;
 }

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -333,4 +333,7 @@
   &:hover {
     color: $white;
   }
+
+  max-width: 75%;
+  overflow: scroll;
 }

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -329,7 +329,7 @@
   color: $white;
   font-weight: 500;
   max-width: 75%;
-  overflow: scroll;
+  overflow: auto;
   padding: 5px;
 
   &:hover {

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -157,7 +157,7 @@ body {
   .pagination {
     display: block;
     max-width: none;
-    overflow-x: visible;
+    overflow-x: scroll;
     padding: 0;
     white-space: nowrap;
   }

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -157,7 +157,7 @@ body {
   .pagination {
     display: block;
     max-width: none;
-    overflow-x: scroll;
+    overflow-x: auto;
     padding: 0;
     white-space: nowrap;
   }

--- a/config/initializers/search_paginate_renderer.rb
+++ b/config/initializers/search_paginate_renderer.rb
@@ -1,9 +1,7 @@
 class SearchPaginateRenderer < WillPaginate::ActionView::LinkRenderer
 
   def container_attributes
-    attributes = super.except(*[:link_options])
-    attributes[:additional_class] = "pagination-cont"
-    return attributes
+    super.except(*[:link_options])
   end
 
   protected

--- a/config/initializers/search_paginate_renderer.rb
+++ b/config/initializers/search_paginate_renderer.rb
@@ -1,7 +1,9 @@
 class SearchPaginateRenderer < WillPaginate::ActionView::LinkRenderer
 
   def container_attributes
-    super.except(*[:link_options])
+    attributes = super.except(*[:link_options])
+    attributes[:additional_class] = "pagination-cont"
+    return attributes
   end
 
   protected


### PR DESCRIPTION
Fixes #4108

#### Describe the changes you have made in this PR -
Fixed the responsiveness of projects list page by containing the width of search-tags of projects and pagination overflow to scroll as in home page
### Screenshots of the changes (If any) -

![image](https://github.com/CircuitVerse/CircuitVerse/assets/105278343/87fd2eea-4b3f-4034-8e6c-181d3bbde4bd)


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
