### PR TITLE
fix: alignment of name for searched profiles

### DIFF
--- a/app/views/users/circuitverse/search.html.erb
+++ b/app/views/users/circuitverse/search.html.erb
@@ -14,8 +14,10 @@
     <% @results.map { |user| ProfileDecorator.new(user) }.each do |profile| %>
       <div class="row center-row search-user-container">
         <div class="col-xs-12 col-sm-12 col-md-5 col-lg-5">
-          <%= image_tag user_profile_picture(profile.profile_picture), alt: "project.name", class: "center-row search-usersearch-image" %>
-          <p class=" center-row search-username"><%= profile.name %></p>
+          <div class="flex flex-col">
+            <%= image_tag user_profile_picture(profile.profile_picture), alt: "project.name", class: "center-row search-usersearch-image" %>
+            <p class=" center-row search-username"><%= profile.name %></p>
+          </div>
         </div>
         <div class="col-xs-12 col-sm-12 col-md-7 col-lg-7 search-userdetails-container">
           <p class="search-user-details-text"><%= t("users.circuitverse.member_since_html", member_since: profile.member_since) %></p>

--- a/app/views/users/circuitverse/search.html.erb
+++ b/app/views/users/circuitverse/search.html.erb
@@ -14,7 +14,7 @@
     <% @results.map { |user| ProfileDecorator.new(user) }.each do |profile| %>
       <div class="row center-row search-user-container">
         <div class="col-xs-12 col-sm-12 col-md-5 col-lg-5">
-          <div class="flex flex-col">
+          <div class="d-flex flex-column">
             <%= image_tag user_profile_picture(profile.profile_picture), alt: "project.name", class: "center-row search-usersearch-image" %>
             <p class=" center-row search-username"><%= profile.name %></p>
           </div>

--- a/app/views/users/circuitverse/search.html.erb
+++ b/app/views/users/circuitverse/search.html.erb
@@ -14,10 +14,8 @@
     <% @results.map { |user| ProfileDecorator.new(user) }.each do |profile| %>
       <div class="row center-row search-user-container">
         <div class="col-xs-12 col-sm-12 col-md-5 col-lg-5">
-          <div class="row center-row">
-            <%= image_tag user_profile_picture(profile.profile_picture), alt: "project.name", class: "center-row search-usersearch-image" %>
-            <p class=" center-row search-username"><%= profile.name %></p>
-          </div>
+          <%= image_tag user_profile_picture(profile.profile_picture), alt: "project.name", class: "center-row search-usersearch-image" %>
+          <p class=" center-row search-username"><%= profile.name %></p>
         </div>
         <div class="col-xs-12 col-sm-12 col-md-7 col-lg-7 search-userdetails-container">
           <p class="search-user-details-text"><%= t("users.circuitverse.member_since_html", member_since: profile.member_since) %></p>


### PR DESCRIPTION
Fixes #4142

#### Describe the changes you have made in this PR -

removed a div which wraps the user name and profile picture as a row

### Screenshots of the changes (If any) -

![Screenshot 2023-10-07 at 3 07 49 PM](https://github.com/CircuitVerse/CircuitVerse/assets/91966855/361aa358-1ad6-45e1-9055-4b30e43c3b20)
