### PR TITLE
fix(ui): social media icons alignment

### DIFF
--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -27,8 +27,11 @@
 }
 
 .footer-social-icon {
-  margin-left: 15px;
   width: 32px;
+} 
+
+.footer-social-icons-row {
+  margin: inherit;
 }
 
 .bounce-out-on-hover {
@@ -37,6 +40,7 @@
   transform: perspective(1px) translateZ(0);
   transition-duration: .5s;
   vertical-align: middle;
+  padding: 4px;
 }
 
 .bounce-out-on-hover:hover,

--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -28,7 +28,7 @@
 
 .footer-social-icon {
   width: 32px;
-} 
+}
 
 .footer-social-icons-row {
   margin: inherit;
@@ -37,10 +37,10 @@
 .bounce-out-on-hover {
   box-shadow: 0 0 1px $black;
   display: inline-block;
+  padding: 4px;
   transform: perspective(1px) translateZ(0);
   transition-duration: .5s;
   vertical-align: middle;
-  padding: 4px;
 }
 
 .bounce-out-on-hover:hover,

--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -31,7 +31,7 @@
 }
 
 .footer-social-icons-row {
-  gap: 5px;
+  column-gap: 5px;
   margin: inherit;
 }
 

--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -27,15 +27,15 @@
 }
 
 .footer-social-icon {
-  width: 32px;
+  width: 28px;
 }
 
 .footer-social-icons-row {
   margin: inherit;
+  gap: 5px;
 }
 
 .bounce-out-on-hover {
-  box-shadow: 0 0 1px $black;
   display: inline-block;
   padding: 4px;
   transform: perspective(1px) translateZ(0);

--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -31,8 +31,8 @@
 }
 
 .footer-social-icons-row {
-  margin: inherit;
   gap: 5px;
+  margin: inherit;
 }
 
 .bounce-out-on-hover {

--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -36,6 +36,7 @@
 }
 
 .bounce-out-on-hover {
+  box-shadow: 0 0 1px $black;
   display: inline-block;
   padding: 4px;
   transform: perspective(1px) translateZ(0);

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -12,12 +12,12 @@
         <div class="row">
           <p class="mt-3 mb-0 footer-social-icon-text"><%= t("layout.footer.social_icon_text") %></p>
         </div>
-        <div class="row">
-          <a class="bounce-out-on-hover" href="/facebook" target="_blank" data-tooltip="facebook"><%= image_tag("logos/facebook-logo.png", class: "footer-social-icon pt-2", alt: "Facebook Logo") %></a>
-          <a class="bounce-out-on-hover" href="/twitter" target="_blank" data-tooltip="twitter"><%= image_tag("logos/twitter-x.png", class: "footer-social-icon pt-2", alt: "Twitter Logo") %></a>
-          <a class="bounce-out-on-hover" href="/linkedin" target="_blank" data-tooltip="linkedin"><%= image_tag("logos/linkedin-logo.png", class: "footer-social-icon pt-2", alt: "LinkedIn Logo") %></a>
-          <a class="bounce-out-on-hover" href="/youtube" target="_blank" data-tooltip="youtube"><%= image_tag("logos/youtube-logo.png", class: "footer-social-icon pt-2", alt: "Youtube Logo") %></a>
-          <a class="bounce-out-on-hover" href="/github" target="_blank" data-tooltip="github"><%= image_tag("logos/github-logo-circle.png", class: "footer-social-icon pt-2", alt: "GitHub Logo") %></a>
+        <div class="row footer-social-icons-row">
+          <a class="bounce-out-on-hover" href="/facebook" target="_blank" data-tooltip="facebook"><%= image_tag("logos/facebook-logo.png", class: "footer-social-icon", alt: "Facebook Logo") %></a>
+          <a class="bounce-out-on-hover" href="/twitter" target="_blank" data-tooltip="twitter"><%= image_tag("logos/twitter-x.png", class: "footer-social-icon", alt: "Twitter Logo") %></a>
+          <a class="bounce-out-on-hover" href="/linkedin" target="_blank" data-tooltip="linkedin"><%= image_tag("logos/linkedin-logo.png", class: "footer-social-icon", alt: "LinkedIn Logo") %></a>
+          <a class="bounce-out-on-hover" href="/youtube" target="_blank" data-tooltip="youtube"><%= image_tag("logos/youtube-logo.png", class: "footer-social-icon", alt: "Youtube Logo") %></a>
+          <a class="bounce-out-on-hover" href="/github" target="_blank" data-tooltip="github"><%= image_tag("logos/github-logo-circle.png", class: "footer-social-icon", alt: "GitHub Logo") %></a>
         </div>
       </div>
       <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4 footer-column">


### PR DESCRIPTION
Fixes #2712 

#### Describe the changes you have made in this PR -
Before:
![image](https://github.com/CircuitVerse/CircuitVerse/assets/102225113/055e68e8-2651-4482-8ae4-6319c8cfcae0)
padding-top and margin-left property on the social-media-icons restricts it from being aligned.

After:
![image](https://github.com/CircuitVerse/CircuitVerse/assets/102225113/881d89cd-224d-4854-b3e7-09bdc60b0c63)
removed padding-top and margin-left property on the social-media-icons, added some margin to the container to align it, and lastly added padding to give some spacing to elements.


### Screenshots of the changes (If any) -



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
