### PR TITLE
The Social Media handles icons are positioned

### DIFF
--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -23,12 +23,13 @@
 }
 
 .footer-social-icon-text {
-  margin-left: 15px;
+  padding-bottom: 5px;
 }
 
 .footer-social-icon {
-  margin-left: 15px;
-  width: 32px;
+  // margin-left: 15px;
+  margin: 8px;
+  width: 25px;
 }
 
 .bounce-out-on-hover {


### PR DESCRIPTION
Fixes #4133 

#### Describe the changes you have made in this PR -
The social media handles in the footers tab of the home page are aligned correctly.

### Screenshots of the changes (If any) -
![image](https://github.com/CircuitVerse/CircuitVerse/assets/121747470/62f96493-e925-4204-9bb4-2243903c68f1)



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
