### PR TITLE
fix : #4178 redundant CSS classes

### DIFF
--- a/app/helpers/group_members_helper.rb
+++ b/app/helpers/group_members_helper.rb
@@ -2,7 +2,7 @@
 
 module GroupMembersHelper
   def membersCardViewerContainer(group)
-    policy(group).admin_access? ? "col-xs-12 col-sm-12 col-md-6 col-lg-4 groups-members-card-container" : "col-xs-12 col-sm-12 col-md-6 col-lg-3 groups-members-card-container"
+    policy(group).admin_access? ? "col-xs-12 col-md-6 col-lg-4 groups-members-card-container" : "col-xs-12 col-md-6 col-lg-3 groups-members-card-container"
   end
 
   def membersCardViewer(group)

--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -33,7 +33,7 @@
   <hr>
   <div class="container">
     <div class="row center-row">
-        <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+        <div class="col-xs-12 col-md-12">
           <h2 class="main-heading"><%= t("about.core_team_heading") %></h2>
           <p class="main-description"><%= t("about.core_team_description") %></p>
         </div>
@@ -53,7 +53,7 @@
   <hr>
   <div class="container">
     <div class="row center-row">
-        <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+        <div class="col-xs-12 col-md-12">
           <h2 class="main-heading"><%= t("about.mentors_team_heading") %></h2>
           <p class="main-description"><%= t("about.mentors_team_description") %></p>
         </div>
@@ -73,7 +73,7 @@
   <hr>
   <div class="container">
     <div class="row center-row">
-        <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+        <div class="col-xs-12 col-md-12">
           <h2 class="main-heading"><%= t("about.alumni_team_heading") %></h2>
           <p class="main-description"><%= t("about.alumni_team_description") %></p>
         </div>

--- a/app/views/assignments/edit.html.erb
+++ b/app/views/assignments/edit.html.erb
@@ -3,13 +3,13 @@
 
 <div class="container projects-new-container">
   <div class="row center-row">
-    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+    <div class="col-xs-12 col-md-12">
       <h1 class="submain-heading"><%= t("assignments.edit.edit_assignment") %></h1>
       <h2 class="submain-heading assignments-submain-heading"><%= t("assignments.group_name", name: @group.name) %></h2> <br>
     </div>
   </div>
   <div class="row">
-    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+    <div class="col-xs-12 col-md-12">
       <div class="form-container">
         <%= render "form", assignment: @assignment, group: @group %>
       </div>

--- a/app/views/assignments/new.html.erb
+++ b/app/views/assignments/new.html.erb
@@ -3,13 +3,13 @@
 
 <div class="container projects-new-container">
   <div class="row center-row">
-    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+    <div class="col-xs-12  col-md-12 ">
       <h1 class="submain-heading"><%= t("assignments.new.new_assignment_heading") %></h1>
       <h2 class="submain-heading assignments-submain-heading"><%= t("assignments.group_name", name: @group.name) %></h2> <br>
     </div>
   </div>
   <div class="row">
-    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+    <div class="col-xs-12 col-md-12">
       <div class="form-container">
         <%= render "form", assignment: @assignment, group: @group %>
       </div>

--- a/app/views/assignments/show.html.erb
+++ b/app/views/assignments/show.html.erb
@@ -11,13 +11,13 @@
   </div>
   <% end %>
   <div class="row center-row">
-    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+    <div class="col-xs-12  col-md-12 ">
       <h1 class="submain-heading"><%= t("assignments.show.assignment_details_heading") %></h1>
     </div>
   </div>
   <div class="assignments-container">
     <div class="row center-row">
-      <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+      <div class="col-xs-12  col-md-12 ">
         <div class="assignments-data">
           <p><%= t("assignments.assignment_data.name_html", name: @assignment.name) %></p>
           <p><%= t("assignments.assignment_data.group_html", group_name: @assignment.group.name) %></p>
@@ -80,7 +80,7 @@
             <% else %>
               <div class="assignments-submission">
                 <div class="row assignments-submission-row">
-                  <div class="col-xs-12 col-sm-12 col-md-3 col-lg-3 assignments-submission-col-3">
+                  <div class="col-xs-12 col-md-3  assignments-submission-col-3">
                     <div id="list-tab" role="tablist">
                       <ul class="list-group assignments-list-group">
                         <% @assignment.project_order.each do |project| %>
@@ -89,7 +89,7 @@
                       </ul>
                     </div>
                   </div>
-                  <div class="col-xs-12 col-sm-12 col-md-9 col-lg-9 assignments-iframe">
+                  <div class="col-xs-12 col-md-9 assignments-iframe">
                     <div class="embed-responsive embed-responsive-4by3 ">
                       <iframe src="" name="assignmentPreview" id="assignmentPreview" scrolling="no" webkitAllowFullScreen mozAllowFullScreen allowFullScreen> </iframe>
                     </div>
@@ -109,7 +109,7 @@
                     <%= form.hidden_field :project_id, id: "assignment-project-id" %>
                     <%= form.hidden_field :assignment_id, value: @assignment.id %>
                     <div class="row">
-                      <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4">
+                      <div class="col-xs-12  col-md-4 ">
                         <h6><%= t("assignments.assignment_data.grade") %></h6>
                         <% if @assignment.grading_scale == "percent" %>
                           <%= form.number_field :grade, id: "assignment-grade-grade", min: 0, max: 100, class: "form-control form-input" %>
@@ -117,17 +117,17 @@
                           <%= form.text_field :grade, id: "assignment-grade-grade", class: "form-control form-input" %>
                         <% end %>
                       </div>
-                      <div class="col-xs-12 col-sm-12 col-md-8 col-lg-8">
+                      <div class="col-xs-12  col-md-8 ">
                         <h6><%= t("assignments.assignment_data.remarks") %></h6>
                         <%= form.text_field :remarks, id: "assignment-grade-remarks", class: "form-control form-input" %>
                       </div>
                     </div>
                     <div class="row">
-                      <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4">
+                      <div class="col-xs-12  col-md-4 ">
                         <button name="button" type="submit" id="grade-form-submit" class="btn primary-button mt-4"><%= t("submit") %></button>
                         &nbsp; &nbsp;
                       </div>
-                      <div class="col-xs-12 col-sm-12 col-md-8 col-lg-8 assignments-grading-help">
+                      <div class="col-xs-12  col-md-8 assignments-grading-help">
                         <% if @assignment.grading_scale == "percent" %>
                           <small><%= t("assignments.assignment_data.grading_scale_percent") %></small>
                         <% elsif @assignment.grading_scale == "letter" || @assignment.grading_scale == "custom" %>
@@ -139,13 +139,13 @@
                 </div>
                 <div class="assignments-grading-container">
                   <div class="row">
-                    <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4">
+                    <div class="col-xs-12  col-md-4 ">
                       <h6><%= t("assignments.assignment_data.grade") %></h6>
                       <span id="project-grade"></span>
                       <br>
                       <div class="assignments-grade-horizontal-rule"></div>
                     </div>
-                    <div class="col-xs-12 col-sm-12 col-md-8 col-lg-8">
+                    <div class="col-xs-12 col-md-8 ">
                       <h6><%= t("assignments.assignment_data.remarks") %></h6>
                       <span id="project-remarks"></span>
                       <br>

--- a/app/views/circuitverse/contribute.html.erb
+++ b/app/views/circuitverse/contribute.html.erb
@@ -41,7 +41,7 @@
     </div>
   </div>
   <div class="row center-row">
-    <div class="card-spacing-media col-xs-12 col-sm-12 col-md-6 col-lg-4">
+    <div class="card-spacing-media col-xs-12  col-md-6 col-lg-4">
       <div class="card contribute-card">
         <%= image_tag "SVGs/student.svg", alt: "Student Icon", class: "card-img-top contribute-card-image" %>
         <div class="card-body contribute-card-body">
@@ -54,7 +54,7 @@
         </div>
       </div>
     </div>
-    <div class="card-spacing-media col-xs-12 col-sm-12 col-md-6 col-lg-4">
+    <div class="card-spacing-media col-xs-12  col-md-6 col-lg-4">
       <div class="card contribute-card">
       <%= image_tag "SVGs/professor.svg", alt: "Professor Icon", class: "card-img-top contribute-card-image" %>
         <div class="card-body contribute-card-body">
@@ -67,7 +67,7 @@
         </div>
       </div>
     </div>
-    <div class="card-spacing-media col-xs-12 col-sm-12 col-md-12 col-lg-4">
+    <div class="card-spacing-media col-xs-12  col-md-12 col-lg-4">
       <div class="card contribute-card">
        <%= image_tag "SVGs/coder.svg", alt: "Developer Icon", class: "card-img-top contribute-card-image" %>
         <div class="card-body contribute-card-body">

--- a/app/views/circuitverse/examples.html.erb
+++ b/app/views/circuitverse/examples.html.erb
@@ -1,14 +1,14 @@
 <% content_for :title, t("circuitverse.examples.title") %>
 <div class="container">
   <div class="row center-row">
-    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+    <div class="col-xs-12  col-md-12 col-lg-12">
       <h1 class="main-heading"><%= t("circuitverse.examples.main_heading") %></h1>
       <p class="main-description"><%= t("circuitverse.examples.main_description") %></p>
     </div>
   </div>
   <div class="row center-row examples-container">
     <% @examples.each do |example| %>
-      <div class="col-xs-12 col-sm-12 col-md-6 col-lg-4">
+      <div class="col-xs-12 col-md-6 col-lg-4">
         <div class="card circuit-card">
           <%= image_tag example[:img], alt: example[:name], class: "card-img-top circuit-card-image examples-circuit-card-image" %>
           <div class="card-footer circuit-card-footer">

--- a/app/views/circuitverse/index.html.erb
+++ b/app/views/circuitverse/index.html.erb
@@ -34,7 +34,7 @@
     <%= render "announcements/announcement" %>
     <div class="container">
       <div class="row center-row">
-        <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6">
+        <div class="col-xs-12 col-md-6 ">
           <div class="home-main-content">
             <h1><%= t("circuitverse.index.main_heading") %></h1><br>
             <p><%= t("circuitverse.index.main_description") %></p>
@@ -44,7 +44,7 @@
             </div>
           </div>
         </div>
-        <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6">
+        <div class="col-xs-12 col-md-6 ">
           <%= image_tag "homepage/new_homepage_sketch.png", alt: "HomepageSketch", class: "home-image-cover" %>
         </div>
       </div>
@@ -55,13 +55,13 @@
         </div>
       </div>
       <div id="home-features-section" class="row center-row">
-        <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+        <div class="col-xs-12 col-md-12 col-lg-12">
           <h3><%= t("circuitverse.index.features.main_heading") %></h3>
           <p><%= t("circuitverse.index.features.main_description") %></p>
         </div>
       </div>
       <div class="row center-row justify-content-center">
-        <div class="col-xs-12 col-sm-12 col-md-6 col-lg-4">
+        <div class="col-xs-12 col-md-6 col-lg-4">
           <div class="card home-feature-card">
             <%= image_tag "homepage/export-hd.png", alt: "Export HD", class: "card-img-top" %>
             <div class="card-body">
@@ -70,7 +70,7 @@
             </div>
           </div>
         </div>
-        <div class="col-xs-12 col-sm-12 col-md-6 col-lg-4">
+        <div class="col-xs-12 col-md-6 col-lg-4">
           <div class="card home-feature-card">
             <%= image_tag "homepage/combinations analysis.png", alt: "Combinational Analysis", class: "card-img-top" %>
             <div class="card-body">
@@ -88,7 +88,7 @@
             </div>
           </div>
         </div>
-        <div class="col-xs-12 col-sm-12 col-md-6 col-lg-4">
+        <div class="col-xs-12 col-md-6 col-lg-4">
           <div class="card home-feature-card">
             <%= image_tag "homepage/sub-circuit.png", alt: "Sub Circuit", class: "card-img-top" %>
             <div class="card-body">
@@ -97,7 +97,7 @@
             </div>
           </div>
         </div>
-        <div class="col-xs-12 col-sm-12 col-md-6 col-lg-4">
+        <div class="col-xs-12 col-md-6 col-lg-4">
           <div class="card home-feature-card">
             <%= image_tag "homepage/multi-bit-bus.png", alt: "Multi Bit Bus", class: "card-img-top" %>
             <div class="card-body">
@@ -110,13 +110,13 @@
     </div>
     <div class="container">
       <div class="row center-row home-circuit-card-row">
-        <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+        <div class="col-xs-12 col-md-12 col-lg-12">
           <h3><%= t("circuitverse.index.featured_examples.main_heading") %></h3>
           <p><%= t("circuitverse.index.featured_examples.main_description") %></p>
         </div>
       </div>
       <div class="row center-row justify-content-center">
-        <div class="col-xs-12 col-sm-12 col-md-6 col-lg-4">
+        <div class="col-xs-12 col-md-6 col-lg-4">
           <div class="card circuit-card">
             <%= image_tag "homepage/rippleCarry.jpg", alt: "Ripple Carry", class: "card-img-top circuit-card-image examples-circuit-card-image" %>
             <div class="card-footer circuit-card-footer">
@@ -128,7 +128,7 @@
             </div>
           </div>
         </div>
-        <div class="col-xs-12 col-sm-12 col-md-6 col-lg-4">
+        <div class="col-xs-12 col-md-6 col-lg-4">
           <div class="card circuit-card">
             <%= image_tag "homepage/sap.jpg", alt: "SAP-1", class: "card-img-top circuit-card-image examples-circuit-card-image" %>
             <div class="card-footer circuit-card-footer">
@@ -140,7 +140,7 @@
             </div>
           </div>
         </div>
-        <div class="col-xs-12 col-sm-12 col-md-6 col-lg-4">
+        <div class="col-xs-12 col-md-6 col-lg-4">
           <div class="card circuit-card">
             <%= image_tag "homepage/fullAdder.jpg", alt: "Full Adder", class: "card-img-top circuit-card-image examples-circuit-card-image", height: "180", width: "288" %>
             <div class="card-footer circuit-card-footer">
@@ -154,7 +154,7 @@
         </div>
       </div>
       <div class="row center-row">
-        <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+        <div class="col-xs-12 col-md-12 col-lg-12">
           <a class="btn primary-button homepage-primary-button-feature" href="/examples"><%= t("circuitverse.index.explore_more") %></a>
         </div>
       </div>
@@ -162,7 +162,7 @@
     <div class="container-fluid home-container-fluid">
       <div class="container">
         <div class="row center-row">
-          <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+          <div class="col-xs-12 col-md-12 col-lg-12">
             <h3><%= t("circuitverse.index.editor_picks.main_heading") %></h3>
             <p><%= t("circuitverse.index.editor_picks.main_description") %></p>
           </div>
@@ -170,7 +170,7 @@
         <% cache :featured_circuits, expires_in: 6.hours do %>
           <div class="row center-row justify-content-center">
             <% @featured_circuits.each do |circuit| %>
-              <div class="col-xs-12 col-sm-12 col-md-6 col-lg-4">
+              <div class="col-xs-12 col-md-6 col-lg-4">
                 <div class="card circuit-card">
                   <%= image_tag circuit.image_preview.url, alt: circuit.name, class: "card-img-top circuit-card-image", height: "180", width: "288" %>
                   <div class="card-footer circuit-card-footer">
@@ -186,7 +186,7 @@
           </div>
         <% end %>
         <div class="row center-row">
-            <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+            <div class="col-xs-12 col-md-12 col-lg-12">
               <a class="btn primary-button homepage-primary-button-feature" href="/featured_circuits"><%= t("circuitverse.index.explore_more") %></a>
             </div>
         </div>
@@ -195,14 +195,14 @@
     <% cache "recent-projects-#{params[:page]}", expires_in: 10.minutes do %>
       <div class="container" id="recent">
         <div class="row center-row home-circuit-card-row">
-          <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+          <div class="col-xs-12 col-md-12 col-lg-12">
             <h3><%= t("circuitverse.index.recent_circuits.main_heading") %></h3>
             <p><%= t("circuitverse.index.recent_circuits.main_description") %></p>
           </div>
         </div>
         <div class="row center-row justify-content-center">
           <% @projects.each do |project| %>
-            <div class="col-xs-12 col-sm-12 col-md-6 col-lg-4">
+            <div class="col-xs-12 col-md-6 col-lg-4">
               <div class="card circuit-card">
                 <%= image_tag project.image_preview.url, alt: project.name, class: "card-img-top circuit-card-image" %>
                 <div class="card-footer circuit-card-footer">

--- a/app/views/circuitverse/teachers.html.erb
+++ b/app/views/circuitverse/teachers.html.erb
@@ -12,11 +12,11 @@
 <div class="container-fluid teacher-fill-container-fluid">
   <div class="container">
     <div class="row center-row teacher-center-content">
-      <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 teacher-left-text">
+      <div class="col-xs-12 col-md-6 teacher-left-text">
         <h4><%= t("circuitverse.teachers.create_group_heading") %></h4> <br>
         <p><%= t("circuitverse.teachers.create_group_description") %></p>
       </div>
-      <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6">
+      <div class="col-xs-12 col-md-6">
         <img class="teacher-image" src="img/groups.png" alt="Groups screenshot">
       </div>
     </div>
@@ -25,11 +25,11 @@
 <div class="container-fluid teacher-container-fluid">
   <div class="container">
     <div class="row center-row teacher-center-content">
-      <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 teacher-left-text">
+      <div class="col-xs-12 col-md-6 teacher-left-text">
         <h4><%= t("circuitverse.teachers.post_assignment_heading") %></h4> <br>
         <p><%= t("circuitverse.teachers.post_assignment_description") %></p>
       </div>
-      <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6">
+      <div class="col-xs-12 col-md-6">
         <img class="teacher-image" src="img/assignment.png" alt="Assignments screenshot">
       </div>
     </div>
@@ -38,11 +38,11 @@
 <div class="container-fluid teacher-fill-container-fluid">
   <div class="container">
     <div class="row center-row teacher-center-content">
-      <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 teacher-left-text">
+      <div class="col-xs-12 col-md-6 teacher-left-text">
         <h4><%= t("circuitverse.teachers.grade_assignment_heading") %></h4> <br>
         <p><%= t("circuitverse.teachers.grade_assignment_description") %></p>
       </div>
-      <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6">
+      <div class="col-xs-12 col-md-6">
         <img class="teacher-image" src="img/grading.png" alt="Grading screenshot" height="250px">
       </div>
     </div>
@@ -51,11 +51,11 @@
 <div class="container-fluid teacher-container-fluid">
   <div class="container">
     <div class="row center-row teacher-center-content">
-      <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 teacher-left-text">
+      <div class="col-xs-12 col-md-6 teacher-left-text">
         <h4><%= t("circuitverse.teachers.use_interactive_circuit_heading") %></h4> <br>
         <p><%= t("circuitverse.teachers.use_interactive_circuit_description") %></p>
       </div>
-      <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6">
+      <div class="col-xs-12 col-md-6">
         <img class="teacher-image" src="img/embed.png" alt="Embed screenshot" height="350px">
       </div>
     </div>

--- a/app/views/commontator/shared/_thread.html.erb
+++ b/app/views/commontator/shared/_thread.html.erb
@@ -9,7 +9,7 @@
 %>
 <div class="container comments-container">
   <div class="row">
-    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+    <div class="col-xs-12 col-md-12 ">
       <% if !thread.nil? && thread.can_be_read_by?(user) %>
         <div id="commontator-thread-<%= thread.id %>" class="commontator thread">
           <% if @commontator_thread_show %>

--- a/app/views/featured_circuits/index.html.erb
+++ b/app/views/featured_circuits/index.html.erb
@@ -2,14 +2,14 @@
 
 <div class="container">
   <div class="row center-row">
-    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+    <div class="col-xs-12 col-md-12 ">
       <h1 class="main-heading"><%= t("featured_circuits.main_heading") %></h1>
       <p class="main-description"><%= t("featured_circuits.main_description") %></p>
     </div>
   </div>
   <div class="row center-row examples-container">
     <% @projects.each do |project| %>
-      <div class="col-xs-12 col-sm-12 col-md-6 col-lg-4">
+      <div class="col-xs-12 col-md-6 col-lg-4">
         <div class="card circuit-card">
           <%= image_tag project.image_preview.url, alt: project.name, class: "card-img-top circuit-card-image" %>
           <div class="card-footer circuit-card-footer">

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -7,10 +7,10 @@
     </div>
   </div>
   <div class="row center-row">
-    <div class="col-xs-12 col-sm-12 col-md-5 col-lg-6">
+    <div class="col-xs-12 col-md-5 col-lg-6">
       <%= image_tag "PNGs/editGroupName.png", alt: "Group Sketch", class: "groups-center-image center-image" %>
     </div>
-    <div class="col-xs-12 col-sm-12 col-md-7 col-lg-6">
+    <div class="col-xs-12 col-md-7 col-lg-6">
       <div class="container">
         <div class="center-row groups-background-card">
           <%= render "form", group: @group %>

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -8,14 +8,14 @@
     </div>
   </div>
   <div class="row center-row">
-    <div class="col-xs-12 col-sm-12 col-md-7 col-lg-6">
+    <div class="col-xs-12 col-md-7 col-lg-6">
       <div class="container">
         <div class="center-row groups-background-card">
           <%= render "form", group: @group %>
         </div>
       </div>
     </div>
-    <div class="col-xs-12 col-sm-12 col-md-5 col-lg-6">
+    <div class="col-xs-12 col-md-5 col-lg-6">
       <%= image_tag "PNGs/newGroup.png", alt: "New Group Sketch", class: "groups-center-image center-image" %>
     </div>
   </div>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -3,7 +3,7 @@
 <div class="container-fluid footer-container-fluid">
   <div class="container footer-container">
     <div class="row">
-      <div class="col-xs-12 col-sm-12 col-md-3 col-lg-3 footer-column">
+      <div class="col-xs-12 col-md-3 footer-column">
         <div class="row">
           <a href="/">
             <%= image_tag("CircuitVerse.png", class: "footer-logo", alt: "CircuitVerse Logo") %>
@@ -20,7 +20,7 @@
           <a class="bounce-out-on-hover" href="/github" target="_blank" data-tooltip="github"><%= image_tag("logos/github-logo-circle.png", class: "footer-social-icon pt-2", alt: "GitHub Logo") %></a>
         </div>
       </div>
-      <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4 footer-column">
+      <div class="col-xs-12 col-md-4 footer-column">
         <div class="row text-left">
           <div class="col-5 footer-links">
             <a href="/simulator"><h6><%= t("layout.link_to_simulator") %></h6></a>
@@ -44,7 +44,7 @@
           </div>
         </div>
       </div>
-      <div class="col-xs-12 col-sm-12 col-md-5 col-lg-5 footer-column">
+      <div class="col-xs-12 col-md-5 footer-column">
         <div class="row">
           <div class="col-6">
             <small class="text-left footer-sponsor-logo-text"><%= t("layout.footer.sponsor_logo_text.developed_by") %></small>

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -3,12 +3,12 @@
 
 <div class="container projects-new-container">
   <div class="row center-row">
-    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+    <div class="col-xs-12 col-md-12">
       <h1 class="submain-heading"><%= t("projects.edit.main_heading") %></h1> <br>
     </div>
   </div>
   <div class="row">
-    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+    <div class="col-xs-12 col-md-12 ">
       <div class="form-container">
         <%= render "form", project: @project %>
       </div>

--- a/app/views/projects/get_projects.html.erb
+++ b/app/views/projects/get_projects.html.erb
@@ -11,7 +11,7 @@
 <div class="container search-tag-search-container">
   <% @projects.each do |project| %>
     <div class="row center-row">
-      <div class="col-xs-12 col-sm-12 col-md-5 col-lg-5">
+      <div class="col-xs-12 col-md-5">
         <div class="row center-row">
           <%= image_tag project.image_preview.url, alt: "project.name", class: "search-image" %>
         </div>
@@ -32,7 +32,7 @@
           </div>
         </div>
       </div>
-      <div class="col-xs-12 col-sm-12 col-md-7 col-lg-7">
+      <div class="col-xs-12 col-md-7">
         <div class="row center-row">
           <div class="col-xs-8 col-sm-8 col-md-8 col-lg-8 search-project-detail-container">
             <div class="row center-row">
@@ -48,7 +48,7 @@
               </div>
             </div>
           </div>
-          <div class="col-xs-4 col-sm-4 col-md-4 col-lg-4 search-project-detail-container">
+          <div class="col-xs-4 col-md-4 search-project-detail-container">
             <a class="btn primary-button search-primary-button" target="_blank" href="<%= user_project_path(project.author, project) %>" role="button"><%= t("view") %></a>
           </div>
         </div>

--- a/app/views/projects/search.html.erb
+++ b/app/views/projects/search.html.erb
@@ -14,7 +14,7 @@
   <div class="container search-container">
     <% @results.each do |project| %>
       <div class="row center-row search-card-container">
-        <div class="col-xs-12 col-sm-12 col-md-5 col-lg-5">
+        <div class="col-xs-12 col-md-5">
           <div class="row center-row">
             <%= image_tag project.image_preview.url, alt: "project.name", class: "search-image" %>
           </div>
@@ -35,9 +35,9 @@
             </div>
           </div>
         </div>
-        <div class="col-xs-12 col-sm-12 col-md-7 col-lg-7">
+        <div class="col-xs-12 col-md-7 ">
           <div class="row center-row">
-            <div class="col-xs-8 col-sm-8 col-md-8 col-lg-8 search-project-detail-container">
+            <div class="col-xs-8 col-md-8  search-project-detail-container">
               <div class="row center-row">
                 <h3 class="search-project-name"><%= project.name %></h3>
               </div>
@@ -51,7 +51,7 @@
                 </div>
               </div>
             </div>
-            <div class="col-xs-4 col-sm-4 col-md-4 col-lg-4 search-project-detail-container">
+            <div class="col-xs-4 col-md-4  search-project-detail-container">
               <a class="btn primary-button search-primary-button" target="_blank" href="<%= user_project_path(project.author, project) %>" role="button"><%= t("view") %></a>
             </div>
           </div>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -27,17 +27,17 @@
   <% end %>
   <br>
   <div class="row center-row">
-    <div class="col-xs-12 col-sm-12 col-md-7 col-lg-7 ">
+    <div class="col-xs-12 col-md-7 ">
       <div class="projects-iframe-container">
         <div class="embed-responsive embed-responsive-4by3">
           <iframe src=<%= simulator_path(@project) %>></iframe>
         </div>
       </div>
     </div>
-    <div class="col-xs-12 col-sm-12 col-md-5 col-lg-5">
+    <div class="col-xs-12 col-md-5">
       <div class="container projects-details">
         <div class="row center-row projects-details-heading-container">
-          <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+          <div class="col-xs-12 col-md-12 col-lg-12">
             <div class="projects-details-heading">
               <%= @project.name %>
             </div>
@@ -155,10 +155,10 @@
   <% collaborators = @project.collaborators %>
     <% if collaborators.count!=0 %>
       <div class="row center-row">
-        <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+        <div class="col-xs-12 col-md-12 ">
           <div class="projects-collaborators-container">
             <div class="row center-row">
-              <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 projects-collaborators-heading">
+              <div class="col-xs-12 col-md-12  projects-collaborators-heading">
                 <div class="">
                   <%= t("projects.show.collaborators") %>
                 </div>
@@ -166,18 +166,18 @@
             </div>
             <% @project.collaborators.each do |user| %>
               <div class="row center-row">
-                <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4">
+                <div class="col-xs-12 col-md-4">
                   <div class="projectshow-collaborators-userdata">
                     <%= link_to user.name, user, class: "anchor-text" %>
                   </div>
                 </div>
                 <% if policy(@project).author_access? %>
-                  <div class="col-xs-8 col-sm-8 col-md-5 col-lg-5">
+                  <div class="col-xs-8 col-md-5">
                     <div class="projects-collaborators-data">
                       <%= user.email %>
                     </div>
                   </div>
-                  <div class="col-xs-4 col-sm-4 col-md-3 col-lg-3">
+                  <div class="col-xs-4 col-md-3">
                     <div class="projects-collaborators-button-container">
                       <%= link_to "#", data: { toggle: "modal", target: "#deletecollaborationModal", currentcollaboration: Collaboration.find_by(user_id: user.id, project_id: @project.id).id }, class: "btn primary-delete-button" do %>
                         <%= image_tag("SVGs/deleteGroup.svg", alt: "Delete Collaboration") %>

--- a/app/views/users/circuitverse/_dashboard.html.erb
+++ b/app/views/users/circuitverse/_dashboard.html.erb
@@ -1,6 +1,6 @@
 <% projects.each do |project| %>
   <% if policy(project).check_direct_view_access? %>
-    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-4 users-circuits-column circuit-card-js">
+    <div class="col-xs-12 col-md-6 col-lg-4 users-circuits-column circuit-card-js">
       <div class="card text-center users-card">
         <div class="card-header users-card-header">
           <div class="users-card-name">

--- a/app/views/users/circuitverse/edit.html.erb
+++ b/app/views/users/circuitverse/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="container projects-new-container">
   <div class="row center-row">
-    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+    <div class="col-xs-12 col-md-12">
       <h1 class="submain-heading"><%= t("users.circuitverse.edit_profile.heading") %></h1>
         <p class="main-description"><%= t("users.circuitverse.edit_profile.description_html") %></p> <br>
     </div>
@@ -46,7 +46,7 @@
           <%= link_to t("back"), :back, class: "anchor-text" %>
         <% end %>
         <div class="row">
-          <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+          <div class="col-xs-12 col-md-12">
             <h4 class="submain-heading"><%= t("users.circuitverse.edit_profile.delete_account_heading") %></h4>
             <p><%= t("users.circuitverse.edit_profile.delete_account_notice") %></p> <br>
           </div>

--- a/app/views/users/circuitverse/groups.html.erb
+++ b/app/views/users/circuitverse/groups.html.erb
@@ -24,7 +24,7 @@
     <h4 class="submain-heading"><%= t("users.circuitverse.groups.groups_user_owns") %></h4>
     <div class="row center-row">
       <% @groups_owned.each do |group| %>
-        <div class="col-xs-12 col-sm-12 col-md-6 col-lg-4">
+        <div class="col-xs-12 col-md-6 col-lg-4">
           <div class="groups-card groups-mentor-card">
             <div class="groups-mentor-card-name"><%= group.name %></div>
             <div>
@@ -54,7 +54,7 @@
     <h4 class="submain-heading"><%= t("users.circuitverse.groups.groups_user_belong_to") %></h4>
     <div class="row center-row">
       <% @user.groups.each do |group| %>
-        <div class="col-xs-12 col-sm-12 col-md-6 col-lg-4">
+        <div class="col-xs-12 col-md-6 col-lg-4">
           <div class="groups-card groups-member-card">
             <div class="groups-member-card-details">
               <div class="groups-mentor-card-name groups-member-card-name"><%= group.name %></div>

--- a/app/views/users/circuitverse/index.html.erb
+++ b/app/views/users/circuitverse/index.html.erb
@@ -32,12 +32,12 @@
   <% end %>
   <div class="row center-row users-details-container">
     <div class="row center-row">
-      <div class="col-xs-12 col-sm-12 col-md-5 col-lg-5">
+      <div class="col-xs-12 col-md-5">
         <div class="row center-row">
           <%= image_tag user_profile_picture(@profile.profile_picture), alt: "project.name", class: "center-row search-usersearch-image" %>
         </div>
       </div>
-      <div class="col-xs-12 col-sm-12 col-md-7 col-lg-7">
+      <div class="col-xs-12 col-md-7">
         <h4 class="users-user-name"><%= @profile.name %></h4>
         <div class="search-userdetails-container">
           <p class="search-user-details-text"><%= t("users.circuitverse.member_since_html", member_since: @profile.member_since) %></p>

--- a/app/views/users/circuitverse/search.html.erb
+++ b/app/views/users/circuitverse/search.html.erb
@@ -13,13 +13,13 @@
   <div class="container search-container">
     <% @results.map { |user| ProfileDecorator.new(user) }.each do |profile| %>
       <div class="row center-row search-user-container">
-        <div class="col-xs-12 col-sm-12 col-md-5 col-lg-5">
+        <div class="col-xs-12 col-md-5 ">
           <div class="row center-row">
             <%= image_tag user_profile_picture(profile.profile_picture), alt: "project.name", class: "center-row search-usersearch-image" %>
             <p class=" center-row search-username"><%= profile.name %></p>
           </div>
         </div>
-        <div class="col-xs-12 col-sm-12 col-md-7 col-lg-7 search-userdetails-container">
+        <div class="col-xs-12 col-md-7 search-userdetails-container">
           <p class="search-user-details-text"><%= t("users.circuitverse.member_since_html", member_since: profile.member_since) %></p>
           <p class="search-user-details-text"><%= t("users.circuitverse.educational_institutes_html", educational_institute: profile.educational_institute) %></p>
           <p class="search-user-details-text"><%= t("users.circuitverse.country_html", country_name: profile.country_name) %></p>

--- a/app/views/users/confirmations/new.html.erb
+++ b/app/views/users/confirmations/new.html.erb
@@ -1,10 +1,10 @@
 <div class="container">
   <div class="row">
-    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 center-image">
+    <div class="col-xs-12 col-md-6  center-image">
       <%= image_tag "SVGs/login.svg", alt: "Login Logo", class: "users-image" %>
       <h5 class="users-image-text"><%= t("welcome_back_text") %></h5>
     </div>
-    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6">
+    <div class="col-xs-12 col-md-6 ">
       <div class="users-form-container">
         <h2 class="users-main-heading"><%= t("users.confirmations.resend_confirmation_instructions") %></h2>
         <%= form_with(model: resource, as: resource_name, url: confirmation_path(resource_name), method: :post, local: true) do |f| %>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -1,11 +1,11 @@
 <div class="container">
   <div class="row">
-    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 center-image">
+    <div class="col-xs-12 col-md-6 center-image">
       <%= image_tag "SVGs/login.svg", alt: "Login Sketch", class: "users-image" %>
       <h5 class="users-image-text"><%= t("welcome_back_text") %></h5>
     </div>
 
-    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6">
+    <div class="col-xs-12 col-md-6">
       <div class="users-form-container">
         <h2 class="users-main-heading"><%= t("users.passwords.change_password_heading") %></h2>
         <%= form_with(model: resource, as: resource_name, url: password_path(resource_name), method: :put, local: true) do |f| %>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -1,11 +1,11 @@
 <div class="container">
   <div class="row">
-    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 center-image">
+    <div class="col-xs-12 col-md-6  center-image">
       <%= image_tag "SVGs/login.svg", alt: "Login Sketch", class: "users-image" %>
       <h5 class="users-image-text"><%= t("welcome_back_text") %></h5>
     </div>
 
-    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6">
+    <div class="col-xs-12 col-md-6 ">
       <div class="users-form-container">
         <h2 class="users-main-heading"><%= t("users.passwords.forgot_password_heading") %></h2>
         <%= form_with(model: resource, as: resource_name, url: password_path(resource_name), method: :post, local: true) do |f| %>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,11 +1,11 @@
 <div class="container">
   <div class="row">
-    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 center-image">
+    <div class="col-xs-12 col-md-6  center-image">
       <%= image_tag "SVGs/signup.svg", alt: "Signup Sketch", class: "users-image" %>
       <h5><%= t("users.registrations.get_started") %></h5>
     </div>
 
-    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6">
+    <div class="col-xs-12 col-md-6 ">
       <div class="form-container">
         <h1 class="users-main-heading"><%= t("sign_up") %></h1>
         <%= form_with(model: resource, as: resource_name, url: registration_path(resource_name), local: true) do |f| %>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,11 +1,11 @@
 <div class="container">
   <div class="row">
-    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 center-image">
+    <div class="col-xs-12 col-md-6 center-image">
       <%= image_tag "SVGs/login.svg", alt: "Login Sketch", class: "users-image" %>
       <h5><%= t("welcome_back_text") %></h5>
     </div>
 
-    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6">
+    <div class="col-xs-12 col-md-6">
       <div class="form-container">
         <h1 class="users-main-heading"><%= t("login") %></h1>
         <%= form_with(model: resource, as: resource_name, url: session_path(resource_name), local: true) do |f| %>

--- a/app/views/users/unlocks/new.html.erb
+++ b/app/views/users/unlocks/new.html.erb
@@ -1,10 +1,10 @@
 <div class="container">
   <div class="row">
-    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 center-image">
+    <div class="col-xs-12 col-md-6 center-image">
       <%= image_tag "SVGs/login.svg", alt: "Login Sketch", class: "users-image" %>
       <h5 class="users-image-text"><%= t("welcome_back_text") %></h5>
     </div>
-    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6">
+    <div class="col-xs-12 col-md-6">
       <div class="users-form-container">
         <h2 class="users-main-heading"><%= t("users.unlock.resend_unlock_instructions") %></h2>
         <%= form_with(model: resource, as: resource_name, url: unlock_path(resource_name), method: :post, local: true) do |f| %>


### PR DESCRIPTION
Throughout the whole project removed col-sm-12 and col-lg-x

Fixes #4178 

Removed -
1> if "col-xs-x col-sm-x" both present, removed the later one and the new code have only "col-xs-x"
2>Similarly for "col-md-x col-lg-x" converted to "col-md-x"

![image](https://github.com/CircuitVerse/CircuitVerse/assets/123815256/037dacf4-8087-40a8-bf8f-1f0c9e667cb3)
 
Additional:
> Removed the useless classes throughout whole project i.e. in all the .html files
