### PR TITLE
feat(navbar): hover, on hover it shows the options

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -168,3 +168,11 @@ body {
     margin-left: -4px;
   }
 }
+@media (min-width: 993px) {
+  .nav-item:hover .getStart {
+    display: block;
+  }
+}
+.dropdown-item {
+  display: block;
+}

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -20,14 +20,15 @@
         <a class="btn rounded-0 navbar-simulator-text" href="/simulator"><%= t("layout.link_to_simulator") %></a>
       </li>
       <div class="navbar-nav nav-item dropdown">
-        <li class="nav-item px-1">
-          <a class="nav-link dropdown-toggle navbar-item navbar-text" id="navbar-dropdown-1" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" tabindex="0" aria-label="getting started"><%= t("layout.getting_started_dropdown") %></a>
-          <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbar-dropdown-1">
-            <a class="dropdown-item" href="https://learn.circuitverse.org/" target="_blank"><%= t("layout.link_to_learn_more") %></a>
-            <a class="dropdown-item" href="https://docs.circuitverse.org/" target="_blank"><%= t("layout.link_to_docs") %></a>
-          </div>
-        </li>
-      </div>
+      <li class="nav-item px-1">
+        <a class="nav-link dropdown-toggle navbar-item navbar-text" id="navbar-dropdown-1" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" tabindex="0" aria-label="getting started"><%= t("layout.getting_started_dropdown") %></a>
+        <div class="dropdown-menu dropdown-menu-right getStart" aria-labelledby="navbar-dropdown-1">
+          <a class="dropdown-item" href="https://learn.circuitverse.org/" target="_blank"><%= t("layout.link_to_learn_more") %></a>
+          <a class="dropdown-item" href="https://docs.circuitverse.org/" target="_blank"><%= t("layout.link_to_docs") %></a>
+        </div>
+      </li>
+    </div>
+    
       <li class="nav-item px-1">
         <a class="nav-link navbar-item navbar-text <%= request.path == "/features" ? "active" : "" %>" href="/#home-features-section"><%= t("layout.link_to_features") %></a>
       </li>


### PR DESCRIPTION
Fixes #
Added a feature in Navbar When on hover it shows the options on hovering getting started  
Issue#
: Request for Hover-Based Dropdown in Navbar "Getting Started" Feature #4162
#### Describe the changes you have made in this PR -
i made changes in public assessts and stylsheet in layouts  and added a class for applying css in view folder in layouts and header 


### Screenshot
![Screenshot from 2023-10-16 23-14-06](https://github.com/CircuitVerse/CircuitVerse/assets/136692180/729a0be3-a2c2-4955-8718-5975969dabaa)
ts of the changes (If any) -



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
