### PR TITLE
Fix alignment of edit details button with parent

### DIFF
--- a/app/views/users/circuitverse/index.html.erb
+++ b/app/views/users/circuitverse/index.html.erb
@@ -56,7 +56,7 @@
             <% end %>
           </p>
           <% if policy(@user).edit? %>
-            <a class="btn primary-button" href="<%= profile_edit_path(current_user) %>"><%= t("users.circuitverse.index.edit_details") %></a>
+            <a class="btn primary-button ml-0" href="<%= profile_edit_path(current_user) %>"><%= t("users.circuitverse.index.edit_details") %></a>
           <% end %>
         </div>
       </div>


### PR DESCRIPTION
Fixes #4105 

#### Describe the changes you have made in this PR -
Remove unnecessary margin left with the help of bootstrap .
### Screenshots of the changes (If any) -

![277314289-f2bc592c-325d-4d2b-acd8-cfa8a59b36d6](https://github.com/CircuitVerse/CircuitVerse/assets/77102885/16975bc3-faaa-4248-a960-3aea2ab4887f)


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
