### PR TITLE
fix(login) Fix the placeholder in login/signup page #4206

### DIFF
--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -27,13 +27,13 @@
               <% end %>
             </h6>
             <div class="input-group">
-              <%= f.password_field :password, autofocus: true, autocomplete: "off", class:"form-control form-input" %>
+              <%= f.password_field :password, autofocus: true, autocomplete: "off", class:"form-control form-input", placeholder: "Enter Password" %>
             </div>
           </div>
           <div class="field form-group">
             <h6><%= f.label :password_confirmation %></h6>
             <div class="input-group">
-              <%= f.password_field :password_confirmation, autocomplete: "off", class:"form-control form-input" %>
+              <%= f.password_field :password_confirmation, autocomplete: "off", class:"form-control form-input", placeholder:"Enter Password" %>
             </div>
           </div>
           <div class="field form-group">

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -21,7 +21,7 @@
           <div class="field form-group">
             <h6><%= f.label :email %></h6>
             <div class="input-group">
-              <%= f.email_field :email, autofocus: true, class:"form-control form-input user-email-input" %>
+              <%= f.email_field :email, autofocus: true, class:"form-control form-input user-email-input", placeholder: "Enter Email" %>
             </div>
           </div>
           <div class="field form-group">

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -28,7 +28,7 @@
         <div class="field form-group">
           <h6><%= f.label :email %></h6>
           <div class="input-group">
-            <%= f.email_field :email, class:"form-control form-input" %>
+            <%= f.email_field :email, class:"form-control form-input", placeholder: "Enter Email" %>
           </div>
         </div>
         <div class="field form-group">
@@ -39,7 +39,7 @@
             <% end %>
           </h6>
         <div class="input-group form-input">
-          <%= f.password_field :password, autocomplete: "off" ,class:"form-control users-password-input" %>
+          <%= f.password_field :password, autocomplete: "off" ,class:"form-control users-password-input", placeholder: "Enter Password" %>
           <div class="input-group-addon ml-3 mt-2" onclick="togglePassword()">
             <i class="far fa-eye-slash password-icon" aria-hidden="true" id="toggle-icon"></i>
           </div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -15,13 +15,13 @@
         <div class="field form-group">
           <h6><%= f.label :email %></h6>
           <div class="input-group">
-            <%= f.email_field :email, autofocus: true, class:"form-control form-input user-email-input" %>
+            <%= f.email_field :email, autofocus: true, class:"form-control form-input user-email-input" , placeholder: "Enter Email" %>
           </div>
         </div>
         <div class="field form-group">
           <h6><%= f.label :password %></h6>
           <div class="input-group form-input">
-            <%= f.password_field :password, autocomplete: "off" ,class:"form-control users-password-input" %>
+            <%= f.password_field :password, autocomplete: "off" ,class:"form-control users-password-input" , placeholder: "Enter Password" %>
             <div class="input-group-addon ml-3 mt-2" onclick="togglePassword()">
               <i class="far fa-eye-slash password-icon" aria-hidden="true" id="toggle-icon"></i>
             </div>


### PR DESCRIPTION
Made the required changes in the login/signup pages to make the placeholder in the email and password container.

Fixes #4206 

#### Describe the changes you have made in this PR -
I added placeholder for email and password in the required container. 
### Screenshots of the changes (If any) -
![Screenshot (237)](https://github.com/CircuitVerse/CircuitVerse/assets/113010708/9542c5cd-e892-4ae8-9327-324be693ee95)



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
