### PR TITLE
fix: label duplication for next element

### DIFF
--- a/simulator/src/engine.js
+++ b/simulator/src/engine.js
@@ -500,6 +500,7 @@ export function update(scope = globalScope, updateEverything = false) {
     if (!embed && prevPropertyObjGet() !== simulationArea.lastSelected) {
         if (simulationArea.lastSelected && simulationArea.lastSelected.objectType !== 'Wire') {
             // ideas: why show properties of project in Nodes but not wires?
+            if(simulationArea.lastSelected.newElement) simulationArea.lastSelected.label = '';
             showProperties(simulationArea.lastSelected);
         } else {
             // hideProperties();

--- a/simulator/src/engine.js
+++ b/simulator/src/engine.js
@@ -500,7 +500,7 @@ export function update(scope = globalScope, updateEverything = false) {
     if (!embed && prevPropertyObjGet() !== simulationArea.lastSelected) {
         if (simulationArea.lastSelected && simulationArea.lastSelected.objectType !== 'Wire') {
             // ideas: why show properties of project in Nodes but not wires?
-            if(simulationArea.lastSelected.newElement) simulationArea.lastSelected.label = '';
+            if (simulationArea.lastSelected.newElement) simulationArea.lastSelected.label = '';
             showProperties(simulationArea.lastSelected);
         } else {
             // hideProperties();


### PR DESCRIPTION
Fixes #4217 

#### Describe the changes you have made in this PR -

I've added a check to ensure that if a new element's properties are being rendered, the "label" property is set to an empty string.

### Screenshots of the changes (If any) -

https://github.com/CircuitVerse/CircuitVerse/assets/91966855/d47273e0-7d6d-492f-a789-8c9e57f50fd9



