### PR TITLE
Remember alignment#4237

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -225,6 +225,14 @@
   text-align: left;
 }
 
+.status-container {
+  display:flex;flex-direction:row-reverse;justify-content:space-between;align-items:center;position:relative
+}
+
+.remember-status {
+  position:absolute;left:0px;bottom: -10px
+}
+
 .form-control {
 
   &:focus {

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -226,11 +226,17 @@
 }
 
 .status-container {
-  display:flex;flex-direction:row-reverse;justify-content:space-between;align-items:center;position:relative
+  display:flex;
+  flex-direction:row-reverse;
+  justify-content:space-between;
+  align-items:center;
+  position:relative;
 }
 
 .remember-status {
-  position:absolute;left:0px;bottom: -10px
+  position:absolute;
+  left:0px;
+  bottom: -10px;
 }
 
 .form-control {

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -226,17 +226,17 @@
 }
 
 .status-container {
-  display:flex;
-  flex-direction:row-reverse;
-  justify-content:space-between;
-  align-items:center;
-  position:relative;
+  display:flex; 
+  flex-direction:row-reverse; 
+  justify-content:space-between; 
+  align-items:center; 
+  position:relative; 
 }
 
 .remember-status {
-  position:absolute;
-  left:0px;
-  bottom: -10px;
+  position:absolute; 
+  bottom: -10px; 
+  left:0; 
 }
 
 .form-control {

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -27,21 +27,23 @@
             </div>
           </div>
         </div>
-        <div class="field form-group">
-          <div class="input-group">
-            <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-              <%= link_to t("users.sessions.forgot_password"), new_password_path(resource_name), class: "anchor-text users-forgot-password-text" %>
-            <% end -%>
-          </div>
-        </div>
-        <% if devise_mapping.rememberable? -%>
+        <div class="status-container">
           <div class="field form-group">
-            <label class="primary-checkpoint-container users-primary-checkpoint"><h6><%= t("users.sessions.remember_me") %></h6>
-              <%= f.check_box :remember_me %>
-              <div class="primary-checkpoint"></div>
-            </label>
+            <div class="input-group">
+              <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+                <%= link_to t("users.sessions.forgot_password"), new_password_path(resource_name), class: "anchor-text users-forgot-password-text" %>
+              <% end -%>
+            </div>
           </div>
-        <% end -%>
+          <% if devise_mapping.rememberable? -%>
+            <div class="field form-group remember-status">
+              <label class="primary-checkpoint-container users-primary-checkpoint"><h6><%= t("users.sessions.remember_me") %></h6>
+                <%= f.check_box :remember_me %>
+                <div class="primary-checkpoint"></div>
+              </label>
+            </div>
+          <% end -%>
+        </div>
         <div class="field form-group">
           <div class="input-group">
             <% if Flipper.enabled?(:recaptcha) %>


### PR DESCRIPTION
Fixes # 🐞 Bug : Alignment of Remember me and forget password is incorrect in login page. #4237

#### Describe the changes you have made in this PR -

1. Aligned "Remember Me" with "Forgot Password" for improved layout.
2. Added a new HTML element with custom CSS to create a responsive design that seamlessly integrates "Remember Me" with "Forgot Password."

### Screenshots of the changes (If any) -

### Before the changes remember me was not aligned with forget password which makes the UI not so appealing

![Screenshot 2023-11-02 182249](https://github.com/CircuitVerse/CircuitVerse/assets/77529419/f75e1883-0543-4b10-b29c-119a3b09ee73)

### After the changes remember me element was aligned with forget password with makes the UI appealing and it is also responsive

![Screenshot 2023-11-02 182216](https://github.com/CircuitVerse/CircuitVerse/assets/77529419/0d4d5218-187b-407c-b29d-963765ed9779)

### Working Demo

https://github.com/CircuitVerse/CircuitVerse/assets/77529419/5b774cee-52dd-47b5-9e7f-129fb3381485

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 