### PR TITLE
Fix(ui) : Notification Page Style broken in small Screen

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -492,7 +492,7 @@
 }
 
 .notification-container {
-  width: 558px;
+  max-width: 558px;
 }
 .notification-heading {
   font-size: 30px;


### PR DESCRIPTION
Fixes #4132 

#### Describe the changes you have made in this PR -
Fix the Notification Page to be responsive in the mobile view.
#### Video of Changes (without Notification) -

https://github.com/CircuitVerse/CircuitVerse/assets/77102885/84a819ab-d011-44b1-b084-7e1bab73f47c


#### Video of Changes (with Notification) -


https://github.com/CircuitVerse/CircuitVerse/assets/77102885/d6bda604-8ec4-4465-be76-8177cd3ab1d5


#### Screenshots of the changes -

#### Mobile -
![CV-PR-noti-width-mobile](https://github.com/CircuitVerse/CircuitVerse/assets/77102885/b1fc8328-ec2a-4dbd-b581-79ca1a0e2818)


#### Tablet -
![CV-PR-noti-width-tablet](https://github.com/CircuitVerse/CircuitVerse/assets/77102885/65aea259-f158-4ef7-9907-c828b09d40a8)

#### Laptop -
![CV-PR-noti-width-desktop](https://github.com/CircuitVerse/CircuitVerse/assets/77102885/3c37a7b7-2093-4b90-9bf9-79308be71c72)
Note - The overflow in height is caused by a fixed value, not by this specific pull request.

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
