### PR TITLE
fix(user-profile): add profile photo logic

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -27,7 +27,13 @@ class Api::V1::UsersController < Api::V1::BaseController
 
   # PATCH api/v1/users/:id
   def update
-    @user.update!(user_params)
+    @user = User.find(params[:id]) # Find the user to update
+
+    if params[:remove_picture] == "1"
+      # Logic to remove the profile picture
+      @user.profile_picture = nil
+    end
+
     if @user.update(user_params)
       render json: Api::V1::UserSerializer.new(@user, @options), status: :accepted
     else

--- a/app/controllers/users/circuitverse_controller.rb
+++ b/app/controllers/users/circuitverse_controller.rb
@@ -27,6 +27,11 @@ class Users::CircuitverseController < ApplicationController
   end
 
   def update
+    if params[:user][:remove_picture] == "1" && @profile.profile_picture.attached?
+      # Logic to remove the profile picture
+      @profile.profile_picture.purge
+    end
+
     if @profile.update(profile_params)
       redirect_to user_projects_path(current_user)
     else
@@ -45,8 +50,10 @@ class Users::CircuitverseController < ApplicationController
   private
 
     def profile_params
-      params.require(:user).permit(:name, :profile_picture, :country, :educational_institute,
-                                   :subscribed, :locale, :remove_picture, :avatar, :vuesim)
+      params.require(:user).permit(
+        :name, :country, :educational_institute, :subscribed, :locale, :avatar, :vuesim,
+        :profile_picture, :remove_picture # Include profile_picture and remove_picture in permitted parameters
+      )
     end
 
     def set_user


### PR DESCRIPTION
Fixes #

I added logic for profile photo removal before clicking update button. 



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
