### PR TITLE
fix: redirection to the recent circuit section

### DIFF
--- a/config/initializers/paginate_renderer.rb
+++ b/config/initializers/paginate_renderer.rb
@@ -6,9 +6,9 @@ class PaginateRenderer < WillPaginate::ActionView::LinkRenderer
   def page_number(page)
 
     if page == current_page
-     tag("li", link(page, page, class: 'page-link', rel: rel_value(page)), class: "page-item active")
+      tag("li", link(page, "/?page=#{page}#recent", class: 'page-link', rel: rel_value(page)), class: "page-item active")
     else
-      tag("li", link(page, "/?page=#{page}#recent", class: 'page-link', rel: rel_value(page)), class: "page-item ")
+      tag("li", link(page, "/?page=#{page}#recent", class: 'page-link', rel: rel_value(page)), class: "page-item")
     end
     # link(page, page, class: 'page-link', rel: rel_value(page))
   end
@@ -19,18 +19,18 @@ class PaginateRenderer < WillPaginate::ActionView::LinkRenderer
   end
 
   def previous_page
-    num = @collection.current_page > 1 && @collection.current_page - 1
+    num = @collection.current_page > 1 && (@collection.current_page - 1)
     previous_or_next_page(num, @options[:previous_label], 'page-link')
   end
 
   def next_page
-    num = @collection.current_page < total_pages && @collection.current_page + 1
+    num = @collection.current_page < total_pages && (@collection.current_page + 1)
     previous_or_next_page(num, @options[:next_label], 'page-link')
   end
 
   def previous_or_next_page(page, text, classname)
     if page
-      link(text, page, :class => classname)
+      link(text, "/?page=#{page}#recent", :class => classname)
     else
       tag(:span, text, :class => classname + ' bg-dark-blue near-white')
     end

--- a/config/initializers/paginate_renderer.rb
+++ b/config/initializers/paginate_renderer.rb
@@ -6,7 +6,7 @@ class PaginateRenderer < WillPaginate::ActionView::LinkRenderer
   def page_number(page)
 
     if page == current_page
-      tag("li", link(page, "/?page=#{page}#recent", class: 'page-link', rel: rel_value(page)), class: "page-item active")
+      tag("li", link(page, page, class: 'page-link', rel: rel_value(page)), class: "page-item active")
     else
       tag("li", link(page, "/?page=#{page}#recent", class: 'page-link', rel: rel_value(page)), class: "page-item")
     end

--- a/config/initializers/paginate_renderer.rb
+++ b/config/initializers/paginate_renderer.rb
@@ -19,12 +19,12 @@ class PaginateRenderer < WillPaginate::ActionView::LinkRenderer
   end
 
   def previous_page
-    num = @collection.current_page > 1 && (@collection.current_page - 1)
+    num = @collection.current_page > 1 && @collection.current_page - 1
     previous_or_next_page(num, @options[:previous_label], 'page-link')
   end
 
   def next_page
-    num = @collection.current_page < total_pages && (@collection.current_page + 1)
+    num = @collection.current_page < total_pages && @collection.current_page + 1
     previous_or_next_page(num, @options[:next_label], 'page-link')
   end
 


### PR DESCRIPTION
Fixes #4248

#### Describe the changes you have made in this PR -

1. For both the next and previous button the link has been changed to `"/?page=#{page}#recent"`
2. Fixed some minor syntax alignments

### Screenshots of the changes (If any) -

https://github.com/CircuitVerse/CircuitVerse/assets/91966855/0f399205-1404-4594-a2db-be639aa85caf
