### PR TITLE
Fix(#4303): Incorrect width of search tag badge

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -341,7 +341,6 @@
   border-radius: 4px;
   color: $white;
   font-weight: 500;
-  max-width: 75%;
   overflow: auto;
   padding: 5px;
 


### PR DESCRIPTION
Fixes #4303 

#### Describe the changes you have made in this PR -
Fix incorrect width of badge.
### Screenshot of the changes -

![CV-PR-incorrect-width-badge](https://github.com/CircuitVerse/CircuitVerse/assets/77102885/30cd1672-06e1-41b4-8dde-8050eeda967b)


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
