### PR TITLE
Modified-highlight-text #4332

### DIFF
--- a/app/assets/stylesheets/commontator/application.scss
+++ b/app/assets/stylesheets/commontator/application.scss
@@ -3,6 +3,16 @@
  *= require_self
  *= require_tree .
  */
+ ::-moz-selection {
+  background: #42b983;
+}
+::-webkit-selection {
+  background: #42b983;
+}
+::selection {
+  background: #42b983;
+}
+
 
 .commontator {
 


### PR DESCRIPTION
Modified stylesheet - application.scss so that the highlighted text matches the theme of the website

Fixes #4332 

#### Describe the changes you have made in this PR -
Modified stylesheet - application.scss so that the highlighted text matches the theme of the website
path of modified file - app/assets/stylesheets/commontator/application.scss
### Screenshots of the changes (If any) -

![contributess](https://github.com/CircuitVerse/CircuitVerse/assets/67982828/41bdf20c-4311-4345-9f07-e5d0dd20806c)


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
