### PR TITLE
fix: moved stylelint-config-standard-scss to dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "postcss-flexbugs-fixes": "^5.0.2",
     "postcss-import": "^15.1.0",
     "postcss-preset-env": "^8.4.2",
+    "stylelint-config-standard-scss": "^11.1.0",
     "vite": "^4.3.0",
     "vite-plugin-ruby": "^3.2.0"
   },
@@ -62,7 +63,6 @@
     "sass": "^1.53.0",
     "stimulus": "^3.2.1",
     "stylelint": "^15.11.0",
-    "stylelint-config-standard-scss": "^11.1.0",
     "trumbowyg": "^2.27.3",
     "turbolinks": "^5.2.0"
   },


### PR DESCRIPTION
Fixes Codeclimate check

#### Describe the changes you have made in this PR -

Moved stylelint-config-standard-scss to dev dependency
