### PR TITLE
Fix(#4330): Fix width in Add Collaborator modal

### DIFF
--- a/app/views/projects/_add_collaborator_modal.html.erb
+++ b/app/views/projects/_add_collaborator_modal.html.erb
@@ -21,7 +21,7 @@
         <div class="field">
           <%= form.hidden_field :project_id, id: :collaboration_project_id %>
         </div>
-        <div class="form-group">
+        <div class="form-group d-flex flex-column">
           <%= form.label :emails %>
           <%= form.select :emails, [], {}, { class: "form-select", multiple: true } %>
         </div>


### PR DESCRIPTION
Fixes #4330 

#### Describe the changes you have made in this PR -
Fixes incorrect email input field width in Add Collaborator modal

### Screenshot of the changes -

![CV-PR-collaborator-width](https://github.com/CircuitVerse/CircuitVerse/assets/77102885/9e9d1f55-e0bb-4799-861c-f6b14e629072)


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
