### PR TITLE
feat(dashboard): revamp the search input #3379

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -323,7 +323,8 @@
 
   input {
     border: 0;
-    border-left: 1px solid $form-border-grey;
+    // border-left: 1px solid $form-border-grey;
+    border: 1px solid #42b983;
     border-radius: 0;
     font-size: 16px;
     margin: 0;
@@ -331,7 +332,7 @@
     transition: .2s ease-in-out;
 
     &:focus {
-      border-color: $primary-green;
+      border-color: green;
       transition: .2s ease-in-out;
     }
   }
@@ -350,12 +351,14 @@
 }
 
 .users-circuits-search {
+  
   align-items: center;
   display: flex;
   flex-wrap: nowrap;
   justify-content: center;
   padding-top: 20px;
   width: 100%;
+  
 }
 
 .fa.fa-search.user-circuits-search-icon {

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -323,7 +323,7 @@
 
   input {
     border: 0;
-    border: 1px solid #42b983;
+    border: 1px solid $primary-green;
     border-radius: 0;
     font-size: 16px;
     margin: 0;
@@ -331,7 +331,7 @@
     transition: .2s ease-in-out;
 
     &:focus {
-      border-color: green;
+      border-color: $primary-green;
       transition: .2s ease-in-out;
     }
   }
@@ -350,14 +350,12 @@
 }
 
 .users-circuits-search {
-  
   align-items: center;
   display: flex;
   flex-wrap: nowrap;
   justify-content: center;
   padding-top: 20px;
   width: 100%;
-  
 }
 
 .fa.fa-search.user-circuits-search-icon {

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -323,7 +323,6 @@
 
   input {
     border: 0;
-    // border-left: 1px solid $form-border-grey;
     border: 1px solid #42b983;
     border-radius: 0;
     font-size: 16px;

--- a/app/views/users/circuitverse/index.html.erb
+++ b/app/views/users/circuitverse/index.html.erb
@@ -70,7 +70,7 @@
         <button id="collaborator-circuits" class="btn users-circuits-tab users-collaborators-tab"><%= t("users.circuitverse.index.collaborated_circuits") %></button>
       </div>
       <div class="users-circuits-search-container">
-      <span><i class="fas fa-search search-icon-dashboard"></i><input type="search" class="users-circuits-search" placeholder="<%= t("users.circuitverse.index.search_circuits") %>"></span>
+      <span><i class="fas fa-search search-icon-dashboard"></i><input type="search" class="users-circuits-search form-control form-input " placeholder="<%= t("users.circuitverse.index.search_circuits") %>"></span>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Fixes #
This pull request addresses the "Revamp: Search Input in Dashboard #3379" issue in CircuitVerse. 

#### Describe the changes you have made in this PR -
It aims to improve the search input appearance in the dashboard making it look more appealing by modifying some css code and adding the class 'form-control' and  'form-input' .  

### Screenshots of the changes (If any) -
A) When Input tag is not clicked and selected 
Before :
<img width="904" alt="image" src="https://github.com/CircuitVerse/CircuitVerse/assets/104618576/a846ba02-6c0c-4dee-ad6b-c4b64958f3fa">

After:
<img width="874" alt="image" src="https://github.com/CircuitVerse/CircuitVerse/assets/104618576/2e755751-314e-4c82-a167-5051490081d0">

B)A) When Input tag is  clicked and selected 
Before: It shows plain black color which clearly does not matches with the website theme .
<img width="905" alt="image" src="https://github.com/CircuitVerse/CircuitVerse/assets/104618576/5aaf7ef6-6575-466a-9de2-e8f69c6b0fc7">
After:
<img width="891" alt="image" src="https://github.com/CircuitVerse/CircuitVerse/assets/104618576/2a31986d-a4dc-47d3-a235-a0048cdb8523">



