### PR TITLE
feat: vue simulator integrate in docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,23 @@ services:
       NODE_ENV: "development"
       HOST_CURRENT_DIRECTORY: $PWD
       OPERATING_SYSTEM: $OPERATING_SYSTEM
+      REBUILD_VUE: "true"
+    restart: unless-stopped
+  vue_simulator:
+    <<: *common_build
+    command: 
+      - bash
+      - -c
+      - |
+        bin/docker/wait_for_setup && \
+        cd cv-frontend-vue && \
+        npm i && \
+        npm run dev:expose
+    ports:
+      - "4000:4000"
+    environment:
+      NODE_ENV: "development"
+      VITE_PROXY_URL: "http://web:3000"
     restart: unless-stopped
   sidekiq:
     <<: *common_build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       NODE_ENV: "development"
       HOST_CURRENT_DIRECTORY: $PWD
       OPERATING_SYSTEM: $OPERATING_SYSTEM
-      REBUILD_VUE: "true"
+      REBUILD_VUE: "false"
     restart: unless-stopped
   vue_simulator:
     <<: *common_build

--- a/installation_docs/docker.md
+++ b/installation_docs/docker.md
@@ -24,7 +24,7 @@
 6. Wait for the docker container to be prepared
 7. Navigate to `http://localhost:3000` in your browser
 8. For Vue-based simulator, navigate to `http://localhost:4000/simulatorvue` in your browser
-    > 🔴 **NOTE:** If you access new simulator with port 3000, you can't see changes in the website quickly. Instead, use port 4000, `http://localhost:4000/simulatorvue`
+    > 🔴 **NOTE:** If you access new simulator with port 3000, you can't see any changes on the website. Instead, use port 4000, `http://localhost:4000/simulatorvue`
 
 
 If you required to restart the server
@@ -61,7 +61,7 @@ Set-ExecutionPolicy RemoteSigned
 5. Run `./bin/docker_run`
 7. Navigate to `http://localhost:3000` in your browser
 8. For Vue-based simulator, navigate to `http://localhost:4000/simulatorvue` in your browser
-    > 🔴 **NOTE:** If you access new simulator with port 3000, you can't see changes in the website quickly. Instead, use port 4000, `http://localhost:4000/simulatorvue`
+    > 🔴 **NOTE:** If you access new simulator with port 3000, you can't see any changes on the website. Instead, use port 4000, `http://localhost:4000/simulatorvue`
 
 
 If you required to restart the server
@@ -89,7 +89,7 @@ If you required to restart the server
 5. Run `./bin/docker_run`
 7. Navigate to `http://localhost:3000` in your browser
 8. For Vue-based simulator, navigate to `http://localhost:4000/simulatorvue` in your browser
-    > 🔴 **NOTE:** If you access new simulator with port 3000, you can't see changes in the website quickly. Instead, use port 4000, `http://localhost:4000/simulatorvue`
+    > 🔴 **NOTE:** If you access new simulator with port 3000, you can't see any changes on the website. Instead, use port 4000, `http://localhost:4000/simulatorvue`
 
 
 If you required to restart the server

--- a/installation_docs/docker.md
+++ b/installation_docs/docker.md
@@ -24,7 +24,7 @@
 6. Wait for the docker container to be prepared
 7. Navigate to `http://localhost:3000` in your browser
 8. For Vue-based simulator, navigate to `http://localhost:4000/simulatorvue` in your browser
-    > 🔴 **NOTE:** If you access new simulator with port 3000, you can't see changes in website quickly. Instead use port 4000, `http://localhost:4000/simulatorvue`
+    > 🔴 **NOTE:** If you access new simulator with port 3000, you can't see changes in the website quickly. Instead, use port 4000, `http://localhost:4000/simulatorvue`
 
 
 If you required to restart the server
@@ -61,7 +61,7 @@ Set-ExecutionPolicy RemoteSigned
 5. Run `./bin/docker_run`
 7. Navigate to `http://localhost:3000` in your browser
 8. For Vue-based simulator, navigate to `http://localhost:4000/simulatorvue` in your browser
-    > 🔴 **NOTE:** If you access new simulator with port 3000, you can't see changes in website quickly. Instead use port 4000, `http://localhost:4000/simulatorvue`
+    > 🔴 **NOTE:** If you access new simulator with port 3000, you can't see changes in the website quickly. Instead, use port 4000, `http://localhost:4000/simulatorvue`
 
 
 If you required to restart the server
@@ -89,7 +89,7 @@ If you required to restart the server
 5. Run `./bin/docker_run`
 7. Navigate to `http://localhost:3000` in your browser
 8. For Vue-based simulator, navigate to `http://localhost:4000/simulatorvue` in your browser
-    > 🔴 **NOTE:** If you access new simulator with port 3000, you can't see changes in website quickly. Instead use port 4000, `http://localhost:4000/simulatorvue`
+    > 🔴 **NOTE:** If you access new simulator with port 3000, you can't see changes in the website quickly. Instead, use port 4000, `http://localhost:4000/simulatorvue`
 
 
 If you required to restart the server

--- a/installation_docs/docker.md
+++ b/installation_docs/docker.md
@@ -23,6 +23,9 @@
 5. Run `./bin/docker_run.ps1`
 6. Wait for the docker container to be prepared
 7. Navigate to `http://localhost:3000` in your browser
+8. For Vue-based simulator, navigate to `http://localhost:4000/simulatorvue` in your browser
+    > 🔴 **NOTE:** If you access new simulator with port 3000, you can't see changes in website quickly. Instead use port 4000, `http://localhost:4000/simulatorvue`
+
 
 If you required to restart the server
 - Type `Ctrl+C` in terminal to stop the server
@@ -56,6 +59,10 @@ Set-ExecutionPolicy RemoteSigned
 3. Open `CircuitVerse` directory
 4. Open `Terminal` in the current directory
 5. Run `./bin/docker_run`
+7. Navigate to `http://localhost:3000` in your browser
+8. For Vue-based simulator, navigate to `http://localhost:4000/simulatorvue` in your browser
+    > 🔴 **NOTE:** If you access new simulator with port 3000, you can't see changes in website quickly. Instead use port 4000, `http://localhost:4000/simulatorvue`
+
 
 If you required to restart the server
 - Type `Ctrl+C` in terminal to stop the server
@@ -80,6 +87,10 @@ If you required to restart the server
 3. Open `CircuitVerse` directory
 4. Open `Terminal` in the current directory
 5. Run `./bin/docker_run`
+7. Navigate to `http://localhost:3000` in your browser
+8. For Vue-based simulator, navigate to `http://localhost:4000/simulatorvue` in your browser
+    > 🔴 **NOTE:** If you access new simulator with port 3000, you can't see changes in website quickly. Instead use port 4000, `http://localhost:4000/simulatorvue`
+
 
 If you required to restart the server
 - Type `Ctrl+C` in terminal to stop the server

--- a/installation_docs/troubleshooting_guide.md
+++ b/installation_docs/troubleshooting_guide.md
@@ -6,3 +6,8 @@
 ![image](https://github.com/CircuitVerse/CircuitVerse/assets/57363826/5e707303-5147-4645-89e4-715c7b70a3f5)
 
 **Solution:** Wait for few seconds (upto 1 minute) and refresh the page.
+
+### 2. The website is not showing any updates after modifying the `cv-frontend-vue` codes
+
+**Solution:** Probably you are accessing the new simulator on port 3000 by using the url `http://localhost:3000/simulatorvue/`. Use port 4000 `http://localhost:4000/simulatorvue/` for seeing changes on website.
+

--- a/installation_docs/troubleshooting_guide.md
+++ b/installation_docs/troubleshooting_guide.md
@@ -9,5 +9,5 @@
 
 ### 2. The website is not showing any updates after modifying the `cv-frontend-vue` codes
 
-**Solution:** Probably you are accessing the new simulator on port 3000 by using the url `http://localhost:3000/simulatorvue/`. Use port 4000 `http://localhost:4000/simulatorvue/` for seeing changes on website.
+**Solution:** Probably you are accessing the new simulator on port 3000 by using the url `http://localhost:3000/simulatorvue/`. Use port 4000 `http://localhost:4000/simulatorvue/` for seeing changes on the website.
 


### PR DESCRIPTION
Fixes #4417

#### Describe the changes you have made in this PR -
- Add `cv-frontend-vue` in docker configuration
- Use the vite development server instead of static build for providing hot-reload

**NOTE**
Before merging this PR, https://github.com/CircuitVerse/cv-frontend-vue/pull/221 this PR need to be merged and the submodule need to be updated

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
