### PR TITLE
fix: the size of sponsor logo in footer

### DIFF
--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -119,3 +119,23 @@
   content: '';
   width: 10px;
 }
+
+//breakpoints
+@media (max-width: 768px){
+  .footer-sponsor-logo{
+    width: 75%;
+    margin-left: 30px;
+  }
+  .footer-sponsor-logo-text{
+    margin-left: 30px;
+  }
+}
+@media (max-width: 388px){
+  .footer-sponsor-logo{
+    width: 100%;
+    margin-left: 0;
+  }
+  .footer-sponsor-logo-text{
+    margin-left: 0;
+  }
+}


### PR DESCRIPTION
Fixes #4398 

#### Describe the changes you have made in this PR -
I tried to put the sponsor logo in the first line line but the problem was that the footer-links where in display : inline due to this i was unable to change the width of the footer-links. So now i made some breakpoints to set width and it will not be that big 

### Screenshots of the changes (If any) -
Previously it was:-
![image](https://github.com/CircuitVerse/CircuitVerse/assets/116784047/dff97b4f-28a7-43b1-b400-236522f053c2)

Now it is:-
![image](https://github.com/CircuitVerse/CircuitVerse/assets/116784047/f3bab014-1d39-4607-bf63-f53f06ae2235)


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
