### PR TITLE
Fix(edit-user-detail): fixed non-working remove picture button with better layout

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -146,43 +146,59 @@
   font-size: 10px;
 }
 
-.users-edit-image {
+.users-edit-image-container {
+  margin: 10px;
   border-radius: 50%;
   height: 150px;
   width: 150px;
+  position: relative;
+  overflow: hidden;
 }
 
-.users-edit-image-button {
-  border: 1px solid $secondary-green;
-  border-radius: 4px;
-  cursor: pointer;
-  height: 35px;
-  line-height: 35px;
-  margin-bottom: 20px;
-  margin-left: 10px;
-  text-align: center;
-  width: 120px;
+.users-edit-image {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: cover; 
 }
 
 .users-edit-image-button-hidden {
   display: none;
 }
 
-.users-edit-image-button:hover {
-  background-color: $primary-green;
-  color: $white;
+.users-edit-image-button {
+  height: 50px;
+  width: 50px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: #ffffff;
+  border-radius: 50%;
+  opacity: 0.7;
 }
 
-.users-remove-image-button {
-  border: 1px solid $secondary-red;
-  border-radius: 4px;
+.users-edit-image-button > * {
+  width: 100%;
+  height: 100%;
   cursor: pointer;
-  height: 35px;
-  line-height: 35px;
-  margin-bottom: 20px;
-  margin-left: 10px;
-  text-align: center;
-  width: 140px;
+}
+
+.users-edit-image-button i {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 20px;
+  cursor: pointer;
+}
+
+.profile-picture-edit-btn:focus {
+  box-shadow: none;
+}
+
+.users-edit-image-button:hover {
+  opacity: 1;
 }
 
 .remove-pic:checked ~ .users-remove-image-button,

--- a/app/views/users/circuitverse/edit.html.erb
+++ b/app/views/users/circuitverse/edit.html.erb
@@ -25,11 +25,37 @@
           </div>
           <div class="field form-group">
             <h6><%= t("users.circuitverse.edit_profile.profile_picture") %><h6>
-            <p><%= image_tag user_profile_picture(@profile.profile_picture), id:'imgedit', class:"users-edit-image", alt:'User Profile Image' %></p>
-            <label for="profile_picture" class="users-edit-image-button"><%= t("users.circuitverse.edit_profile.choose_file") %></label>
+            <div class="users-edit-image-container">
+              <%= image_tag user_profile_picture(@profile.profile_picture), id:'imgedit', class:"users-edit-image", alt:'User Profile Image' %>
+              <div class="users-edit-image-button">
+                <% if @user.profile_picture.attached? %>
+                  <button type="button" class="btn profile-picture-edit-btn" id="editImageBtn" data-toggle="modal" data-target=".bd-example-modal-sm"><i class="fas fa-pen"></i></button>
+                  <label for="profile_picture" id="addNewImageBtn" style="display: none"><i class="fas fa-plus"></i></label>
+                <% else %>
+                  <button type="button" class="btn profile-picture-edit-btn" style="display: none" id="editImageBtn" data-toggle="modal" data-target=".bd-example-modal-sm"><i class="fas fa-pen"></i></button>
+                  <label for="profile_picture" id="addNewImageBtn"><i class="fas fa-plus"></i></label>
+                <% end %>
+              </div>    
+            </div>
             <input tabindex="0" type="file" accept="image/png, .jpeg, .jpg" class="users-edit-image-button-hidden" id="profile_picture" name="user[profile_picture]" onchange="readURL(this);" value="<%= @profile.profile_picture %>">
             <%= f.check_box :remove_picture, id: "remove_pic", class: "remove-pic" %>
-            <label for="remove_pic" class="users-remove-image-button"><%= t("users.circuitverse.edit_profile.remove_picture") %></label>
+            
+            <!-- Modal to Change or Remove Profile Picture -->
+            <div class="modal fade bd-example-modal-sm" tabindex="-1" role="dialog" aria-labelledby="mySmallModalLabel" aria-hidden="true">
+              <div class="modal-dialog modal-sm">
+                <div class="modal-content">
+                  <div class="modal-header">
+                    <h5 class="modal-title">Profile Picture</h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                      <span aria-hidden="true">&times;</span>
+                    </button>
+                  </div>
+                  <label for="profile_picture" class="list-group-item change-picture"><%= t("users.circuitverse.edit_profile.change_picture") %></label>
+                  <label for="remove_pic" class="list-group-item remove-picture"><%= t("users.circuitverse.edit_profile.remove_picture") %></label>                    
+                </div>
+              </div>
+            </div>
+
           </div>
           <div class="field form-group">
             <h6><%= f.label :country %></h6>
@@ -78,9 +104,12 @@
     if (input.files && input.files[0]) {
     var reader = new FileReader();
     reader.onload = function (e) {
+    $('#addNewImageBtn').hide();
+    $('#editImageBtn').show();
     $('#imgedit')
       .attr('src', e.target.result);
     };
+    
     reader.readAsDataURL(input.files[0]);
     }
   }
@@ -131,4 +160,12 @@
   document.querySelector('#remove_pic').addEventListener('change', function() {
       document.querySelector('#imgedit').src = '<%= image_path('thumb/Default.jpg') %>';
   });
+  $('.change-picture').on('click', function() {
+    $('.modal').modal('hide');
+  });
+  $('.remove-picture').on('click', function() {
+    $('#editImageBtn').hide();
+    $('#addNewImageBtn').show();
+    $('.modal').modal('hide');
+  })
 </script>

--- a/config/locales/views/users/bn.yml
+++ b/config/locales/views/users/bn.yml
@@ -18,6 +18,7 @@ bn:
         description_html: '<sup><i class="fa fa-asterisk users-edit-asterisk"></i></sup> দিয়ে চিহ্নিত ক্ষেত্রগুলি বাধ্যতামূলক'
         profile_picture: "প্রোফাইল ছবি"
         choose_file: "ছবি আপলোড"
+        change_picture: "ছবি পরিবর্তন"
         remove_picture: "ছবি সরান"
         country_select_placeholder: "প্রবেশ না করা পছন্দ"
         select_locale_prompt: "ভাষা নির্বাচন করুন"

--- a/config/locales/views/users/en.yml
+++ b/config/locales/views/users/en.yml
@@ -18,6 +18,7 @@ en:
         description_html: "Fields marked with <sup><i class=\"fa fa-asterisk users-edit-asterisk\"></i></sup> are mandatory"
         profile_picture: "Profile Picture"
         choose_file: "Choose File"
+        change_picture: "Change Picture"
         remove_picture: "Remove Picture"
         country_select_placeholder: "Prefer Not To Enter"
         select_locale_prompt: "Select the locale"

--- a/config/locales/views/users/hi.yml
+++ b/config/locales/views/users/hi.yml
@@ -18,6 +18,7 @@ hi:
         description_html: "<sup><i class=\"fa fa-asterisk users-edit-asterisk\"></i></sup> से चिह्नित फ़ील्ड अनिवार्य हैं"
         profile_picture: "प्रोफ़ाइल फोटो"
         choose_file: "फ़ाइल चुनें"
+        change_picture: "फोटो बदलें"
         remove_picture: "फोटो हटाएं"
         country_select_placeholder: "दर्ज न करना पसंद करें"
         select_locale_prompt: "लोकेल चुनें"

--- a/config/locales/views/users/mr.yml
+++ b/config/locales/views/users/mr.yml
@@ -18,6 +18,7 @@ mr:
         description_html: "<sup><i class=\"fa fa-asterisk user-edit-asterisk\"></i></sup> सह चिन्हांकित फील्ड अनिवार्य आहेत"
         profile_picture: "परिचय चित्र"
         choose_file: "फाईल निवडा"
+        change_picture: "फोटो बदला"
         remove_picture: "फोटो हटवा"
         country_select_placeholder: "प्रवेश न करणे पसंत करा"
         select_locale_prompt: "लोकॅल निवडा"


### PR DESCRIPTION
Fixes #4441 

#### There was a problem in the edit user detail page where there was a remove picture button, even when there was no picture selected, and clicking on it won't do anything. To fix it I used conditional rendering for swapping buttons. If there was no image selected then an add new image button will be displayed, if there is already an image selected then there will be a edit image button (to change or remove the image).
Together with adding button, I also add language translation too for all the languages.

### Screenshots of the changes (If any) -

https://github.com/CircuitVerse/CircuitVerse/assets/75238590/cd53059f-a6d3-43f0-8cc4-fa6db77d5bd8


https://github.com/CircuitVerse/CircuitVerse/assets/75238590/9461697d-2737-4ae9-bced-5adda5f442ca

