### PR TITLE
fix: update project name max length

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -8,7 +8,7 @@ class Project < ApplicationRecord
   friendly_id :name, use: %i[slugged history]
   self.ignored_columns += ["data"]
 
-  validates :name, length: { minimum: 1, maximum: 60 }
+  validates :name, length: { minimum: 1, maximum: 90 }
   validates :slug, uniqueness: true
 
   belongs_to :author, class_name: "User"

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -8,7 +8,7 @@ class Project < ApplicationRecord
   friendly_id :name, use: %i[slugged history]
   self.ignored_columns += ["data"]
 
-  validates :name, length: { minimum: 1, maximum: 90 }
+  validates :name, length: { minimum: 1 }
   validates :slug, uniqueness: true
 
   belongs_to :author, class_name: "User"

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -23,7 +23,7 @@
   <% end %>
   <div class="field form-group d-flex flex-column">
     <h6><%= form.label :name %></h6>
-    <%= form.text_field :name, id: :project_name, class: "form-control form-input", maxlength: 60 %>
+    <%= form.text_field :name, id: :project_name, class: "form-control form-input", maxlength: 90 %>
     <span id="name-counter" class="char-counter"></span>
   </div>
   <div class="field form-group projects-tag-form-group">


### PR DESCRIPTION
Related #4235

#### Describe the changes you have made in this PR -
- Increments the Project name max length to 90
- Rollback the limitations from backend as it's causing issue to already existing project



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
