### PR TITLE
fix(dropdown): adds padding to resolve overlapping issue

### DIFF
--- a/simulator/src/css/main.stylesheet.css
+++ b/simulator/src/css/main.stylesheet.css
@@ -2292,6 +2292,7 @@ canvas {
         height: 300px;
         margin: auto;
         box-shadow: rgba(155, 160, 165, 0.2) 0px 8px 24px;
+        padding-top:10px;
     }
     .ce-name {
         height: 0%;


### PR DESCRIPTION
Fixes #4507

#### Describe the changes you have made in this PR -
In the `simulator/src/css/main.stylesheet.css` I have added padding to the Touch-Ce-Menu class and the border no longer overlaps over the text.

### Screenshots of the changes (If any) -
![image](https://github.com/CircuitVerse/CircuitVerse/assets/122573982/854eab01-cbaf-43c7-adcd-d233a4c361db)



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
