### PR TITLE
fix: align simulator username

### DIFF
--- a/simulator/src/css/main.stylesheet.css
+++ b/simulator/src/css/main.stylesheet.css
@@ -205,6 +205,8 @@ input[type="text"]:focus {
     overflow: hidden;
     text-overflow: ellipsis;
     text-align: right;
+    line-height: 20px;
+    padding: 2px 8px;
 }
 
 @media (max-width: 991px) {


### PR DESCRIPTION
Fixes #4534 

#### Describe the changes you have made in this PR -
Align the username vertically to the center and add a gap with the down arrow

### Screenshots of the changes (If any) -
| Before | After |
| :---: | :---: |
| ![Screenshot 2024-01-07 180039](https://github.com/CircuitVerse/CircuitVerse/assets/70331875/e73679b2-c6f6-40c5-981a-cdf4d2e99752) | ![Screenshot 2024-01-07 175909](https://github.com/CircuitVerse/CircuitVerse/assets/70331875/f4d00d3b-03af-418f-9af2-5c9c753b54d0) |


