### PR TITLE
Code Cleanup: Refactor 'notify_recipient' Method - Remove Unnecessary @assignment"

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -26,7 +26,6 @@ class Assignment < ApplicationRecord
     end
   end
 
-
   def send_new_assignment_mail
     group.group_members.each do |group_member|
       AssignmentMailer.new_assignment_email(group_member.user, self).deliver_later

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -21,11 +21,11 @@ class Assignment < ApplicationRecord
   has_noticed_notifications model_name: "NoticedNotification", dependent: :destroy
 
   def notify_recipient
-    @assignment = Assignment.find(id)
     group.group_members.each do |group_member|
       NewAssignmentNotification.with(assignment: self).deliver_later(group_member.user)
     end
   end
+
 
   def send_new_assignment_mail
     group.group_members.each do |group_member|


### PR DESCRIPTION
Fixes https://github.com/CircuitVerse/CircuitVerse/issues/4590

#### Describe the changes you have made in this PR - 
 Removed redundant '@assignment' assignment in 'notify_recipient' method. Utilizing 'self' directly maintains functionality. Requesting review for approval




Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
