### PR TITLE
fix: paragraph style missing in contribution page

### DIFF
--- a/app/assets/stylesheets/contribute.scss
+++ b/app/assets/stylesheets/contribute.scss
@@ -65,6 +65,10 @@
   }
 }
 
+.justified-paragraph {
+  text-align: center;
+}
+
 //breakpoints
 @media (max-width: 1199px) {
   .contribute-social-card {

--- a/app/assets/stylesheets/contribute.scss
+++ b/app/assets/stylesheets/contribute.scss
@@ -65,7 +65,7 @@
   }
 }
 
-.justified-paragraph {
+.centered-paragraph {
   text-align: center;
 }
 

--- a/app/views/circuitverse/contribute.html.erb
+++ b/app/views/circuitverse/contribute.html.erb
@@ -5,7 +5,7 @@
     <div class="col-xs col-sm col-md col-lg">
       <h1 class="main-heading"><%= t("circuitverse.contribute.main_heading") %></h1>
         <p class="main-description"><%= t("circuitverse.contribute.main_description") %></p>
-        <p class="justified-paragraph"><%= t("circuitverse.contribute.submain_description") %></p>
+        <p class="centered-paragraph"><%= t("circuitverse.contribute.submain_description") %></p>
     </div>
   </div>
   <div class="row center-row">


### PR DESCRIPTION
Fixes #4601 

#### Describe the changes you have made in this PR -
center aligned text on contribution page from justified.

### Screenshots of the changes (If any) -

![image](https://github.com/CircuitVerse/CircuitVerse/assets/130479331/1d8bbbb8-e4be-47d7-8924-6b40b4a63491)


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
