### PR TITLE
fix: improved the UI in Firefox

### DIFF
--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -72,12 +72,14 @@
 .footer-sponsor-logo-text {
   margin-bottom: 0;
   padding-bottom: 0;
+  text-wrap: nowrap;
+  display: ruby-base;
 }
 
 .footer-sponsor-logo {
   border: solid $footer-dark-grey 1px;
   border-radius: 5px;
-  width: 100%;
+  width: 200px;
 }
 
 .footer-copyright-text {
@@ -118,4 +120,14 @@
 .bounce-out-on-hover::after {
   content: '';
   width: 10px;
+}
+
+//breakpoints
+@media (max-width: 991px){
+  .footer-sponsor-logo-text{
+    margin-left: 11px;
+  }
+  .footer-sponsor-logo{
+    width: 153px;
+  }
 }

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -3,7 +3,7 @@
 <div class="container-fluid footer-container-fluid">
   <div class="container footer-container">
     <div class="row">
-      <div class="col-xs-12 col-sm-12 col-md-3 col-lg-3 footer-column">
+      <div class="col-xs-12 col-sm-12 col-md-4 col-lg-3 footer-column">
         <div class="row">
           <a href="/">
             <%= image_tag("CircuitVerse.png", class: "footer-logo", alt: "CircuitVerse Logo") %>
@@ -20,7 +20,7 @@
           <a class="bounce-out-on-hover" href="/github" target="_blank" data-tooltip="github"><%= image_tag("logos/github-logo-circle.png", class: "footer-social-icon", alt: "GitHub Logo") %></a>
         </div>
       </div>
-      <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4 footer-column">
+      <div class="col-xs-12 col-sm-12 col-md-5 col-lg-4 footer-column">
         <div class="row text-left">
           <div class="col-5 footer-links">
             <a href="/simulator"><h6><%= t("layout.link_to_simulator") %></h6></a>
@@ -44,7 +44,7 @@
           </div>
         </div>
       </div>
-      <div class="col-xs-12 col-sm-12 col-md-5 col-lg-5 footer-column">
+      <div class="col-xs-12 col-sm-12 col-md-3 col-lg-5 footer-column">
         <div class="row">
           <div class="col-6">
             <small class="text-left footer-sponsor-logo-text"><%= t("layout.footer.sponsor_logo_text.incubated_from") %></small>


### PR DESCRIPTION
Fixes #4597 

#### Describe the changes you have made in this PR -
Firefox doesnt supports some properties like text-wrap etc so i add properties that works same but works in different browser
also the width of the ``sponsor-logo`` container was useless so reduce it's width by changing some bootstrap code

### Screenshots of the changes (If any) -
***Chrome***
``before``
![image](https://github.com/CircuitVerse/CircuitVerse/assets/116784047/c5a361ed-f779-4c9e-bb03-a1cbc4ef286b)
``after``
![image](https://github.com/CircuitVerse/CircuitVerse/assets/116784047/577cf30a-7eb2-405f-a65f-b7e122e5f301)

***Mozilla***
``before``
![image](https://github.com/CircuitVerse/CircuitVerse/assets/116784047/a43c54ca-51e0-4214-ad71-507be1fa2457)

``after``
![image](https://github.com/CircuitVerse/CircuitVerse/assets/116784047/0238dad9-6cb8-4a50-99e1-fdf51a76e559)





Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
