### PR TITLE
style: removes extra space above footer

### DIFF
--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -1,5 +1,5 @@
 .footer-empty-div {
-  height: 250px;
+  height: 48px;
 }
 
 .footer-container-fluid {


### PR DESCRIPTION
Fixes #3621

#### Describe the changes you have made in this PR -
I have decreased the space above footer to 48px, which is a multiple of 4 and closest to 50, which was discussed in previous comments.
### Screenshots of the changes (If any) -
![Screen Shot 2024-01-22 at 10 27 56 PM](https://github.com/CircuitVerse/CircuitVerse/assets/82268257/26ac72b9-1eef-4e2f-96cb-0c310e55aab1)



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
