### PR TITLE
fix: restore custom tooltips

### DIFF
--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -858,6 +858,14 @@ window.addEventListener("load", function() {
     $('.dropdown.open').removeClass('open');
     $(this).parent('.dropdown').addClass('open');
   });
+  $('[title]').each(function() {
+    $(this).tooltip({
+      show: null,
+      track: true,
+      hide: false,
+      tooltipClass: "custom-tooltip-styling",
+    });
+  });
 })
 </script>
 


### PR DESCRIPTION
Fixes #2887 

#### Describe the changes you have made in this PR -
I have updated the jquery which was removed in this [commit](https://github.com/CircuitVerse/CircuitVerse/commit/ba929958c844e3c4d319ac7dcf2480fe56332945)
Now any element having title tag will have custom tooltip style applied.

### Screenshots of the changes (If any) -
![Screen Shot 2024-01-24 at 7 59 36 PM](https://github.com/CircuitVerse/CircuitVerse/assets/82268257/b94a2942-98b4-4537-9197-00fbf026a2f8)
![Screen Shot 2024-01-24 at 7 59 44 PM](https://github.com/CircuitVerse/CircuitVerse/assets/82268257/896c4fc0-4735-4ab1-ba22-6eaf4e31c14c)
