### PR TITLE
style: updated simulator navbar

### DIFF
--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -17,7 +17,7 @@
   <i class="fas fa-bars" id="dropdownIcon"></i>
   </button>
   <div class="collapse navbar-collapse justify-content-between" id="bs-example-navbar-collapse-1">
-    <ul class="navbar-nav navbar-menu noSelect pointerCursor" id="toolbar">
+    <ul class="navbar-nav navbar-menu noSelect pointerCursor col-4" id="toolbar">
       <li class="dropdown nav-dropdown d-flex">
         <a href="#" class="" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><%= t("simulator.nav_item.project") %><span></span></a>
         <ul class="dropdown-menu">
@@ -64,11 +64,11 @@
         </ul>
       </li>
       </ul>
-      <span class="projectName noSelect defaultCursor font-weight-bold" id="projectName">
+      <span class="projectName noSelect defaultCursor font-weight-bold col-4" id="projectName">
           Untitled
       </span>
 
-      <ul class="nav navbar-nav noSelect pointerCursor pull-right account-btn">
+      <ul class="nav navbar-nav noSelect pointerCursor pull-right account-btn col-4 justify-content-end">
         <li class="dropdown pull-right">
           <% if user_signed_in? %>
             <a href="#" class="cur-user acc-drop user-field" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><%= current_user.name %><span class="caret acc-caret"></span></a>

--- a/simulator/src/css/main.stylesheet.css
+++ b/simulator/src/css/main.stylesheet.css
@@ -172,12 +172,13 @@ input[type="text"]:focus {
 .projectName {
     font-size: 1em;
     text-align: center;
-    display: inline-block;
-    width: 35vw;
+    /* display: inline-block; */
+    /* width: 35vw; */
     height: 1.2rem;
     overflow: hidden;
     text-overflow: ellipsis;
-    margin-right: 22rem;
+    padding-right: 106px;
+    /* margin-right: 22rem; */
 }
 
 @media (max-width: 991px) {
@@ -1501,7 +1502,7 @@ input:checked + .slider:before {
 #insertSubcircuitcontent a {
   color: white;
   margin-bottom: 7px;
-} 
+}
 
 #insertSubcircuitDialog > p {
     margin-bottom: 0;


### PR DESCRIPTION
Fixes #4114 

#### Describe the changes you have made in this PR -
I have added flex styling using col class of bootstrap to center the project name and also disply the account name. I have taken the refernece from how **Figma** is doing it.

### Screenshots of the changes (If any) -
### Before
![Screen Shot 2024-01-27 at 3 02 13 PM](https://github.com/CircuitVerse/CircuitVerse/assets/82268257/b184c825-5a3d-402e-9e80-b0966851c8d9)
![Screen Shot 2024-01-27 at 3 01 59 PM](https://github.com/CircuitVerse/CircuitVerse/assets/82268257/59efce4a-3039-4f5b-a046-72d5453161bc)
![Screen Shot 2024-01-27 at 3 01 30 PM](https://github.com/CircuitVerse/CircuitVerse/assets/82268257/f87bd980-1179-483d-a37c-1db5ee204dfd)

### After
![Screen Shot 2024-01-27 at 3 09 57 PM](https://github.com/CircuitVerse/CircuitVerse/assets/82268257/6c64bea4-a844-44f0-9a41-edb5ae8dde0c)
![Screen Shot 2024-01-27 at 3 10 05 PM](https://github.com/CircuitVerse/CircuitVerse/assets/82268257/d41efcff-2218-4c19-9bc1-67113daa3fa1)
![Screen Shot 2024-01-27 at 3 10 11 PM](https://github.com/CircuitVerse/CircuitVerse/assets/82268257/6eff5f5e-dd89-48d4-b246-b36ae6f738ff)


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
