### PR TITLE
fix: code auto completion link corrected

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -29,7 +29,7 @@ There are several ways to run your own instance of CircuitVerse:
 ## Tools Setup
 | Tool | Documentation Link |
 | --- | --- |
-| Code Auto Completion | [Click Here](https://github.com/CircuitVerse/CircuitVerse/blob/master/LSP-SETUP.MD) |
+| Code Auto Completion | [Click Here](https://github.com/CircuitVerse/CircuitVerse/blob/master/LSP-SETUP.md) |
 | Ruby Debugger | [Click Here](https://github.com/CircuitVerse/CircuitVerse/blob/master/DEBUGGER-SETUP.md) |
 
 ## Tests


### PR DESCRIPTION
Fixes #4677 
I correct the doc link of code auto-completion.
from "LSP-SETUP.MD" to "LSP-SETUP.md"
now it's working correctly



https://github.com/CircuitVerse/CircuitVerse/assets/100744516/e03e739a-7f6c-4cb6-8cd0-f7c7a4d5e9d7

