### PR TITLE
#4694 Bug: No gap between the navbar and the title text Terms of Service.

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -119,6 +119,7 @@
 .password-icon {
   color: $secondary-green;
   width: 40px;
+  cursor: pointer;
 }
 
 .users-password-input {

--- a/app/views/circuitverse/tos.html.erb
+++ b/app/views/circuitverse/tos.html.erb
@@ -1,5 +1,6 @@
 <% content_for :title, t("circuitverse.tos.title") %>
 <div class="container">
+  <br/>
   <h1><%= t("circuitverse.tos.main_heading") %></h1>
   <section>
 


### PR DESCRIPTION
### Fixes  #4694  Bug: No gap between the navbar and the title text Terms of Service.

#### I have added a space between the navbar in the title in this [page]( https://circuitverse.org/tos)

### Screenshots of the changes (If any) -

##### before
![before](https://github.com/CircuitVerse/CircuitVerse/assets/101059602/a88f52d8-4f49-48b9-9aa2-98e0af11adb1)

#### after
![Screenshot (18)](https://github.com/CircuitVerse/CircuitVerse/assets/101059602/9db85b8c-0751-4e45-b649-733f6d8ce24c)
