### PR TITLE
fix: no gap between the navbar and the title text

### DIFF
--- a/app/views/circuitverse/tos.html.erb
+++ b/app/views/circuitverse/tos.html.erb
@@ -1,5 +1,6 @@
 <% content_for :title, t("circuitverse.tos.title") %>
 <div class="container">
+  <br>
   <h1 class="text-center my-4"><%= t("circuitverse.tos.main_heading") %></h1>
   <section>
 


### PR DESCRIPTION
## Fixes #4694
### Describe the changes you have made in this PR -
Added gap between the navbar and the title text in this [page](https://circuitverse.org/tos)

### Screenshots of the changes (If any) -
#### before
![before](https://github.com/CircuitVerse/CircuitVerse/assets/101059602/c404eae5-10af-4945-8204-47f94247d01d)


#### after
![Screenshot (18)](https://github.com/CircuitVerse/CircuitVerse/assets/101059602/7a0c9944-200a-41d4-b790-ee5aed127b07)

