### PR TITLE
fix: typo error

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ Please note:  If you wanted to work on an issue, let us know by leaving a commen
 - `no activity` labeled PRs are meant to have no activity in the PR from since a while.
 - `blocked` labeled PRs are meant not to go ahead for review.
 - `do not merge` labeled PRs are meant not to merge the PR right now(may be later).
-- [awaiting-approval](https://github.com/CircuitVerse/CircuitVerse/labels/awaiting-approval) labeled PRs are meant to be waiting for other communtiy members.
+- [awaiting-approval](https://github.com/CircuitVerse/CircuitVerse/labels/awaiting-approval) labeled PRs are meant to be waiting for other community members.
 
 ## Community
 Discussions about CircuitVerse issues and features take place on the repository's [Discussions](https://github.com/CircuitVerse/CircuitVerse/discussions) sections. Anybody is welcome to join these conversations. See the [README](README.md) for more information on communication channels.


### PR DESCRIPTION
Fixes #4772 

#### Describe the changes you have made in this PR -
typo fix 
``communtiy``  to ``community`` 

### Screenshots of the changes (If any) -



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
