### PR TITLE
Fix circuit state flickering on autosave

### DIFF
--- a/simulator/src/data/save.js
+++ b/simulator/src/data/save.js
@@ -104,7 +104,7 @@ export function generateSaveData(name, setName = true) {
         }
 
         completed[id] = true;
-        update(scopeList[id], true); // For any pending integrity checks on subcircuits
+        update(scopeList[id]); // For any pending integrity checks on subcircuits
         data.scopes.push(backUp(scopeList[id]));
     }
 


### PR DESCRIPTION
Fixes an error where during autosave (or rather any save, but it was only visible during an autosave) would result in the circuit flickering into a different circuit in the project. Also, a self balancing circuit would switch into its other legal state without any driving signal.

This happens because of a force-reset-nodes call in the generate- circuit-data workflow. I am not sure why this call exists, my guess is it's related to Subcircuits 1.0, but it is redundant and only causes problems now.

This commit removes the force-reset-nodes call by removing the update-everything flag from the update call in the generate- save-data workflow.

Fixes https://circuitverse-team.slack.com/archives/C010HK6TWQG/p1709146375152669



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
