### PR TITLE
fix: redirect back button to my group page

### DIFF
--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -337,7 +337,7 @@
   </table>
   <div class="row">
     <div class="col-12 groups-back-button-container">
-      <%= link_to t("back"), :back, class: "anchor-text" %>
+      <%= link_to t("back"), user_groups_path(current_user.id), class: "anchor-text" %>
     </div>
   </div>
   <%= render partial: "delete_member_confirmation_modal" %>


### PR DESCRIPTION
Fixes #4803 

#### Describe the changes you have made in this PR -
Fix: Back button now redirects back to the My Group page. Earlier it was not opening My Group page instead it closes the website.


https://github.com/CircuitVerse/CircuitVerse/assets/101208285/019278f8-bc49-4fcb-bd4b-74d4c4519628



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
