### PR TITLE
Alligned dropdown below the username, in Simulator

### DIFF
--- a/simulator/src/css/main.stylesheet.css
+++ b/simulator/src/css/main.stylesheet.css
@@ -313,7 +313,7 @@ input[type="text"]:focus {
     text-align: center;
     position: absolute;
     left: 50%;
-    transform: translate(-50%, 13px);
+    transform: translate(-55%, 13px);
 }
 
 .draggable-panel-css {


### PR DESCRIPTION
Fixes #4709 

#### Describe the changes you have made in this PR - previously transform: translate was -50% due to which it was moving outside the screen, changed it to -55%
![Screenshot from 2024-03-22 02-52-00](https://github.com/CircuitVerse/CircuitVerse/assets/156365622/02353ad7-1210-4382-a653-8506158a1416)
![Screenshot from 2024-03-22 02-51-39](https://github.com/CircuitVerse/CircuitVerse/assets/156365622/fdf064a6-3c29-4b09-8ff3-e5ef4f5435e2)




Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
