### PR TITLE
feat(#3386): notify user when added as a collaborator in the project

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -540,6 +540,10 @@
     padding: 12px 10px;
   }
 
+  .fa-user-plus {
+    padding: 12px 10px;
+  }
+
   .fa-comment {
     padding: 10px;
   }

--- a/app/controllers/users/noticed_notifications_controller.rb
+++ b/app/controllers/users/noticed_notifications_controller.rb
@@ -15,7 +15,7 @@ class Users::NoticedNotificationsController < ApplicationController
     case answer.type
     when "new_assignment"
       redirect_to group_assignment_path(answer.first_param, answer.second)
-    when "star", "fork"
+    when "star", "fork", "new_collaborator"
       redirect_to user_project_path(answer.first_param, answer.second)
     when "forum_comment"
       redirect_to simple_discussion.forum_thread_path(answer.first_param, anchor: "forum_post_#{answer.second}")

--- a/app/models/collaboration.rb
+++ b/app/models/collaboration.rb
@@ -3,4 +3,16 @@
 class Collaboration < ApplicationRecord
   belongs_to :user
   belongs_to :project
+  after_create_commit :notify_recipient
+  has_noticed_notifications model_name: "NoticedNotification"
+  before_destroy :cleanup_notification
+  has_many :notifications, as: :notifiable # rubocop:disable Rails/HasManyOrHasOneDependent
+
+  def notify_recipient
+    NewCollaboratorNotification.with(user: project.author, project: project).deliver_later(user)
+  end
+
+  def cleanup_notification
+    notifications_as_new_collaborator.destroy_all
+  end
 end

--- a/app/notifications/new_collaborator_notification.rb
+++ b/app/notifications/new_collaborator_notification.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class NewCollaboratorNotification < Noticed::Base
+  deliver_by :database, association: :noticed_notifications
+
+  def message
+    user = params[:user]&.name
+    project = params[:project]&.name
+    t("users.notifications.new_collaborator_notification", user: user, project: project)
+  end
+
+  def icon
+    "fa fa-user-plus fa-thin"
+  end
+end

--- a/app/services/notify_user.rb
+++ b/app/services/notify_user.rb
@@ -25,7 +25,7 @@ class NotifyUser
   private
 
     # @return [Result]
-    def type_check
+    def type_check # rubocop:disable Metrics/MethodLength
       case @notification.type
       when "StarNotification"
         Result.new("true", "star", @project.author, @project)

--- a/app/services/notify_user.rb
+++ b/app/services/notify_user.rb
@@ -38,6 +38,8 @@ class NotifyUser
         Result.new("true", "forum_comment", @thread, @post.id)
       when "ForumThreadNotification"
         Result.new("true", "forum_thread", @thread)
+      when "NewCollaboratorNotification"
+        Result.new("true", "new_collaborator", @project.author, @project)
       else
         Result.new("false", "no_type", root_path)
       end

--- a/config/locales/views/users/bn.yml
+++ b/config/locales/views/users/bn.yml
@@ -94,3 +94,4 @@ bn:
       new_assignment_notification: "আপনাকে একটি নতুন অ্যাসাইনমেন্ট '%{assignment_name}' নিয়োগ করা হয়েছে"
       forum_thread_notification: "%{user} একটি নতুন থ্রেড '%{thread}' পোস্ট করেছেন"
       comment_notif: "%{user} থ্রেড '%{thread}' -এ মন্তব্য করেছেন"
+      new_collaborator_notification: "আপনি %{user} দ্বারা %{project} প্রকল্পে সহযোগী হিসেবে যোগ করা হয়েছে"

--- a/config/locales/views/users/en.yml
+++ b/config/locales/views/users/en.yml
@@ -94,3 +94,4 @@ en:
       new_assignment_notification: "You have been assigned a new assignment '%{assignment_name}'"
       forum_thread_notification: "%{user} posted a new thread '%{thread}'"
       comment_notif: "%{user} commented on thread '%{thread}'"
+      new_collaborator_notification: "You have been added as a collaborator in %{project} by %{user}"

--- a/config/locales/views/users/hi.yml
+++ b/config/locales/views/users/hi.yml
@@ -94,3 +94,4 @@ hi:
       new_assignment_notification: "आपको एक नया कार्य सौंपा गया है! - '%{assignment_name}'"
       forum_thread_notification: "%{user} ने एक नया सूत्र '%{thread}' पोस्ट किया"
       comment_notif: "%{user} ने '%{thread}' पर टिप्पणी की"
+      new_collaborator_notification: "आपको %{user} द्वारा %{project} में सहयोगी के रूप में जोड़ा गया है"

--- a/config/locales/views/users/mr.yml
+++ b/config/locales/views/users/mr.yml
@@ -15,7 +15,7 @@ mr:
       edit_profile:
         title: "%{name} - प्रोफाइल संपादित करा"
         heading: "प्रोफाईल संपादित करा"
-        description_html: "<sup><i class=\"fa fa-asterisk user-edit-asterisk\"></i></sup> सह चिन्हांकित फील्ड अनिवार्य आहेत"
+        description_html: '<sup><i class="fa fa-asterisk user-edit-asterisk"></i></sup> सह चिन्हांकित फील्ड अनिवार्य आहेत'
         profile_picture: "परिचय चित्र"
         choose_file: "फाईल निवडा"
         remove_picture: "फोटो हटवा"
@@ -88,9 +88,10 @@ mr:
       mark_as_read_button: "सर्व वाचलेले म्हणून चिन्हांकित करा"
       no_notifications: "तुमच्याकडे कोणत्याही सूचना नाहीत!"
       no_unread_notifications: "तुमच्याकडे कोणत्याही न वाचलेल्या सूचना नाहीत!"
-      see_all : "सभी देखें"
+      see_all: "सभी देखें"
       fork_notification: "%{user} ने तुमचा प्रकल्प  फोर्क केला %{project}"
       star_notification: "%{user} ने तुमच्या प्रकल्पाला तारांकित केले %{project}"
       new_assignment_notification: "तुम्हाला एक नवीन कार्य नियुक्त केले गेले आहे! - '%{assignment_name}'"
       forum_thread_notification: "%{user} ने नवीन धागा '%{thread}' पोस्ट केला"
       comment_notif: "%{user} ने '%{thread}' वर ​​टिप्पणी केली"
+      new_collaborator_notification: "आपल्याला %{user} यांच्याकडून %{project} मध्ये सहकारी म्हणून समाविष्ट केले गेले आहे"

--- a/spec/system/notification_spec.rb
+++ b/spec/system/notification_spec.rb
@@ -2,73 +2,61 @@
 
 require "rails_helper"
 
-describe "fork_notification", type: :system do
-  before do
-    @author = FactoryBot.create(:user)
-    @user = sign_in_random_user
-    @project = FactoryBot.create(:project, name: "Project", author: @author, project_access_type: "Public")
-    driven_by(:selenium_chrome_headless)
-  end
-
-  it "initiate notification" do
-    sign_in @user
-    visit user_project_path(@author, @project)
-    click_on "Fork"
-    expect(@author.noticed_notifications.count).to eq(1)
-  end
-
-  context "notification page" do
+describe "Notifications", type: :system do
+  describe "fork_notification" do
     before do
+      @author = FactoryBot.create(:user)
+      @user = sign_in_random_user
+      @project = FactoryBot.create(:project, name: "Project", author: @author, project_access_type: "Public")
+      driven_by(:selenium_chrome_headless)
+    end
+
+    it "initiate notification" do
       sign_in @user
       visit user_project_path(@author, @project)
       click_on "Fork"
-      sign_in @author
-      visit notifications_path(@author)
+      expect(@author.noticed_notifications.count).to eq(1)
     end
 
-    it "render all notifications" do
-      expect(page).to have_text("#{@user.name} forked your Project #{@project.name}")
-    end
+    context "notification page" do
+      before do
+        sign_in @user
+        visit user_project_path(@author, @project)
+        click_on "Fork"
+        sign_in @author
+        visit notifications_path(@author)
+      end
 
-    it "render all unread notifications" do
-      page.find("#unread-notifications").click
-      expect(page).to have_text("#{@user.name} forked your Project #{@project.name}")
-    end
+      it "render all notifications" do
+        expect(page).to have_text("#{@user.name} forked your Project #{@project.name}")
+      end
 
-    it "mark all notifications as read" do
-      click_on "Mark all as read"
-      expect(@author.noticed_notifications.unread.count).to eq(0)
-    end
+      it "render all unread notifications" do
+        page.find("#unread-notifications").click
+        expect(page).to have_text("#{@user.name} forked your Project #{@project.name}")
+      end
 
-    it "mark notification as read" do
-      click_on "#{@user.name} forked your Project #{@project.name}"
-      expect(@author.noticed_notifications.read.count).to eq(1)
+      it "mark all notifications as read" do
+        click_on "Mark all as read"
+        expect(@author.noticed_notifications.unread.count).to eq(0)
+      end
+
+      it "mark notification as read" do
+        click_on "#{@user.name} forked your Project #{@project.name}"
+        expect(@author.noticed_notifications.read.count).to eq(1)
+      end
     end
   end
-end
 
-describe "new_collaborator_notification", type: :system do
-  before do
-    @author = FactoryBot.create(:user)
-    @user = sign_in_random_user
-    @project = FactoryBot.create(:project, name: "Project", author: @author, project_access_type: "Public")
-    driven_by(:selenium_chrome_headless)
-  end
-
-  it "initiate notification" do
-    email = @user.email
-    sign_in @author
-    visit user_project_path(@author, @project)
-    click_on "+ Add a Collaborator"
-    project_input_field_id = "#project_email_input_collaborator"
-    fill_in_input project_input_field_id, with: email
-    fill_in_input project_input_field_id, with: :enter
-    click_on "Add Collaborators"
-    expect(page).to have_text("1 user(s) will be invited")
-  end
-
-  context "notification page" do
+  describe "new_collaborator_notification" do
     before do
+      @author = FactoryBot.create(:user)
+      @user = sign_in_random_user
+      @project = FactoryBot.create(:project, name: "Project", author: @author, project_access_type: "Public")
+      driven_by(:selenium_chrome_headless)
+    end
+
+    it "initiate notification" do
       email = @user.email
       sign_in @author
       visit user_project_path(@author, @project)
@@ -77,31 +65,45 @@ describe "new_collaborator_notification", type: :system do
       fill_in_input project_input_field_id, with: email
       fill_in_input project_input_field_id, with: :enter
       click_on "Add Collaborators"
-      sign_in @user
-      visit notifications_path(@user)
+      expect(page).to have_text("1 user(s) will be invited")
     end
 
-    it "render all notifications" do
-      expect(page).to have_text("You have been added as a collaborator in #{@project.name} by #{@author.name}")
+    context "notification page" do
+      before do
+        email = @user.email
+        sign_in @author
+        visit user_project_path(@author, @project)
+        click_on "+ Add a Collaborator"
+        project_input_field_id = "#project_email_input_collaborator"
+        fill_in_input project_input_field_id, with: email
+        fill_in_input project_input_field_id, with: :enter
+        click_on "Add Collaborators"
+        sign_in @user
+        visit notifications_path(@user)
+      end
+
+      it "render all notifications" do
+        expect(page).to have_text("You have been added as a collaborator in #{@project.name} by #{@author.name}")
+      end
+
+      it "render all unread notifications" do
+        page.find("#unread-notifications").click
+        expect(page).to have_text("You have been added as a collaborator in #{@project.name} by #{@author.name}")
+      end
+
+      it "mark all notifications as read" do
+        click_on "Mark all as read"
+        expect(@user.noticed_notifications.unread.count).to eq(0)
+      end
+
+      it "mark notification as read" do
+        click_on "You have been added as a collaborator in #{@project.name} by #{@author.name}"
+        expect(@user.noticed_notifications.read.count).to eq(1)
+      end
     end
 
-    it "render all unread notifications" do
-      page.find("#unread-notifications").click
-      expect(page).to have_text("You have been added as a collaborator in #{@project.name} by #{@author.name}")
+    def fill_in_input(editor, with:)
+      find(editor).send_keys with
     end
-
-    it "mark all notifications as read" do
-      click_on "Mark all as read"
-      expect(@user.noticed_notifications.unread.count).to eq(0)
-    end
-
-    it "mark notification as read" do
-      click_on "You have been added as a collaborator in #{@project.name} by #{@author.name}"
-      expect(@user.noticed_notifications.read.count).to eq(1)
-    end
-  end
-
-  def fill_in_input(editor, with:)
-    find(editor).send_keys with
   end
 end

--- a/spec/system/notification_spec.rb
+++ b/spec/system/notification_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Notifcation", type: :system do
+describe "fork_notification", type: :system do
   before do
     @author = FactoryBot.create(:user)
     @user = sign_in_random_user
@@ -44,5 +44,64 @@ describe "Notifcation", type: :system do
       click_on "#{@user.name} forked your Project #{@project.name}"
       expect(@author.noticed_notifications.read.count).to eq(1)
     end
+  end
+end
+
+describe "new_collaborator_notification", type: :system do
+  before do
+    @author = FactoryBot.create(:user)
+    @user = sign_in_random_user
+    @project = FactoryBot.create(:project, name: "Project", author: @author, project_access_type: "Public")
+    driven_by(:selenium_chrome_headless)
+  end
+
+  it "initiate notification" do
+    email = @user.email
+    sign_in @author
+    visit user_project_path(@author, @project)
+    click_on "+ Add a Collaborator"
+    project_input_field_id = "#project_email_input_collaborator"
+    fill_in_input project_input_field_id, with: email
+    fill_in_input project_input_field_id, with: :enter
+    click_on "Add Collaborators"
+    expect(page).to have_text("1 user(s) will be invited")
+  end
+
+  context "notification page" do
+    before do
+      email = @user.email
+      sign_in @author
+      visit user_project_path(@author, @project)
+      click_on "+ Add a Collaborator"
+      project_input_field_id = "#project_email_input_collaborator"
+      fill_in_input project_input_field_id, with: email
+      fill_in_input project_input_field_id, with: :enter
+      click_on "Add Collaborators"
+      sign_in @user
+      visit notifications_path(@user)
+    end
+
+    it "render all notifications" do
+      expect(page).to have_text("You have been added as a collaborator in #{@project.name} by #{@author.name}")
+    end
+
+    it "render all unread notifications" do
+      page.find("#unread-notifications").click
+      expect(page).to have_text("You have been added as a collaborator in #{@project.name} by #{@author.name}")
+    end
+
+    it "mark all notifications as read" do
+      click_on "Mark all as read"
+      expect(@user.noticed_notifications.unread.count).to eq(0)
+    end
+
+    it "mark notification as read" do
+      click_on "You have been added as a collaborator in #{@project.name} by #{@author.name}"
+      expect(@user.noticed_notifications.read.count).to eq(1)
+    end
+  end
+
+  def fill_in_input(editor, with:)
+    find(editor).send_keys with
   end
 end


### PR DESCRIPTION
Fixes #3386

#### Describe the changes you have made in this PR -

- When a user is added to a project they receive a notification saying:
"You have been added as a collaborator in `project` by `author`"

- On clicking the notification it redirects to the project 
- Different locale support has also been included (screenshot included for hindi version)
- I have also written rspec tests for the notification 

### Screenshots of the changes
![notification](https://github.com/CircuitVerse/CircuitVerse/assets/57761549/e4f90372-f718-4879-b084-d71cf08c7a3a)
![notification_hi](https://github.com/CircuitVerse/CircuitVerse/assets/57761549/e53b6e89-a0cb-4c4b-97a1-b76a77b088a5)



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
