### PR TITLE
Feature: Added Color Picker Tool 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -269,6 +269,9 @@ GEM
     globalid (1.2.1)
       activesupport (>= 6.1)
     google-protobuf (3.25.3)
+    google-protobuf (3.25.3-arm64-darwin)
+    google-protobuf (3.25.3-x86_64-darwin)
+    google-protobuf (3.25.3-x86_64-linux)
     googleapis-common-protos-types (1.6.0)
       google-protobuf (~> 3.14)
     hairtrigger (0.2.25)
@@ -415,6 +418,12 @@ GEM
     nio4r (2.7.0)
     nokogiri (1.16.2)
       mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.16.2-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.2-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.2-x86_64-linux)
       racc (~> 1.4)
     noticed (1.6.3)
       http (>= 4.0.0)
@@ -883,7 +892,6 @@ GEM
     zeitwerk (2.6.13)
 
 PLATFORMS
-  aarch64-linux
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -269,9 +269,6 @@ GEM
     globalid (1.2.1)
       activesupport (>= 6.1)
     google-protobuf (3.25.3)
-    google-protobuf (3.25.3-arm64-darwin)
-    google-protobuf (3.25.3-x86_64-darwin)
-    google-protobuf (3.25.3-x86_64-linux)
     googleapis-common-protos-types (1.6.0)
       google-protobuf (~> 3.14)
     hairtrigger (0.2.25)
@@ -418,12 +415,6 @@ GEM
     nio4r (2.7.0)
     nokogiri (1.16.2)
       mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
-    nokogiri (1.16.2-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.16.2-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.16.2-x86_64-linux)
       racc (~> 1.4)
     noticed (1.6.3)
       http (>= 4.0.0)
@@ -892,6 +883,7 @@ GEM
     zeitwerk (2.6.13)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23

--- a/simulator/src/css/main.stylesheet.css
+++ b/simulator/src/css/main.stylesheet.css
@@ -995,7 +995,26 @@ div.icon img {
 .input-group-append button:hover {
     border-radius: 3px !important;
 }
-
+/* color-picker styling */
+div#color-picker-container{
+    position: relative;
+    height: 2.5rem;
+    margin-top: -1rem;
+}
+input#color-picker-text{
+    position: absolute;
+    top: 0;
+    width: calc(100% - 2.3rem);
+}
+input#color-picker
+{
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    width: 2.3rem;
+    height: 2.3rem;
+    border: none !important;
+}
 /* toogle */
 
 .switch {

--- a/simulator/src/modules/DigitalLed.js
+++ b/simulator/src/modules/DigitalLed.js
@@ -16,7 +16,7 @@ import { changeInputSize } from "../modules";
 import { colors } from "../themer/themer";
 
 export default class DigitalLed extends CircuitElement {
-    constructor(x, y, scope = globalScope, color = "Red") {
+    constructor(x, y, scope = globalScope, color = "#ff0000") {
         // Calling base class constructor
 
         super(x, y, scope, "UP", 1);

--- a/simulator/src/modules/HexDisplay.js
+++ b/simulator/src/modules/HexDisplay.js
@@ -15,7 +15,7 @@ import { changeInputSize } from "../modules";
 import { colors } from "../themer/themer";
 
 export default class HexDisplay extends CircuitElement {
-    constructor(x, y, scope = globalScope, color = "Red") {
+    constructor(x, y, scope = globalScope, color = "#ff0000") {
         super(x, y, scope, "RIGHT", 4);
         /* this is done in this.baseSetup() now
         this.scope['HexDisplay'].push(this);

--- a/simulator/src/modules/SevenSegDisplay.js
+++ b/simulator/src/modules/SevenSegDisplay.js
@@ -15,7 +15,7 @@ import {
  * @category modules
  */
 export default class SevenSegDisplay extends CircuitElement {
-    constructor(x, y, scope = globalScope, color = "Red") {
+    constructor(x, y, scope = globalScope, color = "#ff0000") {
         super(x, y, scope, 'RIGHT', 1);
         /* this is done in this.baseSetup() now
         this.scope['SevenSegDisplay'].push(this);

--- a/simulator/src/modules/SixteenSegDisplay.js
+++ b/simulator/src/modules/SixteenSegDisplay.js
@@ -15,7 +15,7 @@ import { changeInputSize } from '../modules';
  * @category modules
  */
 export default class SixteenSegDisplay extends CircuitElement {
-    constructor(x, y, scope = globalScope, color = "Red") {
+    constructor(x, y, scope = globalScope, color = "#ff0000") {
         super(x, y, scope, 'RIGHT', 16);
         /* this is done in this.baseSetup() now
         this.scope['SixteenSegDisplay'].push(this);

--- a/simulator/src/modules/VariableLed.js
+++ b/simulator/src/modules/VariableLed.js
@@ -15,7 +15,7 @@ import { changeInputSize } from "../modules";
 import { colors } from "../themer/themer";
 
 export default class VariableLed extends CircuitElement {
-    constructor(x, y, scope = globalScope, color = "Red") {
+    constructor(x, y, scope = globalScope, color = "#ff0000") {
         // Calling base class constructor
 
         super(x, y, scope, "UP", 8);

--- a/simulator/src/ux.js
+++ b/simulator/src/ux.js
@@ -376,8 +376,8 @@ export function showProperties(obj) {
                     $(moduleProperty.modulePropertyInner).append(s);
                 } else if (obj.mutableProperties[attr].type === 'text') {
                     s = `<p><label for="color-picker">${prop.name}</label> <div class='color-picker'style='display: flex; align-items: center;'>
-                    <input class='objectPropertyAttribute' type='text' style='width:1000%;' autocomplete='off' name='${prop.func}' maxlength='${prop.maxlength || 200}' value=${obj[attr]}>
-                    <input class='objectPropertyAttribute' type='color' id='color-picker' style='padding:1px; margin-left:-28px; margin-right:24px; border: none !important;' autocomplete='off' name='${prop.func}' maxlength='${prop.maxlength || 200}' value=${obj[attr]}>
+                    <input class='objectPropertyAttribute' type='text'aria-labelledby="color-picker-label" style='width:1000%;' autocomplete='off' name='${prop.func}' maxlength='${prop.maxlength || 200}' value=${obj[attr]}>
+                    <input class='objectPropertyAttribute' type='color' id='color-picker' aria-label="Color Picker" style='padding:1px; margin-left:-28px; margin-right:24px; border: none !important;' autocomplete='off' name='${prop.func}' maxlength='${prop.maxlength || 200}' value=${obj[attr]}>
                     </div> </p>`;
                     $(moduleProperty.modulePropertyInner).append(s);
                     const colorPicker = document.querySelector('.color-picker input[type=color]');

--- a/simulator/src/ux.js
+++ b/simulator/src/ux.js
@@ -375,13 +375,13 @@ export function showProperties(obj) {
                     s = `<p><span>${prop.name}</span><input class='objectPropertyAttribute' type='number'  name='${prop.func}' min='${prop.min || 0}' max='${prop.max || 200}' value=${obj[attr]}></p>`;
                     $(moduleProperty.modulePropertyInner).append(s);
                 } else if (obj.mutableProperties[attr].type === 'text') {
-                    s = `<p><label for="color-picker">${prop.name}</label> <div class='color-picker' style='position: relative; height:2.5rem; margin-top:-1rem;'>
-                    <input class='objectPropertyAttribute' type='text' aria-labelledby="color-picker-label" style='position: absolute; top:0;' autocomplete='off' name='${prop.func}' maxlength='${prop.maxlength || 200}' value=${obj[attr]}>
-                    <input class='objectPropertyAttribute' type='color' id='color-picker' aria-label="Color Picker" style='position: absolute; right:0; bottom:0px; width: 2.3rem; height:2.3rem; border: none !important;' autocomplete='off' name='${prop.func}' maxlength='${prop.maxlength || 200}' value=${obj[attr]}>
+                    s = `<p><label for="color-picker">${prop.name}</label> <div id='color-picker-container'>
+                    <input class='objectPropertyAttribute' id='color-picker-text' type='text' aria-labelledby="color-picker-label" autocomplete='off' name='${prop.func}' maxlength='${prop.maxlength || 200}' value=${obj[attr]}>
+                    <input class='objectPropertyAttribute' type='color' id='color-picker' aria-label="Color Picker" autocomplete='off' name='${prop.func}' maxlength='${prop.maxlength || 200}' value=${obj[attr]}>
                     </div> </p>`;
                     $(moduleProperty.modulePropertyInner).append(s);
-                    const colorPicker = document.querySelector('.color-picker input[type=color]');
-                    const colorText = document.querySelector('.color-picker input[type=text]');
+                    const colorPicker = document.querySelector('#color-picker-container input[type=color]');
+                    const colorText = document.querySelector('#color-picker-container input[type=text]');
                     colorPicker.addEventListener('input', (e) => {
                         obj.changeColor(e.target.value);
                         colorText.value = e.target.value;

--- a/simulator/src/ux.js
+++ b/simulator/src/ux.js
@@ -376,7 +376,7 @@ export function showProperties(obj) {
                     $(moduleProperty.modulePropertyInner).append(s);
                 } else if (obj.mutableProperties[attr].type === 'text') {
                     s = `<p><label for="color-picker">${prop.name}</label> <div class='color-picker'style='display: flex; align-items: center;'>
-                    <input class='objectPropertyAttribute' type='text'aria-labelledby="color-picker-label" style='width:1000%;' autocomplete='off' name='${prop.func}' maxlength='${prop.maxlength || 200}' value=${obj[attr]}>
+                    <input class='objectPropertyAttribute' type='text' aria-labelledby="color-picker-label" style='width:1000%;' autocomplete='off' name='${prop.func}' maxlength='${prop.maxlength || 200}' value=${obj[attr]}>
                     <input class='objectPropertyAttribute' type='color' id='color-picker' aria-label="Color Picker" style='padding:1px; margin-left:-28px; margin-right:24px; border: none !important;' autocomplete='off' name='${prop.func}' maxlength='${prop.maxlength || 200}' value=${obj[attr]}>
                     </div> </p>`;
                     $(moduleProperty.modulePropertyInner).append(s);

--- a/simulator/src/ux.js
+++ b/simulator/src/ux.js
@@ -375,9 +375,9 @@ export function showProperties(obj) {
                     s = `<p><span>${prop.name}</span><input class='objectPropertyAttribute' type='number'  name='${prop.func}' min='${prop.min || 0}' max='${prop.max || 200}' value=${obj[attr]}></p>`;
                     $(moduleProperty.modulePropertyInner).append(s);
                 } else if (obj.mutableProperties[attr].type === 'text') {
-                    s = `<p><label for="color-picker">${prop.name}</label> <div class='color-picker'style='display: flex; align-items: center;'>
-                    <input class='objectPropertyAttribute' type='text' aria-labelledby="color-picker-label" style='width:1000%;' autocomplete='off' name='${prop.func}' maxlength='${prop.maxlength || 200}' value=${obj[attr]}>
-                    <input class='objectPropertyAttribute' type='color' id='color-picker' aria-label="Color Picker" style='padding:1px; margin-left:-28px; margin-right:24px; border: none !important;' autocomplete='off' name='${prop.func}' maxlength='${prop.maxlength || 200}' value=${obj[attr]}>
+                    s = `<p><label for="color-picker">${prop.name}</label> <div class='color-picker' style='position: relative; height:2.5rem; margin-top:-1rem;'>
+                    <input class='objectPropertyAttribute' type='text' aria-labelledby="color-picker-label" style='position: absolute; top:0;' autocomplete='off' name='${prop.func}' maxlength='${prop.maxlength || 200}' value=${obj[attr]}>
+                    <input class='objectPropertyAttribute' type='color' id='color-picker' aria-label="Color Picker" style='position: absolute; right:0; bottom:0px; width: 2.3rem; height:2.3rem; border: none !important;' autocomplete='off' name='${prop.func}' maxlength='${prop.maxlength || 200}' value=${obj[attr]}>
                     </div> </p>`;
                     $(moduleProperty.modulePropertyInner).append(s);
                     const colorPicker = document.querySelector('.color-picker input[type=color]');

--- a/simulator/src/ux.js
+++ b/simulator/src/ux.js
@@ -375,8 +375,17 @@ export function showProperties(obj) {
                     s = `<p><span>${prop.name}</span><input class='objectPropertyAttribute' type='number'  name='${prop.func}' min='${prop.min || 0}' max='${prop.max || 200}' value=${obj[attr]}></p>`;
                     $(moduleProperty.modulePropertyInner).append(s);
                 } else if (obj.mutableProperties[attr].type === 'text') {
-                    s = `<p><span>${prop.name}</span><input class='objectPropertyAttribute' type='text' autocomplete='off'  name='${prop.func}' maxlength='${prop.maxlength || 200}' value=${obj[attr]}></p>`;
+                    s = `<p><label for="color-picker">${prop.name}</label> <div class='color-picker'style='display: flex; align-items: center;'>
+                    <input class='objectPropertyAttribute' type='text' style='width:1000%;' autocomplete='off' name='${prop.func}' maxlength='${prop.maxlength || 200}' value=${obj[attr]}>
+                    <input class='objectPropertyAttribute' type='color' id='color-picker' style='padding:1px; margin-left:-28px; margin-right:24px; border: none !important;' autocomplete='off' name='${prop.func}' maxlength='${prop.maxlength || 200}' value=${obj[attr]}>
+                    </div> </p>`;
                     $(moduleProperty.modulePropertyInner).append(s);
+                    const colorPicker = document.querySelector('.color-picker input[type=color]');
+                    const colorText = document.querySelector('.color-picker input[type=text]');
+                    colorPicker.addEventListener('input', (e) => {
+                        obj.changeColor(e.target.value);
+                        colorText.value = e.target.value;
+                });
                 } else if (obj.mutableProperties[attr].type === 'button') {
                     s = `<p class='btn-parent'><button class='objectPropertyAttribute btn custom-btn--secondary' type='button'  name='${prop.func}'>${prop.name}</button></p>`;
                     $(moduleProperty.modulePropertyInner).append(s);


### PR DESCRIPTION

Fixes  [#4866](https://github.com/CircuitVerse/CircuitVerse/issues/4688)
Added Color Picker Tool
#### Describe the changes you have made in this PR -
This PR introduces a new color picker tool feature for DigitalLed ToolTip,Variable Led ToolTip,HexDisplay,SevenSegment Display,Sixteen Segment Display . It adds a color picker input field alongside the existing text input field. The color picker allows users to select a color value, which updates both the color picker input and the text input field. This change enhances the user experience by providing a visual color selection method.

### Screenshots of the changes (If any) -
<img width="1680" alt="Screenshot 2024-03-24 at 1 09 49 AM" src="https://github.com/CircuitVerse/CircuitVerse/assets/96644946/1b483d5f-edaf-44b2-ab7f-71aff77c13d3">


https://github.com/CircuitVerse/CircuitVerse/assets/96644946/c2db99c5-b168-4f48-bcf9-0a50208a4a10



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
