### PR TITLE
Refactor: removed triggered function which is being execute twice

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -48,12 +48,6 @@ class Project < ApplicationRecord
     }
   }
 
-  trigger.before(:insert, :update) do
-    "tsvector_update_trigger(
-        searchable, 'pg_catalog.english', description, name
-      );"
-  end
-
   searchable do
     text :name
 


### PR DESCRIPTION
Fixes #4817

#### Describe the changes you have made in this PR -
function for populating the searchable column with `tsvector` is called twice, one is invoked from the postgresql ([migration file](https://github.com/CircuitVerse/CircuitVerse/blob/efa65c5282f6608e309732ba42addfc0af1ef246/db/migrate/20210418095236_create_trigger_projects_insert_update.rb#L11)), and other from the projects.rb model file

So the trigger function from the model file can be removed, and this can improve performance keeping resources free for db write operation.

### Screenshots of the changes (If any) -
https://github.com/CircuitVerse/CircuitVerse/assets/86405648/0433dd70-9724-416e-abc4-544c90454b06


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
