### PR TITLE
[Simulator] Make data save functions read only

### DIFF
--- a/simulator/src/data/backupCircuit.js
+++ b/simulator/src/data/backupCircuit.js
@@ -17,9 +17,6 @@ export function checkIfBackup(scope) {
 }
 
 export function backUp(scope = globalScope) {
-    // Disconnection of subcircuits are needed because these are the connections between nodes
-    // in current scope and those in the subcircuit's scope
-    for (let i = 0; i < scope.SubCircuit.length; i++) { scope.SubCircuit[i].removeConnections(); }
 
     var data = {};
 
@@ -50,9 +47,6 @@ export function backUp(scope = globalScope) {
     // Storing intermediate nodes (nodes in wires)
     data.nodes = [];
     for (let i = 0; i < scope.nodes.length; i++) { data.nodes.push(scope.allNodes.indexOf(scope.nodes[i])); }
-
-    // Restoring the connections
-    for (let i = 0; i < scope.SubCircuit.length; i++) { scope.SubCircuit[i].makeConnections(); }
 
     return data;
 }

--- a/simulator/src/data/save.js
+++ b/simulator/src/data/save.js
@@ -104,7 +104,12 @@ export function generateSaveData(name, setName = true) {
         }
 
         completed[id] = true;
-        update(scopeList[id]); // For any pending integrity checks on subcircuits
+
+        // Removed: no such check is required. saveScope should be strictly read only and
+        // should not change state
+        // update might change state.
+        
+        // update(scopeList[id]); // For any pending integrity checks on subcircuits
         data.scopes.push(backUp(scopeList[id]));
     }
 

--- a/simulator/src/node.js
+++ b/simulator/src/node.js
@@ -237,6 +237,9 @@ export default class Node {
             connections: [],
         };
         for (var i = 0; i < this.connections.length; i++) {
+            // For connections from scope.Subcircuit.node to localscope.input/output.node
+            // these connections should be ignored while saving.
+            if (this.connections[i].scope != this.scope) continue;
             data.connections.push(findNode(this.connections[i]));
         }
         return data;


### PR DESCRIPTION
Instead of calling removeConnections, we now simply ignore cross-scope connections.

Remove redundant call to update

The save functions should be strictly read-only and should not change the state of the simulator. This is especially important given the existence of auto-save. We don't want simulator state to change every 3 seconds when auto-save is called even when the user did not change the state.

For most circuits this is not a problem, but for some circuits where a section of the circuit has multiple legal values, the circuit should not change to the other legal value without a driving signal. But a force-reset update might cause such a state change. Earlier such an update call was a part of the save flow and was called with autosave(), this should not be a problem after this commit.

This change is expected to be back compatible with all circuits.

This is a proper fix for #4794 
