### PR TITLE
fix: Error after clicking "start working btn" twice

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -29,13 +29,18 @@ class AssignmentsController < ApplicationController
 
   def start
     authorize @assignment
-    @project = current_user.projects.new
-    @project.name = "#{current_user.name}/#{@assignment.name}"
-    @project.assignment_id = @assignment.id
-    @project.project_access_type = "Private"
-    @project.build_project_datum
-    @project.save
-    redirect_to user_project_path(current_user, @project)
+    existing_project = @assignment.projects.find_by(author_id:current_user)
+    if existing_project
+      redirect_to user_project_path(current_user, existing_project)
+    else
+      @project = current_user.projects.new
+      @project.name = "#{current_user.name}/#{@assignment.name}"
+      @project.assignment_id = @assignment.id
+      @project.project_access_type = "Private"
+      @project.build_project_datum
+      @project.save
+      redirect_to user_project_path(current_user, @project)
+    end
   end
 
   # GET /assignments/new

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -29,7 +29,7 @@ class AssignmentsController < ApplicationController
 
   def start
     authorize @assignment
-    existing_project = @assignment.projects.find_by(author_id:current_user)
+    existing_project = @assignment.projects.find_by(author_id: current_user)
     if existing_project
       redirect_to user_project_path(current_user, existing_project)
     else

--- a/app/policies/assignment_policy.rb
+++ b/app/policies/assignment_policy.rb
@@ -23,9 +23,8 @@ class AssignmentPolicy < ApplicationPolicy
   end
 
   def start?
-    # assignment should not be closed and not submitted
-    assignment.status != "closed" \
-      && !Project.exists?(author_id: user.id, assignment_id: assignment.id)
+    # assignment should not be closed
+    assignment.status != "closed"
   end
 
   def edit?


### PR DESCRIPTION
Fixes #4823 

#### Describe the changes you have made in this PR -

1. Previously, when a user tried to start working on an assignment and there was already an existing project associated with it, it would show an authorization error message.
2. To resolve this, I removed the authorization check from the `start` action of assignment policies, meaning that authorization is no longer enforced at this point.
3. Instead, I added a condition in the `start` action of the assignment controller. If an existing project is associated with the assignment, the user will be redirected to that project. If not, a new project is created for the user to start working on.

### Screenshots of the changes (If any) -

https://github.com/CircuitVerse/CircuitVerse/assets/105718863/9428fd0d-9d31-4984-a489-6b3bb35b25e5

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 