### PR TITLE
Reset nodes on contention

### DIFF
--- a/simulator/src/engine.js
+++ b/simulator/src/engine.js
@@ -410,14 +410,15 @@ export function play(scope = globalScope, resetNodes = false) {
             forceResetNodesSet(true);
         }
     }
-    // Check for TriState Contentions
+    // Check for Contentions
     if (simulationArea.contentionPending.size() > 0) {
         for (const [ourNode, theirNode] of simulationArea.contentionPending.nodes()) {
             ourNode.highlighted = true;
             theirNode.highlighted = true;
         }
 
-        showError('Contention Error: One or more bus contentions in the circuit');
+        forceResetNodesSet(true);
+        showError('Contention Error: One or more bus contentions in the circuit (check highlighted nodes)');
     }
 }
 


### PR DESCRIPTION
Since contention does a 'partial' resolution of the circuit, the circuit resolution after contention will likely exit early because the Input elements' output node value will be unchanged, therefore might never re-resolve the contended nodes. So it's necessary to force reset nodes.

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
