### PR TITLE
Fix: SubCircuit i/o nodes not consistent with localscope i/o nodes

### DIFF
--- a/simulator/src/data/save.js
+++ b/simulator/src/data/save.js
@@ -1,6 +1,6 @@
 import { scopeList } from '../circuit';
 import { resetup } from '../setup';
-import { update } from '../engine';
+import { update, updateSubcircuitSet } from '../engine';
 import { stripTags, showMessage } from '../utils';
 import { backUp } from './backupCircuit';
 import simulationArea from '../simulationArea';
@@ -105,11 +105,14 @@ export function generateSaveData(name, setName = true) {
 
         completed[id] = true;
 
-        // Removed: no such check is required. saveScope should be strictly read only and
-        // should not change state
-        // update might change state.
-        
-        // update(scopeList[id]); // For any pending integrity checks on subcircuits
+
+        // This update is very important.
+        // if a scope's input/output changes and the user saves without going
+        // to circuits where this circuit is used as a subcircuit. It will
+        // break the code since the Subcircuit will have different number of
+        // in/out nodes compared to the localscope input/output objects.
+        updateSubcircuitSet(true);
+        update(scopeList[id]); // For any pending integrity checks on subcircuits
         data.scopes.push(backUp(scopeList[id]));
     }
 

--- a/simulator/src/node.js
+++ b/simulator/src/node.js
@@ -40,6 +40,7 @@ export function replace(node, index) {
     node.parent = parent;
     parent.nodeList.push(node);
     node.updateRotation();
+    node.scope.timeStamp = new Date().getTime();
     return node;
 }
 function rotate(x1, y1, dir) {
@@ -161,6 +162,7 @@ export default class Node {
         this.hover = false;
         this.wasClicked = false;
         this.scope = this.parent.scope;
+        this.scope.timeStamp = new Date().getTime();
         /**
         * @type {string}
         * value of this.prev is
@@ -265,6 +267,7 @@ export default class Node {
         for (var i = 0; i < this.connections.length; i++) {
             this.connections[i].connections.clean(this);
         }
+        this.scope.timeStamp = new Date().getTime();
         this.connections = [];
     }
 
@@ -315,6 +318,8 @@ export default class Node {
         this.connections.push(n);
         n.connections.push(this);
 
+        this.scope.timeStamp = new Date().getTime();
+
         updateCanvasSet(true);
         updateSimulationSet(true);
         scheduleUpdate();
@@ -329,7 +334,9 @@ export default class Node {
         this.connections.push(n);
         n.connections.push(this);
 
-        updateCanvasSet(true);
+        this.scope.timeStamp = new Date().getTime();
+
+        // updateCanvasSet(true);
         updateSimulationSet(true);
         scheduleUpdate();
     }
@@ -340,6 +347,8 @@ export default class Node {
     disconnectWireLess(n) {
         this.connections.clean(n);
         n.connections.clean(this);
+
+        this.scope.timeStamp = new Date().getTime();
     }
 
     /**
@@ -734,6 +743,9 @@ export default class Node {
             this.connections[i].connections.clean(this);
             this.connections[i].checkDeleted();
         }
+
+        this.scope.timeStamp = new Date().getTime();
+
         wireToBeCheckedSet(1);
         forceResetNodesSet(true);
         scheduleUpdate();

--- a/simulator/src/subcircuit.js
+++ b/simulator/src/subcircuit.js
@@ -298,7 +298,8 @@ export default class SubCircuit extends CircuitElement {
     }
 
     /**
-     * rebuilds the subcircuit if any change to localscope is made
+     * If the circuit referenced by localscope is changed, then the localscope
+     * needs to be updated. This function does that.
      */
     reBuildCircuit() {
         this.data = JSON.parse(scheduleBackup(scopeList[this.id]));
@@ -467,15 +468,13 @@ export default class SubCircuit extends CircuitElement {
                 this.outputNodes.push(a);
             }
         }
-
+        // console.log(subcircuitScope.name, subcircuitScope.timeStamp, this.lastUpdated)
         if (subcircuitScope.timeStamp > this.lastUpdated) {
             this.reBuildCircuit();
-        }
-
-        // Should this be done here or only when this.reBuildCircuit() is called?
-        {
+            // console.log("rebuild called")
             this.localScope.reset();
             updateSimulationSet(true);
+            // Why is forceResetNodes required here?
             forceResetNodesSet(true);
         }
 

--- a/simulator/src/wire.js
+++ b/simulator/src/wire.js
@@ -171,5 +171,7 @@ export default class Wire {
         this.scope.wires.clean(this);
         this.node1.checkDeleted();
         this.node2.checkDeleted();
+
+        this.scope.timeStamp = new Date().getTime();
     }
 }


### PR DESCRIPTION
SC - SubCircuit

The update() call was reinstated since it remakes the subcircuit (and localscope) just before saving. It is important because it makes sure that SC's i/o is consistent with localscope's i/o (see comment) and localscope is consistent with it's referenced actual scope.

We call rebuildCircuit() (thru update) while saving to rebuild SC's localscope. This function is ONLY called if SC's localscope's actual circuit's lastUpdated timestamp is after subcircuit's last updated timestamp. Which means that circuit has changed and SC's localscope is stale. So localscope is updated.

Another issue was that any scope's timstamp was only updating during scheduleBackup(). schedBackup() is called at certain time intervals and user might save circuit after making a change before a scheduleUpdate is called and so the subcircuit will be saved with a stale localscope.

Now we update the timestamp with every node operation.


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
