### PR TITLE
Disable autosave

### DIFF
--- a/simulator/src/data/backupCircuit.js
+++ b/simulator/src/data/backupCircuit.js
@@ -18,6 +18,10 @@ export function checkIfBackup(scope) {
 
 export function backUp(scope = globalScope) {
 
+    // Disconnection of subcircuits are needed because these are the connections between nodes
+    // in current scope and those in the subcircuit's scope
+    for (let i = 0; i < scope.SubCircuit.length; i++) { scope.SubCircuit[i].removeConnections(); }
+
     var data = {};
 
     // Storing layout
@@ -47,6 +51,9 @@ export function backUp(scope = globalScope) {
     // Storing intermediate nodes (nodes in wires)
     data.nodes = [];
     for (let i = 0; i < scope.nodes.length; i++) { data.nodes.push(scope.allNodes.indexOf(scope.nodes[i])); }
+
+    // Restoring the connections
+    for (let i = 0; i < scope.SubCircuit.length; i++) { scope.SubCircuit[i].makeConnections(); }
 
     return data;
 }

--- a/simulator/src/data/save.js
+++ b/simulator/src/data/save.js
@@ -111,8 +111,7 @@ export function generateSaveData(name, setName = true) {
         // to circuits where this circuit is used as a subcircuit. It will
         // break the code since the Subcircuit will have different number of
         // in/out nodes compared to the localscope input/output objects.
-        updateSubcircuitSet(true);
-        update(scopeList[id]); // For any pending integrity checks on subcircuits
+        update(scopeList[id], true); // For any pending integrity checks on subcircuits
         data.scopes.push(backUp(scopeList[id]));
     }
 
@@ -435,4 +434,6 @@ export function checkBackups() {
     }
 }
 
-setInterval(checkBackups, 3000);
+// Please do not enable autosave. It will not work
+// in the current state and breaks other things.
+// setInterval(checkBackups, 3000); // disabled

--- a/simulator/src/node.js
+++ b/simulator/src/node.js
@@ -240,9 +240,7 @@ export default class Node {
             connections: [],
         };
         for (var i = 0; i < this.connections.length; i++) {
-            // For connections from scope.Subcircuit.node to localscope.input/output.node
-            // these connections should be ignored while saving.
-            if (this.connections[i].scope != this.scope) continue;
+
             data.connections.push(findNode(this.connections[i]));
         }
         return data;

--- a/simulator/src/subcircuit.js
+++ b/simulator/src/subcircuit.js
@@ -471,12 +471,11 @@ export default class SubCircuit extends CircuitElement {
         // console.log(subcircuitScope.name, subcircuitScope.timeStamp, this.lastUpdated)
         if (subcircuitScope.timeStamp > this.lastUpdated) {
             this.reBuildCircuit();
-            // console.log("rebuild called")
-            this.localScope.reset();
-            updateSimulationSet(true);
-            // Why is forceResetNodes required here?
-            forceResetNodesSet(true);
         }
+
+        this.localScope.reset();
+        updateSimulationSet(true);
+        forceResetNodesSet(true);
 
         this.makeConnections();
     }


### PR DESCRIPTION
Not worth the problems it causes

Autosave calls generateSaveData. This function is not read only and cannot be read only. and causes flickering and multiple other problems when called so frequently.


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
