### PR TITLE
bug: Fixed notification when the user or project is deleted 

### DIFF
--- a/app/models/deleted_objects.rb
+++ b/app/models/deleted_objects.rb
@@ -1,0 +1,14 @@
+# app/models/null_objects.rb
+
+class DeletedUser
+    def name
+      "Deleted User"
+    end
+  end
+  
+  class DeletedProject
+    def name
+      "Deleted Project"
+    end
+  end
+  

--- a/app/notifications/fork_notification.rb
+++ b/app/notifications/fork_notification.rb
@@ -4,8 +4,8 @@ class ForkNotification < Noticed::Base
   deliver_by :database, association: :noticed_notifications
 
   def message
-    user = params[:user]
-    project = params[:project]
+    user = params[:user] || DeletedUser.new
+    project = params[:project] || DeletedProject.new
     t("users.notifications.fork_notification", user: user.name, project: project.name)
   end
 


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -
I deleted the old part of code and  implemented the null object pattern in ForkNotification class.

I added a file (deleted_objects.rb) where i  defined the null objects: deleted user and deleted project.

### Screenshots of the changes (If any) -



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
