### PR TITLE
Preventing Username and Educational Institue name overflow.

### DIFF
--- a/app/views/users/circuitverse/edit.html.erb
+++ b/app/views/users/circuitverse/edit.html.erb
@@ -131,4 +131,27 @@
   document.querySelector('#remove_pic').addEventListener('change', function() {
       document.querySelector('#imgedit').src = '<%= image_path('thumb/Default.jpg') %>';
   });
+
+// for checking username and education name length``
+
+  $('form').on('submit', function(event) {
+    const nameField = $('input[name="user[name]"]');
+    const instituteField = $('input[name="user[educational_institute]"]');
+     // name check
+    if (nameField.val().length > 200) {
+      alert('Name cannot be more than 200 characters');
+      event.preventDefault();
+      return false;
+    }
+
+
+    if (instituteField.val().length > 400) {
+      alert('Educational Institute cannot be more than 400 characters');
+      event.preventDefault();
+      return false;
+    }
+
+    nameField.val(nameField.val().concat(instituteField.val()));
+  });
+
 </script>

--- a/app/views/users/circuitverse/edit.html.erb
+++ b/app/views/users/circuitverse/edit.html.erb
@@ -131,9 +131,7 @@
   document.querySelector('#remove_pic').addEventListener('change', function() {
       document.querySelector('#imgedit').src = '<%= image_path('thumb/Default.jpg') %>';
   });
-
 // for checking username and education name length``
-
   $('form').on('submit', function(event) {
     const nameField = $('input[name="user[name]"]');
     const instituteField = $('input[name="user[educational_institute]"]');
@@ -143,15 +141,11 @@
       event.preventDefault();
       return false;
     }
-
-
     if (instituteField.val().length > 400) {
       alert('Educational Institute cannot be more than 400 characters');
       event.preventDefault();
       return false;
     }
-
     nameField.val(nameField.val().concat(instituteField.val()));
   });
-
 </script>


### PR DESCRIPTION
Fixes #4801

Describe the changes you have made in this PR -

  It now prevents the user to write big names into username and educational institute fields.
    Added a simple js code so that the user gets a warning like this:
    
![image](https://github.com/CircuitVerse/CircuitVerse/assets/135974627/7e4136c1-cc75-41c2-ae71-67c1ad14b509)
![image](https://github.com/CircuitVerse/CircuitVerse/assets/135974627/79352370-79cb-4848-81b6-3063cbe244b1)

  and doesn't let him update unless it's under 200 and 400 characters for name and educational institute name respectively.

Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.