### PR TITLE
Notification issue Fixed

### DIFF
--- a/app/notifications/fork_notification.rb
+++ b/app/notifications/fork_notification.rb
@@ -4,8 +4,8 @@ class ForkNotification < Noticed::Base
   deliver_by :database, association: :noticed_notifications
 
   def message
-    user = params[:user]
-    project = params[:project]
+    user = params[:user] || DeletedUser.new
+    project = params[:project] || DeletedProject.new
     t("users.notifications.fork_notification", user: user&.name, project: project&.name)
   end
 


### PR DESCRIPTION
This pull request addresses an issue related to notifications failing to display correctly when a project is deleted. Currently, the notification system encounters errors when attempting to retrieve information about the user or project associated with a notification after deletion. This disruption can lead to inconsistencies and unexpected behavior in the application.

To mitigate this issue, I've implemented the null object pattern within the ForkNotification class. This pattern ensures that even if the project or user associated with a notification is deleted, the notification system can generate a message without encountering errors. Specifically, I've introduced DeletedUser and DeletedProject classes to represent deleted entities, allowing the notification system to handle such cases gracefully.

![Screenshot 2024-06-10 155540](https://github.com/CircuitVerse/CircuitVerse/assets/123581868/94969c55-fa1d-44e3-93d2-79ece96f2f04)

![Screenshot 2024-06-10 155709](https://github.com/CircuitVerse/CircuitVerse/assets/123581868/2042e70e-c626-41cf-9579-01d29d504a4c)

https://github.com/CircuitVerse/CircuitVerse/issues/4904


