### PR TITLE
feat: add version column to projects table

### DIFF
--- a/db/migrate/20240629135159_add_version_to_projects.rb
+++ b/db/migrate/20240629135159_add_version_to_projects.rb
@@ -1,0 +1,5 @@
+class AddVersionToProjects < ActiveRecord::Migration[7.0]
+  def change
+    add_column :projects, :version, :string, default: "v0", null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_25_140331) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_29_135159) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -366,6 +366,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_25_140331) do
     t.string "slug"
     t.tsvector "searchable"
     t.string "lis_result_sourced_id"
+    t.string "version", default: "v0", null: false
     t.index ["assignment_id"], name: "index_projects_on_assignment_id"
     t.index ["author_id"], name: "index_projects_on_author_id"
     t.index ["forked_project_id"], name: "index_projects_on_forked_project_id"


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -

 - Migration adding a `version` column to `projects` table. (with default value as `v0`)




Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
