### PR TITLE
feat: slack notification in specific channel on new thread

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ GITHUB_CLIENT_SECRET=<github-client-secret>
 GITLAB_CLIENT_ID=<gitlab-client-id>
 GITLAB_CLIENT_SECRET=<gitlab-client-secret>
 SLACK_ISSUE_HOOK_URL=<Slack-hook-url>
+SLACK_NOTIFY_HOOK_URL=<Slack-notify-hook-url>
 BUGSNAG_API_KEY=''
 RECAPTCHA_SITE_KEY=<google-recaptcha-site-key>
 RECAPTCHA_SECRET_KEY=<google-recaptcha-secret-key>

--- a/app/notifications/forum_thread_notification.rb
+++ b/app/notifications/forum_thread_notification.rb
@@ -2,6 +2,7 @@
 
 class ForumThreadNotification < Noticed::Base
   deliver_by :database, association: :noticed_notifications
+  deliver_by :slack, format: :slack_message, url: :slack_webhook_url
 
   def message
     user = params[:user]
@@ -12,4 +13,20 @@ class ForumThreadNotification < Noticed::Base
   def icon
     "far fa-comments"
   end
+
+  def slack_message
+    {
+      text: "*New Forum Thread Notification*\n<#{generate_forum_thread_link(params[:forum_thread])}|#{params[:forum_thread].title}> *by*: #{params[:user].name}"
+    }
+  end
+
+  def slack_webhook_url
+    ENV.fetch("SLACK_NOTIFY_HOOK_URL", nil)
+  end
+
+  private
+
+    def generate_forum_thread_link(forum_thread)
+      "https://circuitverse.org/forum/threads/#{forum_thread.slug}"
+    end
 end


### PR DESCRIPTION
Fixes #5004 

#### Describe the changes you have made in this PR -
This PR introduces a feature that automatically posts a notification in our public Slack channel whenever a new forum thread is created.

### Screenshots of the changes (If any) -
![image](https://github.com/CircuitVerse/CircuitVerse/assets/86405648/e61b4703-7752-4a72-ba95-77ef75e29225)



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
