### PR TITLE
Fix footer movement issue when switching read/unread notifications

### DIFF
--- a/app/views/users/noticed_notifications/index.html.erb
+++ b/app/views/users/noticed_notifications/index.html.erb
@@ -46,7 +46,7 @@
       </div>
     <% end %>
   </div>
-  <div id="unread-notifications-div" class="d-none flex-column bd-highlight mb-3 mt-3 notifications_container">
+  <div id="unread-notifications-div" class="d-none flex-column bd-highlight mb-11 mt-3 notifications_container">
     <% @unread.each do |notification| %>
       <% if notification.unread? %>
         <%= link_to mark_as_read_path(id: current_user, notification_id: notification.id), method: :post, class: "mb-2 mt-2 notification" do %>


### PR DESCRIPTION
Fixes #4535

#### Describe the changes you have made in this PR -
I have modified the margin-bottom class from mb-3 to mb-11 for the <div> element with the ID unread-notifications-div. This change was made to ensure that the footer remains in a consistent position when switching between read and unread notifications, regardless of the message count.


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
