### PR TITLE
feat: remove recent circuits section

### DIFF
--- a/app/controllers/circuitverse_controller.rb
+++ b/app/controllers/circuitverse_controller.rb
@@ -4,20 +4,6 @@ class CircuitverseController < ApplicationController
   MAXIMUM_FEATURED_CIRCUITS = 3
 
   def index
-    @projects = Project.select(:id, :author_id, :image_preview, :name, :slug)
-                       .public_and_not_forked
-                       .where.not(image_preview: "default.png")
-                       .order(id: :desc)
-                       .includes(:author)
-                       .limit(Project.per_page)
-
-    page = params[:page].to_i
-    @projects = if page.positive?
-      @projects.paginate(page: page)
-    else
-      @projects.paginate(page: nil)
-    end
-
     @featured_circuits = Project.joins(:featured_circuit)
                                 .order("featured_circuits.created_at DESC")
                                 .includes(:author)

--- a/app/views/circuitverse/index.html.erb
+++ b/app/views/circuitverse/index.html.erb
@@ -192,35 +192,6 @@
         </div>
       </div>
     </div>
-    <% cache "recent-projects-#{params[:page]}", expires_in: 10.minutes do %>
-      <div class="container" id="recent">
-        <div class="row center-row home-circuit-card-row">
-          <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
-            <h3><%= t("circuitverse.index.recent_circuits.main_heading") %></h3>
-            <p><%= t("circuitverse.index.recent_circuits.main_description") %></p>
-          </div>
-        </div>
-        <div class="row center-row justify-content-center">
-          <% @projects.each do |project| %>
-            <div class="col-xs-12 col-sm-12 col-md-6 col-lg-4">
-              <div class="card circuit-card">
-                <%= image_tag project_image_preview(project, current_user), alt: project.name, class: "card-img-top circuit-card-image" %>
-                <div class="card-footer circuit-card-footer">
-                  <div class="circuit-card-name">
-                    <p><%= project.name %></p>
-                    <span class="tooltiptext"><%= project.name %></span>
-                  </div>
-                  <a class="btn primary-button circuit-card-primary-button" target="_blank" href="<%= user_project_url(project.author, project) %>"><%= t("view") %></a>
-                </div>
-              </div>
-            </div>
-          <% end %>
-        </div>
-        <div class="container pagination-cont">
-          <%= will_paginate @projects, renderer: PaginateRenderer, page_links: false %>
-        </div>
-      </div>
-    <% end %>
 
     <% if user_signed_in? %>
     <script>


### PR DESCRIPTION
Fixes #4953 

#### Describe the changes you have made in this PR -

- Remove"Recent Circuits on Landing Page "due to decreased relevance caused by a high volume of new circuits
per hour from `app/views/circuitverse/index.html.erb`
- update the `circuitverse_controller.rb` as there is no requirement of fetching all the projects from the database.

### Screenshots of the changes (If any) -



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The index page now highlights featured circuits prominently.
  
- **Removed Features**
	- The "Recent Projects" section has been removed from the index page, eliminating project visibility and pagination controls. 

These changes may significantly impact how users interact with the CircuitVerse platform, focusing more on featured content while omitting recent project details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->