### PR TITLE
fix: changing redirect link in the buttons for vue simulator circuits

### DIFF
--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -100,7 +100,14 @@
             <p>
               <hr class="projects-horizontal-rule">
               <% if policy(@project).user_access? %>
-                <a href="<%= simulator_edit_path(@project) %>" class="btn primary-button projects-primary-button" target="_blank" rel="noopener noreferrer"><%= t("launch_simulator") %></a>
+                <% if @project.project_datum && @project.project_datum.data["simulatorVersion"].present? %>
+                  <% simulator_version = JSON.parse(@project.project_datum.data)["simulatorVersion"] %>
+                  <a href="<%= simulatorvue_path("edit/" + @project.id.to_s) %>?simver=<%= simulator_version %>" class="btn primary-button projects-primary-button" target="_blank" rel="noopener noreferrer">
+                    <%= t("launch_simulator") %>
+                  </a>
+                <% else %>
+                  <a href="<%= simulator_edit_path(@project) %>" class="btn primary-button projects-primary-button" target="_blank" rel="noopener noreferrer"><%= t("launch_simulator") %></a>
+                <% end %>
               <% else %>
                 <a class="btn primary-button projects-self-embed-button" class="embed-trigger" href="#" data-target="#embedProjectCircuit" data-toggle="modal">
                 <i class="fas fa-code"></i>

--- a/app/views/users/circuitverse/_dashboard.html.erb
+++ b/app/views/users/circuitverse/_dashboard.html.erb
@@ -19,7 +19,14 @@
         </div>
         <div class="card-footer users-card-footer">
           <% if policy(project).user_access? %>
-            <a href="<%= simulator_edit_path(project) %>" class="btn primary-button" target="_blank"><%= t("launch") %></a>
+            <% if project.project_datum && project.project_datum.data["simulatorVersion"].present? %>
+                <% simulator_version = JSON.parse(project.project_datum.data)["simulatorVersion"] %>
+                  <a href="<%= simulatorvue_path("edit/" + project.id.to_s) %>?simver=<%= simulator_version %>" class="btn primary-button" target="_blank">
+                    <%= t("launch") %>
+                  </a>
+            <% else %>
+              <a href="<%= simulator_edit_path(project) %>" class="btn primary-button" target="_blank"><%= t("launch") %></a>
+            <% end %>            
           <% else %>
               <%= link_to create_fork_project_path(project), class: "btn primary-button", target: "_blank", method: :post, rel: "noopener" do %>
               <span><%= t("fork") %></span>


### PR DESCRIPTION
Fixes #5057 

#### Describe the changes you have made in this PR -

- Updated the "Launch Simulator" button links: they now redirect to `simulatorvue_edit_path` if the `simulatorVersion` is present in the circuit_data; otherwise, they use `simulator_edit_path`
-  This change also applies to the dashboard's "Launch Simulator" button.

### Screenshots of the changes (If any) -



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
