### PR TITLE
fix color of announcements 'learn more' button and link

### DIFF
--- a/app/assets/stylesheets/announcements.scss
+++ b/app/assets/stylesheets/announcements.scss
@@ -19,7 +19,7 @@
   }
 
   a {
-    background: $secondary-red;
+    background: $primary-red;
   }
 }
 


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -

Changed the background color of links which are inside of the announcements panel
secondary-red hides the color change on hover effect applied on the button and looks bad on normal links also
So changed it to primary-red which is more subtle and the button now changes color on hovering


### Screenshots of the changes (If any) -

Before change:-

![Screenshot from 2024-09-16 18-21-21](https://github.com/user-attachments/assets/f4d62ad6-6ee0-488c-81ba-945cbdaa01c9)

After change:-

![Screenshot from 2024-09-16 18-28-37](https://github.com/user-attachments/assets/db0d2d19-67de-4423-a047-76fad6a61c60)
[Screencast from 2024-09-16 18-28-43.webm](https://github.com/user-attachments/assets/d3c15b25-484f-4d77-a660-09270741c6c5)


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 


This is my first PR ever on github so happy to hear your feedback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the background color of anchor elements in the announcements section to enhance visual presentation and user interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->