### PR TITLE
fix(CI): update CI configuration to use docker compose instead of docker-compose

### DIFF
--- a/.github/workflows/codespaces.yml
+++ b/.github/workflows/codespaces.yml
@@ -26,4 +26,4 @@ jobs:
         run: jq . < .devcontainer/devcontainer.json
 
       - name: Validate docker-compose.yml
-        run: docker-compose -f .devcontainer/docker-compose.yml config
+        run: docker compose -f .devcontainer/docker-compose.yml config


### PR DESCRIPTION
#### This PR fixes an issue in the CI configuration where the outdated `docker-compose` command was used. The command has been replaced with `docker compose`, which is the newer syntax supported by Docker.

### Changes:
- Replaced `docker-compose` with `docker compose` in the CI configuration file.

### Issue:
Previously, the test used to fail as shown in this screenshot:

![Screenshot from 2024-09-22 20-12-08](https://github.com/user-attachments/assets/a62d46a2-7673-4423-b8d6-1928868807f6)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the command for validating the `docker-compose.yml` file in the GitHub Actions workflow.
	- Changed the subproject commit reference to a newer version, ensuring the latest updates are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->