### PR TITLE
Limit user name and institute display to a single line

### DIFF
--- a/app/views/users/circuitverse/index.html.erb
+++ b/app/views/users/circuitverse/index.html.erb
@@ -38,12 +38,14 @@
         </div>
       </div>
       <div class="col-xs-12 col-sm-12 col-md-7 col-lg-7">
-        <h4 class="users-user-name"><%= @profile.name %></h4>
+        <h4 class="users-user-name">
+          <%= truncate(@profile.name, length: 15, separator: ' ') %>
+        </h4>
         <div class="search-userdetails-container">
           <p class="search-user-details-text"><%= t("users.circuitverse.member_since_html", member_since: @profile.member_since) %></p>
           <p class="search-user-details-text">
             <% if @profile.educational_institute.present? %>
-              <%= t("users.circuitverse.educational_institutes_html", educational_institute: @profile.educational_institute) %>
+              <%= t("users.circuitverse.educational_institutes_html", educational_institute: truncate(@profile.educational_institute, length: 50, separator: ' ')) %>
             <% else %>
               <%= t("users.circuitverse.educational_institutes_html", educational_institute: t("not_entered")) %>
             <% end %>


### PR DESCRIPTION
Fixes #4801 

This PR addresses Issue #4801 related to the display of user names and educational institutes on CircuitVerse. Currently, long names or institutes can span multiple lines, affecting the layout and user interface. Instead of setting a word limit which wouldn't be feasible for existing users, the frontend has been tweaked to:

Changes Made:
Modified the frontend code to ensure names and institutes fit on a single line.
Implemented an ellipsis for text overflow in cases where the content exceeds one line.
No word limit has been applied, as it could cause issues for previous users with existing long names.



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- User names are now truncated to a maximum of 15 characters for improved display.
	- Educational institute names are truncated to 50 characters, with a default message shown if not provided.

- **Bug Fixes**
	- Enhanced presentation of user details without altering existing functionality or layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->