### PR TITLE
Set disabled tristate's output value downstream when contention exists

### DIFF
--- a/simulator/src/modules/TriState.js
+++ b/simulator/src/modules/TriState.js
@@ -82,6 +82,8 @@ export default class TriState extends CircuitElement {
             this.output1.value = undefined;
             simulationArea.simulationQueue.add(this.output1);
             this.setOutputsUpstream(false);
+        } else {
+            this.setOutputsUpstream(false);
         }
         simulationArea.contentionPending.removeAllContentionsForNode(this.output1);
     }


### PR DESCRIPTION
Fixes unnecessary [temporary] contention in https://circuitverse.org/users/3/projects/67

#### Describe the changes you have made in this PR -

### Screenshots of the changes (If any) -



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved output resolution logic in the simulation, ensuring consistent management of output states.
  
- **Documentation**
	- Updated comments for clarity and enhanced documentation of constructor parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->