### PR TITLE
Update omniauth_callbacks_controller.rb to Alert Users if Login Fails Due to Private Email

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -51,16 +51,21 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   def generic_callback(provider)
-    @user = User.from_omniauth(request.env["omniauth.auth"])
-    if @user.persisted?
-      sign_in_and_redirect @user, event: :authentication
-      set_flash_message(:notice, :success, kind: provider.capitalize) if is_navigational_format?
-    elsif Flipper.enabled?(:block_registration)
-      redirect_to new_user_session_path, alert: t("registration_blocked")
+  @user = User.from_omniauth(request.env["omniauth.auth"])
+  if @user.persisted?
+    sign_in_and_redirect @user, event: :authentication
+    set_flash_message(:notice, :success, kind: provider.capitalize) if is_navigational_format?
+  elsif Flipper.enabled?(:block_registration)
+    redirect_to new_user_session_path, alert: t("registration_blocked")
+  else
+    session["devise.#{provider}_data"] = request.env["omniauth.auth"].except(:extra).except("extra")
+    
+    # Check if the email is private and show a flash message
+    if request.env["omniauth.auth"].info.email.blank?
+      redirect_to new_user_registration_url, alert: "It seems your GitHub email is private. Please sign up manually or make your email public to continue."
     else
-      session["devise.#{provider}_data"] =
-        request.env["omniauth.auth"].except(:extra).except("extra")
       redirect_to new_user_registration_url
     end
   end
 end
+


### PR DESCRIPTION
####  Description

This PR addresses an issue where user creation fails during OAuth login (specifically GitHub) if the user's email is set to private. The following changes were made:

Added logic to check if the user's email is missing from the authentication response (due to private email).
Added a flash message to alert users that the login failed due to a private email, and provided guidance on how to resolve the issue (either by signing up manually or making their GitHub email public).


#### Fixes #5125

#### Describe the changes you have made in this PR -

Updated the generic_callback method in omniauth_callbacks_controller.rb to handle cases where the email is private.
Added a flash message to inform the user of the private email issue and suggest next steps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced authentication process with specific feedback for users with private emails during sign-up.
	- Added support for multiple OAuth providers including Facebook, Google, GitHub, GitLab, and Microsoft Office365.

- **Bug Fixes**
	- Improved user experience by addressing email privacy issues during authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->