### PR TITLE
🐞 Fix: Remove deprecated "version" attribute from docker-compose.yml (#5162)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,6 @@ x-common-build: &common_build
     - ./config/database.docker.yml:/circuitverse/config/database.yml:rw
     - ruby_bundle:/home/vendor/bundle:rw
 
-version: "3.1"
 services:
   db:
     image: postgres:14


### PR DESCRIPTION
Fixes #5162

### Summary:
Removed the "version" attribute from docker-compose.yml, as it is deprecated in Docker Compose v2 and later. This change eliminates deprecation warnings and aligns the configuration file with the updated Docker Compose standards.

### Changes:
- Deleted the `version` field from docker-compose.yml.

### Impact:
- No more deprecation warnings during `docker-compose up` or related commands.
- Maintains backward compatibility with supported Docker Compose versions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new services: Sidekiq, Solargraph, Asset Build, and Mailcatcher.
- **Improvements**
	- Updated Docker Compose version to 3.1 for enhanced service configuration.
	- Corrected volume path for PostgreSQL to ensure data persistence.
	- Streamlined service configurations by centralizing build arguments and volume mappings.
- **Service Enhancements**
	- Web service now remains active indefinitely and exposes multiple ports for better accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->