### PR TITLE
chore: update codespace node version to 18

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,6 +4,6 @@ FROM ruby:3.2.1-slim
 RUN apt-get update -qq && apt-get install -y build-essential ca-certificates curl gnupg imagemagick shared-mime-info cmake cmake-data netcat libvips libpq-dev pkg-config git \
  && mkdir -p /etc/apt/keyrings \ 
  && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
- && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+ && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
  && apt-get update && apt-get install -y nodejs && apt-get autoremove && apt-get clean && apt-get autoremove && rm -rf /var/lib/apt/lists/* \
  && npm install -g yarn


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Node.js version to 18.x in the development environment configuration. 
	- Added a newline at the end of the Dockerfile for improved formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->