### PR TITLE
fix: error message no more obstructs circuit elements

### DIFF
--- a/simulator/src/css/5-layout/simulator.scss
+++ b/simulator/src/css/5-layout/simulator.scss
@@ -48,8 +48,9 @@
 
 #MessageDiv {
   position: absolute;
-  left: 30px;
-  bottom: 30px;
+  left: 50%; 
+  top: 30px; 
+  transform: translateX(-50%); 
   z-index: 110;
 }
 


### PR DESCRIPTION
Fixes #5242 

Earlier the error message used to be at the left-bottom of the page, now it has been moved to the top-center of the page.

### Screenshots of the changes (If any) -
![Screenshot 2025-01-01 170458](https://github.com/user-attachments/assets/39375799-1beb-4cd8-ab13-d140a7ab06a1)



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated positioning of message display to be horizontally centered and moved to the top of its container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->