### PR TITLE
Fixed the language_filter

### DIFF
--- a/app/models/concerns/project_validations.rb
+++ b/app/models/concerns/project_validations.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module ProjectValidations
+  extend ActiveSupport::Concern
+
+  included do
+    validates :description, length: { maximum: 10_000 }
+    validates :slug, uniqueness: true
+
+    validate :check_validity
+    validate :clean_description
+  end
+
+  private
+
+    def check_validity
+      return unless (project_access_type != "Private") && !assignment_id.nil?
+
+      errors.add(:project_access_type, "Assignment has to be private")
+    end
+
+    def clean_description
+      matchlists = %i[profanity hate violence]
+      language_filters = matchlists.map { |list| LanguageFilter::Filter.new(matchlist: list) }
+
+      description_matches = check_language_filters(language_filters, description)
+
+      return nil if description_matches.empty?
+
+      errors.add(
+        :description,
+        "contains inappropriate language: #{description_matches.join(', ')}"
+      )
+    end
+
+    def check_language_filters(filters, text)
+      filters.flat_map do |filter|
+        filter.matched(text) if filter.match?(text)
+      end.compact.uniq
+    end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -2,12 +2,10 @@
 
 require "pg_search"
 class Project < ApplicationRecord
+  include ProjectValidations
   extend FriendlyId
   friendly_id :name, use: %i[slugged history]
   self.ignored_columns += ["data"]
-
-  validates :name, length: { minimum: 1 }
-  validates :slug, uniqueness: true
 
   belongs_to :author, class_name: "User"
   has_many :forks, class_name: "Project", foreign_key: "forked_project_id", dependent: :nullify
@@ -138,26 +136,7 @@ class Project < ApplicationRecord
     project_access_type == "Public" && FeaturedCircuit.exists?(project_id: id)
   end
 
-  validate :check_validity
-  validate :clean_description
-
   private
-
-    def check_validity
-      return unless (project_access_type != "Private") && !assignment_id.nil?
-
-      errors.add(:project_access_type, "Assignment has to be private")
-    end
-
-    def clean_description
-      profanity_filter = LanguageFilter::Filter.new matchlist: :profanity
-      return nil unless profanity_filter.match? description
-
-      errors.add(
-        :description,
-        "contains inappropriate language: #{profanity_filter.matched(description).join(', ')}"
-      )
-    end
 
     def check_and_remove_featured
       return unless saved_change_to_project_access_type? && saved_changes["project_access_type"][1] != "Public"


### PR DESCRIPTION

Fixes #

1.Expanded the matchlist of language_filter gem by adding profanity,hate,violence lists
2.Restricted the maximum size of description to 10k characters
3.Added language_filter to name of users 
4.Restricted the user name to 500 characters
5.Refactored Project.rb by shifting the validation logic to project_validation.rb

### Screenshots of the changes (If any) -
![Screenshot from 2025-01-13 18-15-37](https://github.com/user-attachments/assets/fd15a804-36c5-4cd2-8adc-6e9e89406ecc)
![Screenshot from 2025-01-13 18-18-10](https://github.com/user-attachments/assets/01563e66-4c63-400b-9257-29eba73e6dc8)


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
