### PR TITLE
Fixed language_filter

### DIFF
--- a/app/models/concerns/language_filterable.rb
+++ b/app/models/concerns/language_filterable.rb
@@ -6,13 +6,8 @@ module LanguageFilterable
   private
 
     def check_language_filters(filters, text)
-      return [] if filters.blank? || text.blank?
-
       filters.flat_map do |filter|
         filter.matched(text) if filter.match?(text)
-      rescue LanguageFilter::Error => e
-        Rails.logger.error("Language filter error: #{e.message}")
-        nil
       end.compact.uniq
     end
 

--- a/app/models/concerns/language_filterable.rb
+++ b/app/models/concerns/language_filterable.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module LanguageFilterable
+  extend ActiveSupport::Concern
+
+  private
+
+    def check_language_filters(filters, text)
+      return [] if filters.blank? || text.blank?
+
+      filters.flat_map do |filter|
+        filter.matched(text) if filter.match?(text)
+      rescue LanguageFilter::Error => e
+        Rails.logger.error("Language filter error: #{e.message}")
+        nil
+      end.compact.uniq
+    end
+
+    def create_language_filters
+      matchlists = %i[profanity hate violence]
+      matchlists.map { |list| LanguageFilter::Filter.new(matchlist: list) }
+    end
+end

--- a/app/models/concerns/project_validations.rb
+++ b/app/models/concerns/project_validations.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module ProjectValidations
+  extend ActiveSupport::Concern
+  include LanguageFilterable
+
+  included do
+    validates :description, length: { maximum: 10_000 }
+    validates :slug, uniqueness: true
+
+    validate :check_validity
+    validate :clean_description
+  end
+
+  private
+
+    def check_validity
+      return unless (project_access_type != "Private") && !assignment_id.nil?
+
+      errors.add(:project_access_type, "Assignment has to be private")
+    end
+
+    def clean_description
+      language_filters = create_language_filters
+
+      description_matches = check_language_filters(language_filters, description)
+
+      return nil if description_matches.empty?
+
+      errors.add(
+        :description,
+        "contains inappropriate language in description: #{description_matches.join(', ')}"
+      )
+    end
+end

--- a/app/models/concerns/project_validations.rb
+++ b/app/models/concerns/project_validations.rb
@@ -5,9 +5,10 @@ module ProjectValidations
   include LanguageFilterable
 
   included do
-    validates :name, length: { minimum: 1 }
+    validates :name, presence: true, length: { minimum: 2, maximum: 500 }
     validates :description, length: { maximum: 10_000 }
-    validates :slug, uniqueness: true
+    validates :slug, presence: true, uniqueness: true, format: { with: /\A[\w\W]+\z/,
+                                                                 message: "invalid symbols }
 
     validate :check_validity
     validate :clean_description

--- a/app/models/concerns/project_validations.rb
+++ b/app/models/concerns/project_validations.rb
@@ -5,6 +5,7 @@ module ProjectValidations
   include LanguageFilterable
 
   included do
+    validates :name, length: { minimum: 1 }
     validates :description, length: { maximum: 10_000 }
     validates :slug, uniqueness: true
 

--- a/app/models/concerns/project_validations.rb
+++ b/app/models/concerns/project_validations.rb
@@ -7,8 +7,7 @@ module ProjectValidations
   included do
     validates :name, presence: true, length: { minimum: 2, maximum: 500 }
     validates :description, length: { maximum: 10_000 }
-    validates :slug, presence: true, uniqueness: true, format: { with: /\A[\w\W]+\z/,
-                                                                 message: "invalid symbols }
+    validates :slug, presence: true, uniqueness: true
 
     validate :check_validity
     validate :clean_description

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -2,12 +2,10 @@
 
 require "pg_search"
 class Project < ApplicationRecord
+  include ProjectValidations
   extend FriendlyId
   friendly_id :name, use: %i[slugged history]
   self.ignored_columns += ["data"]
-
-  validates :name, length: { minimum: 1 }
-  validates :slug, uniqueness: true
 
   belongs_to :author, class_name: "User"
   has_many :forks, class_name: "Project", foreign_key: "forked_project_id", dependent: :nullify
@@ -138,26 +136,7 @@ class Project < ApplicationRecord
     project_access_type == "Public" && FeaturedCircuit.exists?(project_id: id)
   end
 
-  validate :check_validity
-  validate :clean_description
-
   private
-
-    def check_validity
-      return unless (project_access_type != "Private") && !assignment_id.nil?
-
-      errors.add(:project_access_type, "Assignment has to be private")
-    end
-
-    def clean_description
-      profanity_filter = LanguageFilter::Filter.new matchlist: :profanity
-      return nil unless profanity_filter.match? description
-
-      errors.add(
-        :description,
-        "contains inappropriate language: #{profanity_filter.matched(description).join(', ')}"
-      )
-    end
 
     def check_and_remove_featured
       return unless saved_change_to_project_access_type? && saved_changes["project_access_type"][1] != "Public"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
+  include LanguageFilterable
+
   mailkick_user
   require "pg_search"
   include SimpleDiscussion::ForumUser
@@ -48,6 +50,9 @@ class User < ApplicationRecord
                                              message: "can only contain letters and spaces" }
 
   validates :email, presence: true, format: /\A[^@,\s]+@[^@,\s]+\.[^@,\s]+\z/
+  validates :name, length: { minimum: 1 }
+  validates :name, length: { maximum: 500 }
+  validate :clean_name
 
   scope :subscribed, -> { where(subscribed: true) }
 
@@ -113,5 +118,18 @@ class User < ApplicationRecord
 
     def purge_profile_picture
       profile_picture.purge if profile_picture.attached?
+    end
+
+    def clean_name
+      language_filters = create_language_filters
+
+      name_matches = check_language_filters(language_filters, name)
+
+      return nil if name_matches.empty?
+
+      errors.add(
+        :name,
+        "contains inappropriate language in name: #{name_matches.join(', ')}"
+      )
     end
 end


### PR DESCRIPTION
Fixes #5298

1.Expanded the matchlist of language_filter gem by adding profanity,hate,violence lists
2.Refactored Project.rb by shifting the validation logic to project_validation.rb
3.Added language_filter to name of users
4.Restricted the user name to 500 characters
5.Restricted the maximum size of description to 10k characters

Screenshots of the changes (If any) -

![Screenshot from 2025-01-13 18-18-10](https://github.com/user-attachments/assets/cdcfb524-b506-4a4c-b2b1-549a5b694876)
![Screenshot from 2025-01-13 18-15-37](https://github.com/user-attachments/assets/2cba1f40-eba2-4ae0-943a-d0f4ce4167ac)

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Added language filtering capabilities to validate text content.
	- Enhanced validation for project and user attributes.

- **Improvements**
	- Implemented more robust validation checks for project descriptions and user names.
	- Added length restrictions and inappropriate language detection for user names.

- **Code Quality**
	- Introduced modular validation concerns to improve code organization and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->