### PR TITLE
fix(css): gap between prev and next button in the home page

### DIFF
--- a/app/views/circuitverse/index.html.erb
+++ b/app/views/circuitverse/index.html.erb
@@ -219,7 +219,7 @@
         <div class="container pagination-cont">
           <div class="pagination justify-content-center">
             <% if @projects_page.has_previous? %>
-              <%= link_to t("previous"), root_path(before: @projects_page.previous_cursor), class: "page-link" %>
+              <%= link_to t("previous"), root_path(before: @projects_page.previous_cursor), class: "page-link me-3" %>
             <% end %>
             <% if @projects_page.has_next? %>
               <%= link_to t("next"), root_path(after: @projects_page.next_cursor), class: "page-link" %>


### PR DESCRIPTION
Fixes #5308 

#### Describe the changes you have made in this PR -
Added the me-3 Bootstrap utility class to the "Previous" button to create space between the "Previous" and "Next" buttons, ensuring better visual separation while maintaining the centered layout and functionality.

### Screenshots of the changes (If any) -
|Before|After|
|----|----|
|<img width="364" alt="Screenshot 2025-01-16 at 4 10 18 AM" src="https://github.com/user-attachments/assets/891a9628-6c5d-4fe9-8c06-12d2d39cb8d5" />|<img width="452" alt="Screenshot 2025-01-16 at 4 09 00 AM" src="https://github.com/user-attachments/assets/74842aac-f08a-45f3-bbf2-62e2260ac8b4" />|



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
