### PR TITLE
Fixed the overlapping of timing diagram

### DIFF
--- a/simulator/src/plotArea.js
+++ b/simulator/src/plotArea.js
@@ -35,7 +35,7 @@ var ptA = currentScreen();
 // Helper functions for canvas
 
 function getFullHeight(flagCount) {
-    return !flagCount ? (plotHeight + padding) : (timeLineHeight + (plotHeight + padding) * flagCount);
+    return timeLineHeight + (plotHeight + padding) * flagCount;
 }
 
 function getFlagStartY(flagIndex) {
@@ -47,7 +47,7 @@ function getCycleStartX(cycleNumber) {
 }
 function changeHeight(dir) {
     plotHeight += dir ? 5 : -5;
-    plotHeight = dir ? plotHeight = Math.min(sh(50), plotHeight) : plotHeight = Math.max(sh(20), plotHeight);
+    plotHeight = dir ? plotHeight = Math.min(sh(60), plotHeight) : plotHeight = Math.max(sh(20), plotHeight);
     waveFormHeight = plotHeight - 2 * waveFormPadding;
     plotArea.resize();
 }
@@ -236,7 +236,7 @@ const plotArea = {
         ctx.fillText('Time', sh(5), timeLineHeight * 0.7);
 
         // Timeline numbers
-        ctx.font = `${sh(9)}px Times New Roman`;
+        ctx.font = `${sh(10)}px Times New Roman`;
         ctx.strokeStyle = textColor;
         ctx.textAlign = 'center';
         for (var i = Math.floor(plotArea.cycleOffset); getCycleStartX(i) <= width ; i++) {

--- a/simulator/src/plotArea.js
+++ b/simulator/src/plotArea.js
@@ -47,7 +47,11 @@ function getCycleStartX(cycleNumber) {
 }
 function changeHeight(dir) {
     plotHeight += dir ? 5 : -5;
-    plotHeight = dir ? plotHeight = Math.min(sh(60), plotHeight) : plotHeight = Math.max(sh(20), plotHeight);
+    if (dir) {
+        plotHeight = Math.min(sh(60), plotHeight);
+    } else {
+        plotHeight = Math.max(sh(20), plotHeight);
+    }
     waveFormHeight = plotHeight - 2 * waveFormPadding;
     plotArea.resize();
 }


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -
1.Fixed the overlapping of timing diagram by changing the startingY point of labels
2.Fixed the padding problem
3.Increased the size of numbers on timeLine

Before changes : 

![Screenshot from 2024-12-14 18-45-40](https://github.com/user-attachments/assets/c2d5f5a6-3a6b-4170-9375-9bfee9413c5e)

After changes:

![Screenshot from 2025-01-20 18-18-50](https://github.com/user-attachments/assets/1fd09eae-0486-4eed-aea7-fdc0da93ce9c)


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **UI Improvements**
	- Adjusted timeline height calculations to provide more vertical space
	- Increased font size for timeline numbers to improve readability
<!-- end of auto-generated comment: release notes by coderabbit.ai -->