### PR TITLE
feat: add manual subscription to comment thread/projects  #5325

### DIFF
--- a/config/initializers/commontator.rb
+++ b/config/initializers/commontator.rb
@@ -23,7 +23,7 @@ Commontator.configure do |config|
   # through the view object (for example, view.flash)
   # However, the view does not include the main application's helpers
   # Default: ->(view) { '' }
-  config.javascript_proc = ->(view) { '' }
+  config.javascript_proc = ->(_view) { '' }
 
 
   # User (acts_as_commontator) Configuration
@@ -62,7 +62,7 @@ Commontator.configure do |config|
   # Default: ->(user, view) {
   #   view.commontator_gravatar_image_tag(user, 1, s: 60, d: 'mm')
   # }
-  config.user_avatar_proc = ->(user, view) {
+  config.user_avatar_proc = ->(user, _view) {
     # image_tag(user.profile_picture.url(:thumb), { alt: user.name,
     #                  title: user.name,
     #                  border: 1 })
@@ -85,7 +85,7 @@ Commontator.configure do |config|
   # If the mailer argument is not nil, then Commontator intends to send an email to
   # the address returned; you can prevent it from being sent by returning a blank String
   # Default: ->(user, mailer) { user.try(:email) || '' }
-  config.user_email_proc = ->(user, mailer) { user.try(:email) || '' }
+  config.user_email_proc = ->(user, _mailer) { user.try(:email) || '' }
 
 
 
@@ -109,7 +109,7 @@ Commontator.configure do |config|
   # Returns: a Boolean, true if and only if the user should be allowed to read that thread
   # Note: can be called with a user object that is nil (if they are not logged in)
   # Default: ->(thread, user) { true } (anyone can read any thread)
-  config.thread_read_proc = ->(thread, user) { 
+  config.thread_read_proc = ->(thread, user) {
     return true if thread.commontable.public?
 
     ProjectPolicy.new(user, thread.commontable).check_view_access?
@@ -121,7 +121,7 @@ Commontator.configure do |config|
   # Returns: a Boolean, true if and only if the user is a moderator for that thread
   # If you want global moderators, make this proc true for them regardless of thread
   # Default: ->(thread, user) { false } (no moderators)
-  config.thread_moderator_proc = ->(thread, user) { user.admin? }
+  config.thread_moderator_proc = ->(_thread, user) { user.admin? }
 
   # comment_editing
   # Type: Symbol
@@ -174,7 +174,7 @@ Commontator.configure do |config|
   # pos is the number of likes, or the rating, or the reputation
   # neg is the number of dislikes, if applicable, or 0 otherwise
   # Default: ->(thread, pos, neg) { "%+d" % (pos - neg) }
-  config.vote_count_proc = ->(thread, pos, neg) { "%+d" % (pos - neg) }
+  config.vote_count_proc = ->(_thread, pos, neg) { "%+d" % (pos - neg) }
 
   # comment_order
   # Type: Symbol
@@ -224,7 +224,7 @@ Commontator.configure do |config|
   #   :m (manual subscriptions only)
   #   :b (both automatic, when commenting, and manual)
   # Default: :n
-  config.thread_subscription = :b
+  config.thread_subscription = :m
 
   # email_from_proc
   # Type: Proc
@@ -234,7 +234,7 @@ Commontator.configure do |config|
   # Default: ->(thread) {
   #   "no-reply@#{Rails.application.class.parent.to_s.downcase}.com"
   # }
-  config.email_from_proc = ->(thread) {
+  config.email_from_proc = ->(_thread) {
     # "no-reply@#{Rails.application.class.parent.to_s.downcase}.com"
     return "#{ENV["CIRCUITVERSE_EMAIL_ID"]}"
   }
@@ -300,7 +300,7 @@ Commontator.configure do |config|
   # Default: ->(current_user, query) {
   #   current_user.class.where('username LIKE ?', "#{query}%")
   # }
-  config.user_mentions_proc = ->(current_user, thread, query) {
+  config.user_mentions_proc = ->(current_user, _thread, query) {
     current_user.class.where('name LIKE ?', "#{query}%")
   }
 end


### PR DESCRIPTION
Fixes #5325 

#### Describe the changes you have made in this PR -

- This PR allows user to subscribe the thread/project rather than auto-subscription.
- Give control to user if he/she wants to subscribe or not.
- Someone might just comment to help other rather than interest in the projects.


### Screenshots of the changes (If any) -

[Screencast from 20-01-25 06:28:03 PM IST.webm](https://github.com/user-attachments/assets/605a2e87-eeeb-49c8-a0aa-09045e14b1c8)


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated Commontator configuration parameters to improve code clarity
	- Modified thread subscription settings

- **Chores**
	- Cleaned up unused parameter names in configuration procedures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->