### PR TITLE
Delete button under comment section#5340

### DIFF
--- a/app/views/commontator/comments/_delete_comment_confirmation_modal.html.erb
+++ b/app/views/commontator/comments/_delete_comment_confirmation_modal.html.erb
@@ -8,11 +8,12 @@
       <div class="modal-body">
         <p><%= t("commontator.comment.actions.confirm_delete") %></p>
       </div>
-      <div class="modal-footer" data-bs-dismiss="modal">
-        <%= link_to "#",
-                    method: :put,
+      <div class="modal-footer">
+        <%= link_to commontator.comment_delete_path(comment),
+                    method: :delete,
                     remote: true,
                     class: "btn btn-danger",
+                    data: { "bs-dismiss": "modal" },
                     id: "projects-comment-delete-button" do %>
           <%= t("delete") %>
         <% end %>

--- a/app/views/commontator/comments/delete.js.erb
+++ b/app/views/commontator/comments/delete.js.erb
@@ -1,11 +1,18 @@
-<%=
-  render partial: 'show', locals: {
-    user: @commontator_user,
-    thread: @commontator_thread,
-    comment: @comment,
-    page: @commontator_page,
-    show_all: @commontator_show_all
-  }
-%>
+$("#commontator-comment-<%= @comment.id %>").fadeOut(400, function() {
+  $(this).replaceWith("<%= escape_javascript(
+    render partial: 'commontator/comments/show', locals: {
+      user: @commontator_user,
+      thread: @commontator_thread,
+      comment: @comment,
+      page: @commontator_page,
+      show_all: @commontator_show_all
+    }
+  ) %>");
+});
 
-<%= javascript_proc %>
+$("#deletecommentModal").modal('hide');
+$('.modal-backdrop').remove();
+
+<% if javascript_proc %>
+  <%= javascript_proc %>
+<% end %>


### PR DESCRIPTION
**Fixes #5340**

#### **Describe the changes you have made in this PR**  
- Fixed the issue where the delete button under the comment section was not working as intended.  
- Updated the logic to ensure the comment gets deleted without reloading the page.  
- Implemented appropriate event handling to prevent the default page reload behavior.

#### **Steps to Verify the Fix**  
1. Navigate to the Circuitverse official page.
2. Log in to your account.
3. Go to the recent circuits section and click on any project.
4. Add a comment to the project.
5. Use the delete button under the comment section to delete the comment.  
6. Verify that the comment gets deleted without the page reloading.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved comment deletion workflow
	- Enhanced modal interaction for comment deletion

- **Bug Fixes**
	- Fixed modal dismissal behavior during comment deletion
	- Optimized comment removal process with smoother UI transition

- **Refactor**
	- Updated comment deletion method and path handling
	- Implemented more robust JavaScript-based comment removal mechanism

<!-- end of auto-generated comment: release notes by coderabbit.ai -->