### PR TITLE
fix: Replace deprecated `Rack::Attack.throttled_response` with `Rack::Attack.throttled_responder`

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -84,7 +84,7 @@ class Rack::Attack
     req.json_params["email"].to_s.downcase if req.path == "/api/v1/password/forgot" && req.post?
   end
 
-  self.throttled_response = lambda do |_env|
+  self.throttled_responsder = lambda do |_env|
     [429, # status
      {}, # headers
      ["Too many requests, please try again later"]] # body

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -84,7 +84,7 @@ class Rack::Attack
     req.json_params["email"].to_s.downcase if req.path == "/api/v1/password/forgot" && req.post?
   end
 
-  self.throttled_responsder = lambda do |_env|
+  self.throttled_responder = lambda do |_env|
     [429, # status
      {}, # headers
      ["Too many requests, please try again later"]] # body


### PR DESCRIPTION
Fixes https://github.com/CircuitVerse/CircuitVerse/issues/5353

#### Describe the changes you have made in this PR -
- Replaced Rack::Attack.throttled_response with Rack::Attack.throttled_responder as the former is deprecated.
- Verified functionality to ensure throttling responses are handled correctly using the new method.

### Screenshots of the changes (If any) -
N/A



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated internal naming for request throttling configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->