### PR TITLE
Integrate Sentry for better error tracking

### DIFF
--- a/app/controllers/api/v1/simulator_controller.rb
+++ b/app/controllers/api/v1/simulator_controller.rb
@@ -20,6 +20,7 @@ class Api::V1::SimulatorController < Api::V1::BaseController
 
     response = HTTP.post(url, json: { text: text })
     unless response.code == 200
+      Sentry.capture_message("Failed to submit issue to Slack")
       render json: { error: "Failed to submit issue to Slack" },
              status: :unprocessable_entity and return
     end
@@ -32,6 +33,9 @@ class Api::V1::SimulatorController < Api::V1::BaseController
   def verilog_cv
     url = "#{ENV.fetch('YOSYS_PATH', 'http://127.0.0.1:3040')}/getJSON"
     response = HTTP.post(url, json: { code: params[:code] })
+    unless response.code == 200
+      Sentry.capture_message("Failed to get JSON from Yosys")
+    end
     render json: response.to_s, status: response.code
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,10 +13,12 @@ class ApplicationController < ActionController::Base
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
 
   def auth_error
+    Sentry.capture_message("Pundit::NotAuthorizedError")
     render plain: "You are not authorized to do the requested operation"
   end
 
   def custom_auth_error(exception)
+    Sentry.capture_message("Not Authorized: #{exception.custom_message}")
     render plain: "Not Authorized: #{exception.custom_message}", status: :forbidden
   end
 

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -2,6 +2,7 @@
 
 class ErrorsController < ApplicationController
   def not_found
+    Sentry.capture_message("Resource not found")
     respond_to do |format|
       format.html { render status: :not_found }
       format.json { render json: { error: "Resource not found" }, status: :not_found }
@@ -9,6 +10,7 @@ class ErrorsController < ApplicationController
   end
 
   def unacceptable
+    Sentry.capture_message("Params unacceptable")
     respond_to do |format|
       format.html { render status: :unprocessable_entity }
       format.json { render json: { error: "Params unacceptable" }, status: :unprocessable_entity }
@@ -16,6 +18,7 @@ class ErrorsController < ApplicationController
   end
 
   def internal_error
+    Sentry.capture_message("Internal server error")
     respond_to do |format|
       format.html { render status: :internal_server_error }
       format.json do


### PR DESCRIPTION
Related to #4962

Integrate Sentry error handling to capture and report errors in the application.

* **ApplicationController**:
  - Add Sentry error handling to capture and report errors.
  - Update `auth_error` method to send errors to Sentry.
  - Update `custom_auth_error` method to send errors to Sentry.

* **Api::V1::SimulatorController**:
  - Add Sentry error handling to capture and report errors.
  - Update `post_issue` method to send errors to Sentry.
  - Update `verilog_cv` method to send errors to Sentry.

* **ErrorsController**:
  - Add Sentry error handling to capture and report errors.
  - Update `not_found` method to send errors to Sentry.
  - Update `unacceptable` method to send errors to Sentry.
  - Update `internal_error` method to send errors to Sentry.

---


