### PR TITLE
Fix: doc.yml node 22 update

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,11 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Install build tools 
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
+
       - name: jsdocs-dep
         run: npm install --legacy-peer-deps
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install build tools 
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
+          sudo apt-get install -y build-essential libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 
       - name: jsdocs-dep
         run: npm install --legacy-peer-deps


### PR DESCRIPTION
Fixes #5367

#### Describe the changes you have made in this PR -
- Removed the unnecessary Cairo dependencies from the build tools as they weren’t required for our current setup.
- Kept only the Canvas-related build tools, which are essential for building and testing the project.
- This ensures a cleaner and more efficient workflow while upgrading to Node.js 22.

### Screenshots of the changes (If any) -
N/A


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
