### PR TITLE
Query Timeout Solution

### DIFF
--- a/app/views/users/circuitverse/index.html.erb
+++ b/app/views/users/circuitverse/index.html.erb
@@ -109,7 +109,7 @@
     </div>
     <div id="collaborator-circuits-div" class="row center-row circuit-page">
       <% collaborated_projects = @user.collaborated_projects %>
-      <% if collaborated_projects.count == 0 %>
+      <% if !collaborated_projects.exists? %>
         <div class="col-12">
           <div class="search-no-results-image">
             <%= image_tag "SVGs/noProject.svg", alt: "No result image" %>


### PR DESCRIPTION
Fixes #5378

#### Describe the changes you have made in this PR -

Uses ".exists?"  replacing ".count" as it is faster than ".count" because ".count" scans all rows whereas ".exists?" stops as soon as it finds the first record.


Kindly review the PR. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the method used to determine if a user has collaborative projects. This adjustment streamlines performance for users with many project collaborations while keeping the interface consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->