### PR TITLE
fix: preset logic error fix

### DIFF
--- a/simulator/src/sequential/DflipFlop.js
+++ b/simulator/src/sequential/DflipFlop.js
@@ -67,7 +67,9 @@ export default class DflipFlop extends CircuitElement {
      * and input of the clock. We flip the bits to find qInvOutput
      */
     resolve() {
-        if (this.reset.value == 1) {
+        if (this.preset.value == 1) {
+            this.masterState = this.slaveState = 1;
+        } else if (this.reset.value == 1) {
             this.masterState = this.slaveState = (this.preset.value || 0);
         } else if (this.en.value == 0) {
             this.prevClockState = this.clockInp.value;
@@ -115,7 +117,7 @@ export default class DflipFlop extends CircuitElement {
 
     customDraw() {
         var ctx = simulationArea.context;
-        //        
+        //
         ctx.strokeStyle = (colors['stroke']);
         ctx.fillStyle = colors['fill'];
         ctx.beginPath();

--- a/simulator/src/sequential/JKflipFlop.js
+++ b/simulator/src/sequential/JKflipFlop.js
@@ -66,7 +66,9 @@ export default class JKflipFlop extends CircuitElement {
      * in the clock. masterState = this.J when no change in clock.
      */
     resolve() {
-        if (this.reset.value == 1) {
+        if (this.preset.value == 1) {
+            this.masterState = this.slaveState = 1;
+        } else if (this.reset.value == 1) {
             this.masterState = this.slaveState = this.preset.value || 0;
         } else if (this.en.value == 0) {
             this.prevClockState = this.clockInp.value;

--- a/simulator/src/sequential/JKflipFlop.js
+++ b/simulator/src/sequential/JKflipFlop.js
@@ -66,9 +66,10 @@ export default class JKflipFlop extends CircuitElement {
      * in the clock. masterState = this.J when no change in clock.
      */
     resolve() {
-        if (this.preset.value == 1) {
-            this.masterState = this.slaveState = 1;
-        } else if (this.reset.value == 1) {
+        if (this.preset.value === 1) {
+            this.masterState = 1;
+            this.slaveState = 1;
+        } else if (this.reset.value === 1) {
             this.masterState = this.slaveState = this.preset.value || 0;
         } else if (this.en.value == 0) {
             this.prevClockState = this.clockInp.value;

--- a/simulator/src/sequential/SRflipFlop.js
+++ b/simulator/src/sequential/SRflipFlop.js
@@ -63,7 +63,9 @@ export default class SRflipFlop extends CircuitElement {
      * set this.state to value S.
      */
     resolve() {
-        if (this.reset.value == 1) {
+        if (this.preset.value == 1) {
+            this.state = 1;
+        } else if (this.reset.value == 1) {
             this.state = this.preset.value || 0;
         } else if ((this.en.value == 1 || this.en.connections == 0) && this.S.value ^ this.R.value) {
             this.state = this.S.value;

--- a/simulator/src/sequential/SRflipFlop.js
+++ b/simulator/src/sequential/SRflipFlop.js
@@ -63,9 +63,9 @@ export default class SRflipFlop extends CircuitElement {
      * set this.state to value S.
      */
     resolve() {
-        if (this.preset.value == 1) {
+        if (this.preset.value === 1) {
             this.state = 1;
-        } else if (this.reset.value == 1) {
+        } else if (this.reset.value === 1) {
             this.state = this.preset.value || 0;
         } else if ((this.en.value == 1 || this.en.connections == 0) && this.S.value ^ this.R.value) {
             this.state = this.S.value;

--- a/simulator/src/sequential/TflipFlop.js
+++ b/simulator/src/sequential/TflipFlop.js
@@ -73,7 +73,9 @@ export default class TflipFlop extends CircuitElement {
      * We flip the bits to find qInvOutput
      */
     resolve() {
-        if (this.reset.value == 1) {
+        if (this.preset.value == 1) {
+            this.masterState = this.slaveState = 1;
+        } else if (this.reset.value == 1) {
             // if reset bit is set
             this.masterState = this.slaveState = this.preset.value || 0;
         } else if (this.en.value == 0) {

--- a/simulator/src/sequential/TflipFlop.js
+++ b/simulator/src/sequential/TflipFlop.js
@@ -73,9 +73,10 @@ export default class TflipFlop extends CircuitElement {
      * We flip the bits to find qInvOutput
      */
     resolve() {
-        if (this.preset.value == 1) {
-            this.masterState = this.slaveState = 1;
-        } else if (this.reset.value == 1) {
+        if (this.preset.value === 1) {
+            this.masterState = 1;
+            this.slaveState = 1;
+        } else if (this.reset.value === 1) {
             // if reset bit is set
             this.masterState = this.slaveState = this.preset.value || 0;
         } else if (this.en.value == 0) {


### PR DESCRIPTION
## Fixes #5415 

The preset in sequential elements was working with just reset high not when reset was low,
Now preset works even with reset low.

### collaborator : @092vk 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated multiple flip-flop simulation components so that preset signals now take precedence over reset signals, refining state transitions and affecting simulation outcomes.
	- Incorporated minor formatting adjustments to improve internal clarity without changing the visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->