### PR TITLE
Race conditions in flipflops 

### DIFF
--- a/simulator/src/sequential/DflipFlop.js
+++ b/simulator/src/sequential/DflipFlop.js
@@ -42,8 +42,8 @@ export default class DflipFlop extends CircuitElement {
      * WIP always resolvable?
      */
     isResolvable() {
-        if(this.reset.value == 1 && this.preset.value == 1){
-            showError('Race Condition: Multiple signals are attempting to drive the same signal')
+        if (this.reset.value === 1 && this.preset.value === 1) {
+            showError('Race Condition: Multiple signals are attempting to drive the same signal');
         }
         return true;
         // if (this.reset.value == 1) return true;

--- a/simulator/src/sequential/DflipFlop.js
+++ b/simulator/src/sequential/DflipFlop.js
@@ -42,6 +42,9 @@ export default class DflipFlop extends CircuitElement {
      * WIP always resolvable?
      */
     isResolvable() {
+        if(this.reset.value == 1 && this.preset.value == 1){
+            showError('Race Condition: Multiple signals are attempting to drive the same signal')
+        }
         return true;
         // if (this.reset.value == 1) return true;
         // if (this.clockInp.value != undefined && this.dInp.value != undefined) return true;

--- a/simulator/src/sequential/JKflipFlop.js
+++ b/simulator/src/sequential/JKflipFlop.js
@@ -48,8 +48,8 @@ export default class JKflipFlop extends CircuitElement {
      * if none of the predefined nodes have been deleted it isresolvable
      */
     isResolvable() {
-        if(this.reset.value == 1 && this.preset.value == 1 || this.J.value == 1 && this.K.value == 1){
-            showError('Race Condition: Multiple signals are attempting to drive the same signal')
+        if ((this.reset.value === 1 && this.preset.value === 1) || (this.J.value === 1 && this.K.value === 1)) {
+            showError('Race Condition: Multiple signals are attempting to drive the same signal');
         }
         if (this.reset.value == 1) return true;
         if (this.clockInp.value != undefined && this.J.value != undefined && this.K.value != undefined) return true;

--- a/simulator/src/sequential/JKflipFlop.js
+++ b/simulator/src/sequential/JKflipFlop.js
@@ -2,6 +2,8 @@ import CircuitElement from '../circuitElement';
 import Node, { findNode } from '../node';
 import simulationArea from '../simulationArea';
 import { correctWidth, lineTo, moveTo, fillText } from '../canvasApi';
+import { showError } from '../utils';
+
 /**
  * @class
  * JKflipFlop
@@ -46,6 +48,9 @@ export default class JKflipFlop extends CircuitElement {
      * if none of the predefined nodes have been deleted it isresolvable
      */
     isResolvable() {
+        if(this.reset.value == 1 && this.preset.value == 1 || this.J.value == 1 && this.K.value == 1){
+            showError('Race Condition: Multiple signals are attempting to drive the same signal')
+        }
         if (this.reset.value == 1) return true;
         if (this.clockInp.value != undefined && this.J.value != undefined && this.K.value != undefined) return true;
         return false;

--- a/simulator/src/sequential/SRflipFlop.js
+++ b/simulator/src/sequential/SRflipFlop.js
@@ -51,8 +51,8 @@ export default class SRflipFlop extends CircuitElement {
      * always resolvable
      */
     isResolvable() {
-        if(this.reset.value == 1 && this.preset.value == 1 || this.S.value == 1 && this.R.value == 1){
-            showError('Race Condition: Multiple signals are attempting to drive the same signal')
+        if ((this.reset.value === 1 && this.preset.value === 1) || (this.S.value === 1 && this.R.value === 1)) {
+            showError('Race Condition: Multiple signals are attempting to drive the same signal');
         }
         return true;
         if (this.reset.value == 1) return true;

--- a/simulator/src/sequential/SRflipFlop.js
+++ b/simulator/src/sequential/SRflipFlop.js
@@ -51,6 +51,9 @@ export default class SRflipFlop extends CircuitElement {
      * always resolvable
      */
     isResolvable() {
+        if(this.reset.value == 1 && this.preset.value == 1 || this.S.value == 1 && this.R.value == 1){
+            showError('Race Condition: Multiple signals are attempting to drive the same signal')
+        }
         return true;
         if (this.reset.value == 1) return true;
         if (this.S.value != undefined && this.R.value != undefined) return true;

--- a/simulator/src/sequential/TflipFlop.js
+++ b/simulator/src/sequential/TflipFlop.js
@@ -46,8 +46,8 @@ export default class TflipFlop extends CircuitElement {
      * returns true if clock is defined
      */
     isResolvable() {
-        if(this.reset.value == 1 && this.preset.value == 1){
-            showError('Race Condition: Multiple signals are attempting to drive the same signal')
+        if (this.reset.value === 1 && this.preset.value === 1) {
+            showError('Race Condition: Multiple signals are attempting to drive the same signal');
         }
         if (this.reset.value == 1) return true;
         if (this.clockInp.value != undefined && this.dInp.value != undefined) return true;

--- a/simulator/src/sequential/TflipFlop.js
+++ b/simulator/src/sequential/TflipFlop.js
@@ -3,6 +3,7 @@ import Node, { findNode } from '../node';
 import simulationArea from '../simulationArea';
 import { correctWidth, lineTo, moveTo, fillText } from '../canvasApi';
 import { colors } from '../themer/themer';
+import { showError } from '../utils';
 
 /**
  * @class
@@ -45,6 +46,9 @@ export default class TflipFlop extends CircuitElement {
      * returns true if clock is defined
      */
     isResolvable() {
+        if(this.reset.value == 1 && this.preset.value == 1){
+            showError('Race Condition: Multiple signals are attempting to drive the same signal')
+        }
         if (this.reset.value == 1) return true;
         if (this.clockInp.value != undefined && this.dInp.value != undefined) return true;
         return false;


### PR DESCRIPTION
Fixes #5212

Describe the changes you have made in this PR -
Race conditions occur when multiple signals attempt to change the same output simultaneously, leading to unpredictable behavior. In such cases, the final output depends on which signal is processed first, that is why it is called race condiiton due to the race between the two signals "race condition."

Fix introduces a race condition warning to notify users whenever such a conflict arises, helping them identify and address the issue more effectively.

This warning will allow the user to avoid race condition and employ methods to counter them.

Screenshots of the changes (If any) -


![Screenshot from 2025-02-14 00-01-23](https://github.com/user-attachments/assets/ba410427-ae9c-46e0-8b01-f9eec2d2a726)


![Screenshot from 2025-02-13 22-42-57](https://github.com/user-attachments/assets/79e2540a-d6d7-4908-8ff5-f0b006ab2dba)


Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling in digital circuit simulation so that users now receive clear alerts when conflicting input signals occur (e.g., simultaneous activation of multiple inputs). This update helps prevent misleading simulation outcomes by detecting potential signal conflicts early, ensuring a smoother and more reliable experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->