### PR TITLE
Race Conditions in Flip Flops

### DIFF
--- a/simulator/src/sequential/DflipFlop.js
+++ b/simulator/src/sequential/DflipFlop.js
@@ -3,6 +3,8 @@ import Node, { findNode } from '../node';
 import simulationArea from '../simulationArea';
 import { correctWidth, lineTo, moveTo, fillText } from '../canvasApi';
 import { colors } from '../themer/themer';
+import { showError } from '../utils';
+
 /**
  * @class
  * DflipFlop
@@ -42,6 +44,8 @@ export default class DflipFlop extends CircuitElement {
      * WIP always resolvable?
      */
     isResolvable() {
+        if (this.reset.value === 1 && this.preset.value === 1) {
+            showError('Race Condition: Multiple signals are attempting to drive the same signal');
         return true;
         // if (this.reset.value == 1) return true;
         // if (this.clockInp.value != undefined && this.dInp.value != undefined) return true;

--- a/simulator/src/sequential/JKflipFlop.js
+++ b/simulator/src/sequential/JKflipFlop.js
@@ -2,6 +2,8 @@ import CircuitElement from '../circuitElement';
 import Node, { findNode } from '../node';
 import simulationArea from '../simulationArea';
 import { correctWidth, lineTo, moveTo, fillText } from '../canvasApi';
+import { showError } from '../utils';
+
 /**
  * @class
  * JKflipFlop
@@ -46,6 +48,9 @@ export default class JKflipFlop extends CircuitElement {
      * if none of the predefined nodes have been deleted it isresolvable
      */
     isResolvable() {
+        if ((this.reset.value === 1 && this.preset.value === 1) || (this.J.value === 1 && this.K.value === 1)) {
+            showError('Race Condition: Multiple signals are attempting to drive the same signal');
+        }   
         if (this.reset.value == 1) return true;
         if (this.clockInp.value != undefined && this.J.value != undefined && this.K.value != undefined) return true;
         return false;

--- a/simulator/src/sequential/SRflipFlop.js
+++ b/simulator/src/sequential/SRflipFlop.js
@@ -2,6 +2,8 @@ import CircuitElement from '../circuitElement';
 import Node, { findNode } from '../node';
 import simulationArea from '../simulationArea';
 import { correctWidth, fillText } from '../canvasApi';
+import { showError } from '../utils';
+
 /**
  * @class
  * SRflipFlop
@@ -51,6 +53,9 @@ export default class SRflipFlop extends CircuitElement {
      * always resolvable
      */
     isResolvable() {
+        if ((this.S.value === 1 && this.R.value === 1) || (this.reset.value === 1 && this.preset.value === 1)) {
+            showError('Race Condition: Multiple signals are attempting to drive the same signal');
+        }
         return true;
         if (this.reset.value == 1) return true;
         if (this.S.value != undefined && this.R.value != undefined) return true;

--- a/simulator/src/sequential/TflipFlop.js
+++ b/simulator/src/sequential/TflipFlop.js
@@ -3,6 +3,7 @@ import Node, { findNode } from '../node';
 import simulationArea from '../simulationArea';
 import { correctWidth, lineTo, moveTo, fillText } from '../canvasApi';
 import { colors } from '../themer/themer';
+import { showError } from '../utils';
 
 /**
  * @class
@@ -45,6 +46,9 @@ export default class TflipFlop extends CircuitElement {
      * returns true if clock is defined
      */
     isResolvable() {
+        if (this.reset.value === 1 && this.preset.value === 1) {
+            showError('Race Condition: Multiple signals are attempting to drive the same signal');
+        }
         if (this.reset.value == 1) return true;
         if (this.clockInp.value != undefined && this.dInp.value != undefined) return true;
         return false;


### PR DESCRIPTION
Fixes #5212

#### Describe the changes you have made in this PR -

**Race conditions** occur when multiple signals attempt to change the same output simultaneously, leading to unpredictable behavior. In such cases, the final output depends on which signal is processed first, that is why it is called race condiiton due to the race between the two signals "race condition."

Fix introduces race condition warnings to notify users whenever such a conflict or invalid case arises, helping them identify and address the issue more effectively.There are many ways to handle race conditions , by wanring the users about race conditions , user can change its cirucit according to it.

This warning will allow the user to avoid race condition and employ methods to counter them.

### Screenshots of the changes (If any) -

![Screenshot from 2025-02-13 22-42-57](https://github.com/user-attachments/assets/e79c5098-ede8-41eb-81dd-6b7ce6f9e522)



![Screenshot from 2025-02-14 00-01-23](https://github.com/user-attachments/assets/a8850243-c5d6-42c0-8637-993b87164389)


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling for circuit simulation components to alert users when conflicting signal states are detected, improving overall simulation robustness and user feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->