### PR TITLE
fix(notification): optimize unread notifications query using index

### DIFF
--- a/db/migrate/20250217101253_add_partial_index_for_unread_notifications.rb
+++ b/db/migrate/20250217101253_add_partial_index_for_unread_notifications.rb
@@ -1,0 +1,11 @@
+class AddPartialIndexForUnreadNotifications < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    add_index :noticed_notifications, [:recipient_type, :recipient_id], where: 'read_at IS NULL', name: 'idx_noticed_notifications_unread', algorithm: :concurrently
+  end
+
+  def down
+    remove_index :noticed_notifications, name: 'idx_noticed_notifications_unread'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_10_20_082634) do
+ActiveRecord::Schema[7.0].define(version: 2025_02_17_101253) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -308,6 +308,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_10_20_082634) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["read_at"], name: "index_noticed_notifications_on_read_at"
+    t.index ["recipient_type", "recipient_id"], name: "idx_noticed_notifications_unread", where: "(read_at IS NULL)"
     t.index ["recipient_type", "recipient_id"], name: "index_noticed_notifications_on_recipient"
   end
 


### PR DESCRIPTION
Fixes #5391 

#### Describe the changes you have made in this PR -
Optimized the unread notifications query by adding a more efficient index. This optimization improves performance by reducing the execution time when fetching unread notifications.

### Screenshots of the changes (If any) -
![Screenshot from 2025-02-17 15-35-13](https://github.com/user-attachments/assets/a3f7368f-faf8-47b9-8c13-4ac72d62ed22)

- **Previous Execution Time (with original index)**:  
  Execution Time: 195.084 ms  
  Planning Time: 0.112 ms  

![Screenshot from 2025-02-17 15-34-31](https://github.com/user-attachments/assets/0e8ac7c3-b3d8-46f7-b999-6fdb4e96a903)

- **Current Execution Time (with optimized index)**:  
  Execution Time: 63.285 ms  
  Planning Time: 0.139 ms 

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR.
