### PR TITLE
Changed the SETUP.md description to setup Yosys serer in local

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -125,11 +125,22 @@ If you wish to do Verilog RTL Synthesis/create CircuitVerse Verilog Circuits in 
 
       yarn
 
+      npm install cors (remove cors before pushing the code)
+
       cd ..
+      ```
+    - Add the following lines in server.js to allow requests from all origins in your local setup(remember to remove them before pushing server.js and delete cors)
+      ```sh
+      var cors = require('cors')
+      server.use(cors());
       ```
     - To use CircuitVerse yosys2digitaljs-server:
       ```sh
       bin/yosys
+      ```
+    - In verilog2CV.js in main repo at line 162 change the URL to
+      ```sh
+      const url='http://localhost:3040/getJSON';
       ```
 
 ## Distributed Tracing using Opentelmetry


### PR DESCRIPTION

#### Added description on how to correctly setup Yosys server in local

1.The current description of how to setup Yosys server lags additional details on how to configure your server to handle requests from localhost.
2.CORS need to be enabled in the server to receive requests from the localhost:3000.
3.In verilog2CV.js URL of Yosys server needs to be changed as url='http://localhost:3040/getJSON';

** Additional warning was added to not push any of the above changes in the repository and they are just for development in local.



## Checklist before requesting a review
- [+] I have added proper PR title and linked to the issue
- [+ ] I have performed a self-review of my code
- [+ ] If it is a core feature, I have added thorough tests.




Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced the project setup guide with updated instructions for installing essential dependencies and configuring the development environment.
	- Provided clear guidance on adjusting server settings to support external requests during local testing.
	- Included guidelines for updating connection endpoints, with reminders to remove temporary configurations before production deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->