### PR TITLE
fix(simulator): text annotation color not changing in custom themes

### DIFF
--- a/simulator/src/themer/customThemeAbstraction.js
+++ b/simulator/src/themer/customThemeAbstraction.js
@@ -3,42 +3,40 @@
  * @param {*} themeOptions
  * @returns an Object
  */
-export const CreateAbstraction = (themeOptions) => {
-    return {
-        Navbar: {
-            color: themeOptions['--bg-navbar'],
-            description: 'navbar background',
-            ref: ['--bg-navbar'],
-        },
-        Primary: {
-            color: themeOptions['--primary'],
-            description: 'modals background',
-            ref: ['--primary'],
-        },
-        Secondary: {
-            color: themeOptions['--bg-tabs'],
-            description: 'tabBar background',
-            ref: ['--bg-tabs'],
-        },
-        Canvas: {
-            color: themeOptions['--canvas-fill'],
-            description: 'canvas background',
-            ref: ['--canvas-fill'],
-        },
-        Stroke: {
-            color: themeOptions['--canvas-stroke'],
-            description: 'canvas grid color',
-            ref: ['--canvas-stroke'],
-        },
-        Text: {
-            color: themeOptions['--text-lite'],
-            description: 'text color',
-            ref: ['--text-lite', '--text-panel', '--text-dark'],
-        },
-        Borders: {
-            color: themeOptions['--br-secondary'],
-            description: 'borders color',
-            ref: ['--br-secondary'],
-        },
-    };
-};
+export default (themeOptions) => ({
+    Navbar: {
+        color: themeOptions['--bg-navbar'],
+        description: 'navbar background',
+        ref: ['--bg-navbar'],
+    },
+    Primary: {
+        color: themeOptions['--primary'],
+        description: 'modals background',
+        ref: ['--primary'],
+    },
+    Secondary: {
+        color: themeOptions['--bg-tabs'],
+        description: 'tabBar background',
+        ref: ['--bg-tabs'],
+    },
+    Canvas: {
+        color: themeOptions['--canvas-fill'],
+        description: 'canvas background',
+        ref: ['--canvas-fill'],
+    },
+    Stroke: {
+        color: themeOptions['--canvas-stroke'],
+        description: 'canvas grid color',
+        ref: ['--canvas-stroke'],
+    },
+    Text: {
+        color: themeOptions['--text-lite'],
+        description: 'text color',
+        ref: ['--text-lite', '--text-panel', '--text-dark', '--text'],
+    },
+    Borders: {
+        color: themeOptions['--br-secondary'],
+        description: 'borders color',
+        ref: ['--br-secondary'],
+    },
+});

--- a/simulator/src/themer/customThemer.js
+++ b/simulator/src/themer/customThemer.js
@@ -3,7 +3,7 @@
 import { dots } from '../canvasApi';
 import themeOptions from './themes';
 import updateThemeForStyle from './themer';
-import { CreateAbstraction } from './customThemeAbstraction';
+import CreateAbstraction from './customThemeAbstraction';
 
 /**
  *


### PR DESCRIPTION
Fixes #4460

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -
This PR fixes an issue where text annotations do not change color when using custom themes. This was because the `--text` CSS variable (used for text annotations) was not there in the reference list for text colors in the custom theme abstraction.

To fix added the `--text` variable to the refs list in the Text property of the customThemeAbstraction.js file.

Also, I updated the export statement in customThemeAbstraction.js from a named export to a default export to comply with the project's ESLint rules While maintaining the same functionality.

### Screenshots of the UI changes (If any) -
<!-- Do not add code diff here -->
The Video explains the fix
https://github.com/user-attachments/assets/73a430e4-93f7-45d6-a197-65db64f83d94


## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.