### PR TITLE
Enhance Footer: Add FOSS United Logo Under Infrastructure Sponsor

### DIFF
--- a/app/component/footer_component.html.erb
+++ b/app/component/footer_component.html.erb
@@ -32,6 +32,14 @@
               <%= image_tag("footer/zense.png", class: "footer-sponsor-logo", alt: "Zense Logo") %>
             </a>
           </div>
+          <div class="col-6 footer-sponsor-logo-div">
+           <small class="text-start footer-sponsor-logo-text">
+            <%= t("layout.footer.sponsor_logo_text.infrastructure_sponsor") %>
+          </small>
+          <a href="https://fossunited.org/" rel="noopener" target="_blank">
+               <%= image_tag("footer/fossunited.png", class: "footer-sponsor-logo", alt: "FOSS United Logo") %>
+          </a>
+          </div>
         </div>
       </div>
     </div>

--- a/config/locales/views/layouts/en.yml
+++ b/config/locales/views/layouts/en.yml
@@ -20,6 +20,7 @@ en:
         hosting_sponsor: "Hosting Sponsor:"
         marketed_by: "Marketed by:"
         incubated_from: "Incubated From:"
+        infrastructure_sponsor: "Infrastructure Sponsor:" 
       copyright_text: "Copyright © %{time_current_year} CircuitVerse, All rights reserved."
     header:
       dashboard: "Dashboard"


### PR DESCRIPTION
Fixes #5481

---
<!-- Add issue number above --> 

#### Describe the changes you have made in this PR - 
Added the **FOSS United logo** under the "Infrastructure Sponsor" section in the footer section of the homepage

---
### Screenshots of the UI changes (If any) -

Before:
![418500258-4e6939f3-1290-4dc5-8dbc-b06c44e8a729](https://github.com/user-attachments/assets/1f462996-d7cd-453b-a807-c55117f05a5f)

After:
![Screenshot 2025-03-04 011928](https://github.com/user-attachments/assets/4af20eeb-8a9c-404c-96c2-3b9a03e2485d)

<!-- Do not add code diff here -->

-----

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.




Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the footer with a dedicated sponsorship section displaying “Infrastructure Sponsor” details.
	- Introduced a clickable sponsor image and updated sponsorship label text for clearer identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->