### PR TITLE
Removed about page   custom css to the bootstrap 5 layout (Refactor CSS) #5484

### DIFF
--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -7,76 +7,47 @@
     </div>
   </div>
   <div class="d-flex justify-content-center gap-0 my-1">
-    <a class="btn" href="/tos" target="_blank" 
-   style="background-color:#42b983; color:#ffffff; margin:5px; padding:8px 16px; transition: all 0.3s ease-in-out, background-color 0.3s ease-in-out;" 
-   onmouseover="this.style.transform='scale(1.1)'; this.style.backgroundColor='#0F3F2D';" 
-   onmouseout="this.style.transform='scale(1)'; this.style.backgroundColor='#42b983';">
+    <a class="btn" href="/tos" target="_blank" style="background-color:#42b983; color:#ffffff; margin:5px; padding:8px 16px; transition: all 0.3s ease-in-out, background-color 0.3s ease-in-out;" onmouseover="this.style.transform='scale(1.1)'; this.style.backgroundColor='#0F3F2D';" onmouseout="this.style.transform='scale(1)'; this.style.backgroundColor='#42b983';">
   <%= t("about.terms_of_service") %>
 </a>
-
-<a class="btn" href="/privacy" target="_blank" 
-   style="background-color:#42b983; color:#ffffff; margin:5px; padding:8px 16px; transition: all 0.3s ease-in-out, background-color 0.3s ease-in-out;" 
-   onmouseover="this.style.transform='scale(1.1)'; this.style.backgroundColor='#0F3F2D';" 
-   onmouseout="this.style.transform='scale(1)'; this.style.backgroundColor='#42b983';">
+<a class="btn" href="/privacy" target="_blank" style="background-color:#42b983; color:#ffffff; margin:5px; padding:8px 16px; transition: all 0.3s ease-in-out, background-color 0.3s ease-in-out;" onmouseover="this.style.transform='scale(1.1)'; this.style.backgroundColor='#0F3F2D';" onmouseout="this.style.transform='scale(1)'; this.style.backgroundColor='#42b983';">
   <%= t("about.privacy_policy") %>
 </a>
-
-  </div>
+ </div>
   <div class="row text-center">
     <div class="row row-center gap-3 " style="align-items:baseline; justify-content:center; margin-top:25px;">
-     <div class="card p-3" 
-     style="width: 300px; margin-bottom: 16px; box-shadow: 0px 2px 7px #00000029; opacity: .89; transition: box-shadow .2s ease-in-out;" 
-     onmouseover="this.style.boxShadow='0px 4px 15px #00000050';" 
-     onmouseout="this.style.boxShadow='0px 2px 7px #00000029';">
-  
-  <a href="mailto:support@circuitverse.org" target="_blank" style="text-decoration: none;">
+     <div class="card p-3" style="width: 300px; margin-bottom: 16px; box-shadow: 0px 2px 7px #00000029; opacity: .89; transition: box-shadow .2s ease-in-out;" onmouseover="this.style.boxShadow='0px 4px 15px #00000050';" onmouseout="this.style.boxShadow='0px 2px 7px #00000029';">
+   <a href="mailto:support@circuitverse.org" target="_blank" style="text-decoration: none;">
     <%= image_tag "SVGs/email.svg", height: "60", width: "60", alt: "Email Icon", class: "social-card-image" %>
     <h6 style="color: #000000;"><%= t("email_us_heading") %></h6>
     <p style="color: #000000;">support@circuitverse.org</p>
   </a>
-
 </div>
-
-     <div class="card p-3 mt-3" 
-     style="width: 300px; margin-bottom: 16px; box-shadow: 0px 2px 7px #00000029; opacity: .89; transition: box-shadow .2s ease-in-out;" 
-     onmouseover="this.style.boxShadow='0px 4px 15px #00000050';" 
-     onmouseout="this.style.boxShadow='0px 2px 7px #00000029';">
-
+    <div class="card p-3 mt-3" style="width: 300px; margin-bottom: 16px; box-shadow: 0px 2px 7px #00000029; opacity: .89; transition: box-shadow .2s ease-in-out;" onmouseover="this.style.boxShadow='0px 4px 15px #00000050';" onmouseout="this.style.boxShadow='0px 2px 7px #00000029';">
   <a href="<%= Rails.configuration.slack_url %>" target="_blank" style="text-decoration: none;">
     <%= image_tag "SVGs/slack.svg", height: "60", width: "60", alt: "Slack Logo", class: "social-card-image" %>
     <h6 style="color: #000000;"><%= t("join_at_slack_heading") %></h6>
     <p style="color: #000000;"><%= t("join_at_slack_description") %></p>
   </a>
-
 </div>
-
-    </div>
+   </div>
   </div>
   <hr>
   <div class="container">
     <div class="row text-center">
         <div class="col-12">
-          <h2 class="display-6" style="font-size: 2rem;
-    margin-bottom: 10px;
-    margin-top: 40px;
-    color: #026e57;
-    font-weight: 500;"><%= t("about.core_team_heading") %></h2>
-          <p class="lead" style="font-size: 20px;
-    font-weight: 500; margin:0px 0px 16px; color:#212529;"><%= t("about.core_team_description") %></p>
+          <h2 class="display-6" style="font-size: 2rem; margin-bottom: 10px; margin-top: 40px; color: #026e57; font-weight: 500;"><%= t("about.core_team_heading") %></h2>
+          <p class="lead" style="font-size: 20px; font-weight: 500; margin:0px 0px 16px; color:#212529;"><%= t("about.core_team_description") %></p>
         </div>
     </div>
-    <div class="row justify-content-center" style="margin: -25px 0px 0px;
-    padding: 31px;">
+    <div class="row justify-content-center" style="margin: -25px 0px 0px; padding: 31px;">
   <% @cores.each do |member| %>
     <div class="col-md-3 col-sm-6 d-flex flex-column align-items-center text-center my-3">
-      
-      <div class="d-flex flex-column align-items-center">
+       <div class="d-flex flex-column align-items-center">
         <a target="_blank" href="<%= member[:link] %>">
-          <%= image_tag member[:img], class: "img-fluid rounded-circle shadow-sm", 
-            style:"width: 100px; height: 100px; object-fit: cover; border: 2px solid #ddd; " %>
+          <%= image_tag member[:img], class: "img-fluid rounded-circle shadow-sm",style:"width: 100px; height: 100px; object-fit: cover; border: 2px solid #ddd; " %>
         </a>
       </div>
-      
      <div class="mt-2">
   <a target="_blank" href="<%= member[:link] %>" style="color: black; text-decoration: none; transition: text-decoration 0.3s ease-in-out;">
     <p class="fw-light mt-1" style="display: inline-block; position: relative; color:#000000;">
@@ -84,21 +55,15 @@
     </p>
   </a>
 </div>
-
-    </div>
+   </div>
   <% end %>
 </div>
 </div>
-
-  <hr>
+ <hr>
   <div class="container">
     <div class="row text-center">
-        <div class="col-12 " style="padding: 0px 12px;
-    color: #212529; margin-bottom:45px;">
-          <h2 class="display-6" style="font-size: 2rem;
-    color: #026e57;
-    margin-bottom: 10px;
-    margin-top: 40px;"><%= t("about.mentors_team_heading") %></h2>
+        <div class="col-12 " style="padding: 0px 12px; color: #212529; margin-bottom:45px;">
+          <h2 class="display-6" style="font-size: 2rem;color: #026e57; margin-bottom: 10px; margin-top: 40px;"><%= t("about.mentors_team_heading") %></h2>
           <p class="lead"><%= t("about.mentors_team_description") %></p>
         </div>
     </div>
@@ -107,22 +72,19 @@
     <div class="col-md-3 col-sm-6 d-flex flex-column align-items-center text-center my-3">
       <div class="border-bottom pb-2 w-100">
         <a target="_blank" href="<%= member[:link] %>" style="color: black; text-decoration: none;">
-          <%= image_tag member[:img], class: "rounded-circle shadow-sm", style: "width: 80px; height: 80px; object-fit: cover; border: 2px solid #ddd; display: block; margin: 0 auto;" %>
+          <%= image_tag member[:img], class: "rounded-circle shadow-sm", style: "width: 80px; height: 80px; object-fit: cover; border: 2px solid #ddd; display: block; margin: 0 auto;",alt: "#{member[:name]}'s profile picture" %>
           <p class="fw-bold mt-2" style="color: black; text-decoration: none; margin-bottom: 0;"><%= member[:name] %></p>
         </a>
       </div>
     </div>
   <% end %>
 </div>
-
-  </div>
+ </div>
   <hr>
   <div class="container">
     <div class="row text-center">
         <div class="col-12 col-sm-12 col-md-12 col-lg-12">
-          <h2 class="display-6" style="color: #026e57;
-    margin-bottom: 10px;
-    margin-top: 40px; font-size:2rem;"><%= t("about.issues_triaging_team") %></h2>
+          <h2 class="display-6" style="color: #026e57; margin-bottom: 10px; margin-top: 40px; font-size:2rem;"><%= t("about.issues_triaging_team") %></h2>
           <p class="lead" style="font-size:20px; font-weight:500; margin-top:0; margin-bottom:1rem;"><%= t("about.issues_triaging_team_description") %></p>
         </div>
     </div>
@@ -130,32 +92,28 @@
   <% @issues_triaging.each do |member| %>
     <div class="col-md-3 col-sm-4 text-center d-flex flex-column align-items-center my-2" >
       <a target="_blank" href="<%= member[:link] %>" class="text-decoration-none text-dark">
-        <%= image_tag member[:img], class: "img-fluid rounded-circle shadow-sm", style: "width: 100px; height: 100px; object-fit: cover; margin-bottom: 10px;" %>
+        <%= image_tag member[:img], class: "img-fluid rounded-circle shadow-sm", style: "width: 100px; height: 100px; object-fit: cover; margin-bottom: 10px;" ,alt: "#{member[:name]}'s profile picture" %>
         <p class="fw-light m-0"><%= member[:name] %></p>
       </a>
     </div>
   <% end %>
 </div>
-
-  </div>
+ </div>
   <hr>
   <div class="container">
     <div class="row text-center">
         <div class="col-12">
-          <h2 class="display-6" style="color: #026e57;
-    margin-bottom: 10px;
-    margin-top: 40px; font-size:2rem;"><%= t("about.alumni_team_heading") %></h2>
+          <h2 class="display-6" style="color: #026e57; margin-bottom: 10px; margin-top: 40px; font-size:2rem;"><%= t("about.alumni_team_heading") %></h2>
           <p class="lead"><%= t("about.alumni_team_description") %></p>
         </div>
     </div>
-    <div class="container" style="margin: -25px 0px 0px;
-    padding: 34px;">
+    <div class="container" style="margin: -25px 0px 0px; padding: 34px;">
     <% @alumni.each_slice(6) do |row_members| %>  
     <div class="row justify-content-center g-4" style="margin-bottom:43px; margin-top:5px;"> 
       <% row_members.each do |member| %>
         <div class="col-md-2 col-sm-4 text-center d-flex flex-column align-items-center">
           <div>
-            <%= image_tag member[:img], class: "img-fluid rounded-circle shadow-sm", style: "width: 90px; height: 90px; object-fit: cover;" %>
+            <%= image_tag member[:img], class: "img-fluid rounded-circle shadow-sm", style: "width: 90px; height: 90px; object-fit: cover;",alt: "#{member[:name]}'s profile picture" %>
           </div>
           <div class="mt-1">
             <a target="_blank" href="<%= member[:link] %>" class="text-decoration-none text-dark">
@@ -178,27 +136,17 @@
       <h5><%= t("about.contributors_description") %></h5>
     </div>
   </div>
-
-  
-  <div class="container " style="margin:30px 0px 0px; padding:0px 12px;">
-    <div class="row justify-content-center" id="contributors-section" style="margin-top:50px;">
-      
-    </div>
+ <div class="container " style="margin:30px 0px 0px; padding:0px 12px;">
+    <div class="row justify-content-center" id="contributors-section" style="margin-top:50px;"></div>
   </div>
-
   <div class="row text-center mt-4">
     <div class="col">
-     <a class="btn " href="/contribute" 
-   style="background-color: #42b983; color: #fff; margin:20px 5px 5px; padding:12px 30px; transition: transform 0.3s ease-in-out, background-color 0.3s ease-in-out;" 
-   onmouseover="this.style.transform='scale(1.1)'; this.style.backgroundColor='#0F3F2D';" 
-   onmouseout="this.style.transform='scale(1)'; this.style.backgroundColor='#42b983';">
+     <a class="btn " href="/contribute" style="background-color: #42b983; color: #fff; margin:20px 5px 5px; padding:12px 30px; transition: transform 0.3s ease-in-out, background-color 0.3s ease-in-out;" onmouseover="this.style.transform='scale(1.1)'; this.style.backgroundColor='#0F3F2D';" onmouseout="this.style.transform='scale(1)'; this.style.backgroundColor='#42b983';">
   <%= t("about.become_contributor") %>
 </a>
-
-    </div>
+   </div>
   </div>
 </div>
-
 <script>
   async function getContributors(url) {
     let apiData = await fetch(url);
@@ -206,36 +154,29 @@
     let contributorUsers = contributorsData.filter(user => user.type === 'User');
     let contributorsContainer = document.getElementById('contributors-section');
     contributorsContainer.innerHTML = "";
-
     let row;
     contributorUsers.slice(0, 100).forEach((user, index) => {
       if (index % 10 === 0) {
-        
-        row = document.createElement("div");
-        row.classList.add("row", "justify-content-center", "gx-3", "gy-3", style="gap:16px;" );
-        contributorsContainer.appendChild(row);
+       row = document.createElement("div");
+       row.classList.add("row", "justify-content-center", "gx-3", "gy-3" );
+       row.style.gap = "16px";
+       contributorsContainer.appendChild(row);
       }
-
-      let contributorElement = document.createElement('div');
+     let contributorElement = document.createElement('div');
       contributorElement.classList.add('col-lg-1', 'col-md-2', 'col-sm-3', 'col-4', 'text-center');
-
-      let contributorElementAnchor = document.createElement('a');
+     let contributorElementAnchor = document.createElement('a');
       contributorElementAnchor.href = user['html_url'];
       contributorElementAnchor.target = "_blank";
-
       let contributorElementImage = document.createElement('img');
       contributorElementImage.src = user['avatar_url'];
       contributorElementImage.classList.add('img-fluid', 'rounded-circle', 'shadow-sm');
       contributorElementImage.style.width = '70px';
       contributorElementImage.style.height = '70px';
       contributorElementImage.style.objectFit = 'cover';
-
-      contributorElementAnchor.appendChild(contributorElementImage);
+     contributorElementAnchor.appendChild(contributorElementImage);
       contributorElement.appendChild(contributorElementAnchor);
-
-      row.appendChild(contributorElement);
+     row.appendChild(contributorElement);
     });
   }
-
   getContributors('https://api.github.com/repos/CircuitVerse/CircuitVerse/contributors?per_page=100');
 </script>

--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row text-center">
     <div class="col">
-      <h1 class="display-6" style="color: #026e57; margin-top:40px; margin-bottom;10px;" ><%= t("about.main_heading") %></h1>
+      <h1 class="display-6" style="color: #026e57; margin-top:40px; margin-bottom:10px;" ><%= t("about.main_heading") %></h1>
       <p class="lead"><%= t("about.main_description") %></p>
       <p class="text-center" style="margin:30px 0px;"><%= t("about.product_details") %></p>
     </div>

--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -1,153 +1,241 @@
-<% content_for :title, t("about.title") %>
-
 <div class="container">
-  <div class="row center-row">
-    <div class="col col-sm col-md col-lg">
-      <h1 class="main-heading"><%= t("about.main_heading") %></h1>
-        <p class="main-description"><%= t("about.main_description") %></p>
-        <p class="centered-paragraph"><%= t("about.product_details") %></p>
+  <div class="row text-center">
+    <div class="col">
+      <h1 class="display-6" style="color: #026e57; margin-top:40px; margin-bottom;10px;" ><%= t("about.main_heading") %></h1>
+      <p class="lead"><%= t("about.main_description") %></p>
+      <p class="text-center" style="margin:30px 0px;"><%= t("about.product_details") %></p>
     </div>
   </div>
-  <div class="col col-sm col-md col-lg div-flex-center">
-    <a class="btn primary-button" href="/tos" target="_blank"><%= t("about.terms_of_service") %></a>
-    <a class="btn primary-button" href="/privacy" target="_blank"><%= t("about.privacy_policy") %></a>
-  </div>
-  <div class="row center-row">
-    <div class="col col-sm col-md col-lg">
-      <div class="social-card about-social-card-1">
-        <a class="about-social-anchor" href="mailto:support@circuitverse.org" target="_blank">
-          <%= image_tag "SVGs/email.svg", height: "60", width: "60", alt: "Email Icon", class: "social-card-image" %>
-          <h6><%= t("email_us_heading") %></h6>
-          <p>support@circuitverse.org</p>
-        </a>
-      </div>
-      <div class="social-card about-social-card-2">
-        <a class="about-social-anchor" href="<%= Rails.configuration.slack_url %>" target="_blank">
-          <%= image_tag "SVGs/slack.svg", height: "60", width: "60", alt: "Slack Logo", class: "social-card-image" %>
-          <h6><%= t("join_at_slack_heading") %></h6>
-          <p><%= t("join_at_slack_description") %></p>
-        </a>
-      </div>
-    </div>
-  </div>
-  <hr>
-  <div class="container">
-    <div class="row center-row">
-        <div class="col-12 col-sm-12 col-md-12 col-lg-12">
-          <h2 class="main-heading"><%= t("about.core_team_heading") %></h2>
-          <p class="main-description"><%= t("about.core_team_description") %></p>
-        </div>
-    </div>
-    <div class="row center-row teams-section ">
-        <% @cores.each do |member| %>
-        <div class="team-member-container team-link ">
-          <div class="team-underline">
-            <a target="_blank" href="<%= member[:link] %>"><%= image_tag member[:img], class: "about-contributor-image" %><p class="team-footer "><%= member[:name] %></p></a>
-          </div>
-        </div>
-        <% end %>
-        <br><br>
-    </div>
-  </div>
-  <br><br>
-  <hr>
-  <div class="container">
-    <div class="row center-row">
-        <div class="col-12 col-sm-12 col-md-12 col-lg-12">
-          <h2 class="main-heading"><%= t("about.mentors_team_heading") %></h2>
-          <p class="main-description"><%= t("about.mentors_team_description") %></p>
-        </div>
-    </div>
-    <div class="row center-row teams-section">
-        <% @mentors.each do |member| %>
-        <div class="team-member-container team-link">
-          <div class="team-underline">
-            <a target="_blank" href="<%= member[:link] %>"><%= image_tag member[:img], class: "about-contributor-image" %><p class="team-footer"><%= member[:name] %></p></a>
-          </div>
-        </div>
-        <% end %>
-        <br><br>
-    </div>
-  </div>
-  <br><br>
-  <hr>
+  <div class="d-flex justify-content-center gap-0 my-1">
+    <a class="btn" href="/tos" target="_blank" 
+   style="background-color:#42b983; color:#ffffff; margin:5px; padding:8px 16px; transition: all 0.3s ease-in-out, background-color 0.3s ease-in-out;" 
+   onmouseover="this.style.transform='scale(1.1)'; this.style.backgroundColor='#0F3F2D';" 
+   onmouseout="this.style.transform='scale(1)'; this.style.backgroundColor='#42b983';">
+  <%= t("about.terms_of_service") %>
+</a>
 
-  <div class="container">
-    <div class="row center-row">
-        <div class="col-12 col-sm-12 col-md-12 col-lg-12">
-          <h2 class="main-heading"><%= t("about.issues_triaging_team") %></h2>
-          <p class="main-description"><%= t("about.issues_triaging_team_description") %></p>
-        </div>
-    </div>
-    <div class="row center-row teams-section">
-        <% @issues_triaging.each do |member| %>
-        <div class="team-member-container team-link">
-          <div class="team-underline">
-            <a target="_blank" href="<%= member[:link] %>"><%= image_tag member[:img],alt: "User Image", class: "about-contributor-image" %><p class="team-footer"><%= member[:name] %></p></a>
-          </div>
-        </div>
-        <% end %>
-        <br><br>
-    </div>
-  </div>
-  <br><br>
-  <hr>
+<a class="btn" href="/privacy" target="_blank" 
+   style="background-color:#42b983; color:#ffffff; margin:5px; padding:8px 16px; transition: all 0.3s ease-in-out, background-color 0.3s ease-in-out;" 
+   onmouseover="this.style.transform='scale(1.1)'; this.style.backgroundColor='#0F3F2D';" 
+   onmouseout="this.style.transform='scale(1)'; this.style.backgroundColor='#42b983';">
+  <%= t("about.privacy_policy") %>
+</a>
 
-  <div class="container">
-    <div class="row center-row">
-        <div class="col-12 col-sm-12 col-md-12 col-lg-12">
-          <h2 class="main-heading"><%= t("about.alumni_team_heading") %></h2>
-          <p class="main-description"><%= t("about.alumni_team_description") %></p>
-        </div>
-    </div>
-    <div class="row center-row teams-section">
-        <% @alumni.each do |member| %>
-        <div class="team-member-container team-link">
-          <div class="team-underline">
-            <a target="_blank" href="<%= member[:link] %>"><%= image_tag member[:img], class: "about-contributor-image " %><p class="team-footer underline"><%= member[:name] %></p></a>
-          </div>
-        </div>
-        <% end %>
-        <br><br>
-    </div>
   </div>
-  <br><br>
-  <hr>
-    <div class="row center-row">
-      <div class="col col-sm col-md col-lg">
-        <h2 class="submain-heading"><%= t("about.contributors_heading") %></h2>
-        <h5><%= t("about.contributors_description") %></h5>
-      </div>
-    </div>
-    <div class="row center-row">
-      <div class="about-contributors-section">
-      </div>
-    </div>
-    <br>
-    <div class="row center-row">
-      <div class="col col-sm col-md col-lg text-center">
-        <a class="btn primary-button about-primary-button" href="/contribute"><%= t("about.become_contributor") %></a>
-      </div>
-    </div>
+  <div class="row text-center">
+    <div class="row row-center gap-3 " style="align-items:baseline; justify-content:center; margin-top:25px;">
+     <div class="card p-3" 
+     style="width: 300px; margin-bottom: 16px; box-shadow: 0px 2px 7px #00000029; opacity: .89; transition: box-shadow .2s ease-in-out;" 
+     onmouseover="this.style.boxShadow='0px 4px 15px #00000050';" 
+     onmouseout="this.style.boxShadow='0px 2px 7px #00000029';">
+  
+  <a href="mailto:support@circuitverse.org" target="_blank" style="text-decoration: none;">
+    <%= image_tag "SVGs/email.svg", height: "60", width: "60", alt: "Email Icon", class: "social-card-image" %>
+    <h6 style="color: #000000;"><%= t("email_us_heading") %></h6>
+    <p style="color: #000000;">support@circuitverse.org</p>
+  </a>
+
 </div>
 
-<script type="text/javascript">
-  async function getContributors(url){
+     <div class="card p-3 mt-3" 
+     style="width: 300px; margin-bottom: 16px; box-shadow: 0px 2px 7px #00000029; opacity: .89; transition: box-shadow .2s ease-in-out;" 
+     onmouseover="this.style.boxShadow='0px 4px 15px #00000050';" 
+     onmouseout="this.style.boxShadow='0px 2px 7px #00000029';">
+
+  <a href="<%= Rails.configuration.slack_url %>" target="_blank" style="text-decoration: none;">
+    <%= image_tag "SVGs/slack.svg", height: "60", width: "60", alt: "Slack Logo", class: "social-card-image" %>
+    <h6 style="color: #000000;"><%= t("join_at_slack_heading") %></h6>
+    <p style="color: #000000;"><%= t("join_at_slack_description") %></p>
+  </a>
+
+</div>
+
+    </div>
+  </div>
+  <hr>
+  <div class="container">
+    <div class="row text-center">
+        <div class="col-12">
+          <h2 class="display-6" style="font-size: 2rem;
+    margin-bottom: 10px;
+    margin-top: 40px;
+    color: #026e57;
+    font-weight: 500;"><%= t("about.core_team_heading") %></h2>
+          <p class="lead" style="font-size: 20px;
+    font-weight: 500; margin:0px 0px 16px; color:#212529;"><%= t("about.core_team_description") %></p>
+        </div>
+    </div>
+    <div class="row justify-content-center" style="margin: -25px 0px 0px;
+    padding: 31px;">
+  <% @cores.each do |member| %>
+    <div class="col-md-3 col-sm-6 d-flex flex-column align-items-center text-center my-3">
+      
+      <div class="d-flex flex-column align-items-center">
+        <a target="_blank" href="<%= member[:link] %>">
+          <%= image_tag member[:img], class: "img-fluid rounded-circle shadow-sm", 
+            style:"width: 100px; height: 100px; object-fit: cover; border: 2px solid #ddd; " %>
+        </a>
+      </div>
+      
+     <div class="mt-2">
+  <a target="_blank" href="<%= member[:link] %>" style="color: black; text-decoration: none; transition: text-decoration 0.3s ease-in-out;">
+    <p class="fw-light mt-1" style="display: inline-block; position: relative; color:#000000;">
+      <%= member[:name] %>
+    </p>
+  </a>
+</div>
+
+    </div>
+  <% end %>
+</div>
+</div>
+
+  <hr>
+  <div class="container">
+    <div class="row text-center">
+        <div class="col-12 " style="padding: 0px 12px;
+    color: #212529; margin-bottom:45px;">
+          <h2 class="display-6" style="font-size: 2rem;
+    color: #026e57;
+    margin-bottom: 10px;
+    margin-top: 40px;"><%= t("about.mentors_team_heading") %></h2>
+          <p class="lead"><%= t("about.mentors_team_description") %></p>
+        </div>
+    </div>
+  <div class="row justify-content-center">
+  <% @mentors.each do |member| %>
+    <div class="col-md-3 col-sm-6 d-flex flex-column align-items-center text-center my-3">
+      <div class="border-bottom pb-2 w-100">
+        <a target="_blank" href="<%= member[:link] %>" style="color: black; text-decoration: none;">
+          <%= image_tag member[:img], class: "rounded-circle shadow-sm", style: "width: 80px; height: 80px; object-fit: cover; border: 2px solid #ddd; display: block; margin: 0 auto;" %>
+          <p class="fw-bold mt-2" style="color: black; text-decoration: none; margin-bottom: 0;"><%= member[:name] %></p>
+        </a>
+      </div>
+    </div>
+  <% end %>
+</div>
+
+  </div>
+  <hr>
+  <div class="container">
+    <div class="row text-center">
+        <div class="col-12 col-sm-12 col-md-12 col-lg-12">
+          <h2 class="display-6" style="color: #026e57;
+    margin-bottom: 10px;
+    margin-top: 40px; font-size:2rem;"><%= t("about.issues_triaging_team") %></h2>
+          <p class="lead" style="font-size:20px; font-weight:500; margin-top:0; margin-bottom:1rem;"><%= t("about.issues_triaging_team_description") %></p>
+        </div>
+    </div>
+    <div class="row center-row teams-section" style="padding:25px;">
+  <% @issues_triaging.each do |member| %>
+    <div class="col-md-3 col-sm-4 text-center d-flex flex-column align-items-center my-2" >
+      <a target="_blank" href="<%= member[:link] %>" class="text-decoration-none text-dark">
+        <%= image_tag member[:img], class: "img-fluid rounded-circle shadow-sm", style: "width: 100px; height: 100px; object-fit: cover; margin-bottom: 10px;" %>
+        <p class="fw-light m-0"><%= member[:name] %></p>
+      </a>
+    </div>
+  <% end %>
+</div>
+
+  </div>
+  <hr>
+  <div class="container">
+    <div class="row text-center">
+        <div class="col-12">
+          <h2 class="display-6" style="color: #026e57;
+    margin-bottom: 10px;
+    margin-top: 40px; font-size:2rem;"><%= t("about.alumni_team_heading") %></h2>
+          <p class="lead"><%= t("about.alumni_team_description") %></p>
+        </div>
+    </div>
+    <div class="container" style="margin: -25px 0px 0px;
+    padding: 34px;">
+    <% @alumni.each_slice(6) do |row_members| %>  
+    <div class="row justify-content-center g-4" style="margin-bottom:43px; margin-top:5px;"> 
+      <% row_members.each do |member| %>
+        <div class="col-md-2 col-sm-4 text-center d-flex flex-column align-items-center">
+          <div>
+            <%= image_tag member[:img], class: "img-fluid rounded-circle shadow-sm", style: "width: 90px; height: 90px; object-fit: cover;" %>
+          </div>
+          <div class="mt-1">
+            <a target="_blank" href="<%= member[:link] %>" class="text-decoration-none text-dark">
+              <p class="fw-light m-0"><%= member[:name] %></p>
+            </a>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+</div>
+  </div>
+  <hr>
+  <div class="container">
+  <div class="row text-center">
+    <div class="col-12">
+      <h2 class="display-6" style="color: #026e57; margin-bottom: 10px; margin-top: 40px; font-size:2rem;">
+        <%= t("about.contributors_heading") %>
+      </h2>
+      <h5><%= t("about.contributors_description") %></h5>
+    </div>
+  </div>
+
+  
+  <div class="container " style="margin:30px 0px 0px; padding:0px 12px;">
+    <div class="row justify-content-center" id="contributors-section" style="margin-top:50px;">
+      
+    </div>
+  </div>
+
+  <div class="row text-center mt-4">
+    <div class="col">
+     <a class="btn " href="/contribute" 
+   style="background-color: #42b983; color: #fff; margin:20px 5px 5px; padding:12px 30px; transition: transform 0.3s ease-in-out, background-color 0.3s ease-in-out;" 
+   onmouseover="this.style.transform='scale(1.1)'; this.style.backgroundColor='#0F3F2D';" 
+   onmouseout="this.style.transform='scale(1)'; this.style.backgroundColor='#42b983';">
+  <%= t("about.become_contributor") %>
+</a>
+
+    </div>
+  </div>
+</div>
+
+<script>
+  async function getContributors(url) {
     let apiData = await fetch(url);
     let contributorsData = await apiData.json();
-    let contributorUsers = contributorsData.filter(function(user) { return (user.type == 'User') });
-    for (let i=0; i<contributorUsers.length; i++){
+    let contributorUsers = contributorsData.filter(user => user.type === 'User');
+    let contributorsContainer = document.getElementById('contributors-section');
+    contributorsContainer.innerHTML = "";
+
+    let row;
+    contributorUsers.slice(0, 100).forEach((user, index) => {
+      if (index % 10 === 0) {
+        
+        row = document.createElement("div");
+        row.classList.add("row", "justify-content-center", "gx-3", "gy-3", style="gap:16px;" );
+        contributorsContainer.appendChild(row);
+      }
+
       let contributorElement = document.createElement('div');
+      contributorElement.classList.add('col-lg-1', 'col-md-2', 'col-sm-3', 'col-4', 'text-center');
+
       let contributorElementAnchor = document.createElement('a');
+      contributorElementAnchor.href = user['html_url'];
+      contributorElementAnchor.target = "_blank";
+
       let contributorElementImage = document.createElement('img');
-      contributorElement.classList.add('about-contributor');
-      contributorElementAnchor.href = await contributorUsers[i]['html_url'];
-      contributorElementImage.src = await contributorUsers[i]['avatar_url'];
-      contributorElementImage.classList.add('about-contributor-image');
+      contributorElementImage.src = user['avatar_url'];
+      contributorElementImage.classList.add('img-fluid', 'rounded-circle', 'shadow-sm');
+      contributorElementImage.style.width = '70px';
+      contributorElementImage.style.height = '70px';
+      contributorElementImage.style.objectFit = 'cover';
+
       contributorElementAnchor.appendChild(contributorElementImage);
       contributorElement.appendChild(contributorElementAnchor);
-      document.getElementsByClassName('about-contributors-section')[0].appendChild(contributorElement);
-    }
+
+      row.appendChild(contributorElement);
+    });
   }
+
   getContributors('https://api.github.com/repos/CircuitVerse/CircuitVerse/contributors?per_page=100');
 </script>


### PR DESCRIPTION
Fixes #5484 

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -
Remove the custom css of the about section and make the  transformation from the custom css to the bootstrap 5 layout and also uses inline css in some part of the code .

### Screenshots of the UI changes (If any) -
<!-- Do not add code diff here -->
![image](https://github.com/user-attachments/assets/71beacf3-0b4e-41b2-952d-ee32002d7246)


## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.




Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Revamped the "About" page with refreshed headings, descriptions, and button hover effects that enhance visual appeal.
	- Improved layout responsiveness and spacing across various sections, including team member displays and alumni organization.

- **New Features**
	- Introduced card components for social media links.
	- Updated team section elements with rounded images and shadow effects, offering a modern and engaging user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->