### PR TITLE
Fixes #5501

### DIFF
--- a/app/views/commontator/threads/_reply.html.erb
+++ b/app/views/commontator/threads/_reply.html.erb
@@ -8,7 +8,7 @@
   <% if thread.is_closed? %>
     <p><%= t 'commontator.thread.status.cannot_post' %></p>
   <% elsif !user %>
-    <p>You must <a href="/users/sign_in" class="anchor-text">login</a> before you can post a comment.</p>
+    <p>You must <a href="/users/sign_in" class="anchor-text" style="margin-left: 0px;">login</a> before you can post a comment.</p>
   <% else %>
     <% if @commontator_new_comment.nil? %>
       <div id="commontator-thread-<%= thread.id %>-new-comment-link" class="new-comment">


### PR DESCRIPTION
Fixes #5501 

Fixes Misalignment and Spacing of 'Login Before Commenting' Message.

### Screenshot of the changes:
![Screenshot 2025-03-05 201126](https://github.com/user-attachments/assets/f9fb94a1-f261-401c-a6ab-72f80b0768cf)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the login prompt for commenting with refined inline styling to ensure a consistent visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->