### PR TITLE
Fix PG::UnableToSend Error by Enhancing tagged_with Query

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -117,7 +117,12 @@ class Project < ApplicationRecord
   end
 
   def self.tagged_with(name)
-    Tag.find_by!(name: name).projects
+    return Project.none if name.blank?
+
+    tag = Tag.includes(:projects).find_by(name: name)
+    return Project.none unless tag
+
+    tag.projects || Project.none
   end
 
   def tag_list


### PR DESCRIPTION
### Fixes #5510
-> Resolves Sentry Issue CIRCUITVERSE-CORE-E1
-> Fixes PG::UnableToSend error caused by missing tag lookups.

-----

<!-- Add issue number above --> 

### Describe the changes you have made in this PR -
This PR fixes an issue in the tagged_with method that could cause PG::UnableToSend errors due to unexpected nil values. 

-----


### Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.

----



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the project filtering process by tag to handle situations where tag names are missing or invalid, reducing unexpected errors.
  - Optimized the loading of related projects for a more efficient experience during tag-based filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->