### PR TITLE
🔧 Standardize Teachers Page with Bootstrap 5 Utilities

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,7 +13,6 @@
 @import 'footer';
 @import 'about';
 @import 'contribute';
-@import 'teacher';
 @import 'search';
 @import 'custom_mail';
 @import 'editor';

--- a/app/views/circuitverse/teachers.html.erb
+++ b/app/views/circuitverse/teachers.html.erb
@@ -3,7 +3,7 @@
 <div class="row justify-content-center text-center mt-5">
   <div class="col-12">
     <h1 class="text-success"><%= t("circuitverse.teachers.main_heading") %></h1>
-    <div class="mb-4 mx-auto" style="max-width: 768px;">
+    <div class="mb-4 mx-auto mw-100">
       <p class="fs-5"><%= t("circuitverse.teachers.main_description") %></p>
     </div>
     <h2><%= t("circuitverse.teachers.benefits") %></h2>

--- a/app/views/circuitverse/teachers.html.erb
+++ b/app/views/circuitverse/teachers.html.erb
@@ -1,62 +1,62 @@
 <% content_for :title, t("circuitverse.teachers.title") %>
 
-<div class="row center-row">
+<div class="row justify-content-center text-center mt-5">
   <div class="col-12">
-    <h1 class="main-heading"><%= t("circuitverse.teachers.main_heading") %></h1>
-    <div class="teacher-main-description-container">
-      <p class="main-description"><%= t("circuitverse.teachers.main_description") %></p>
-    </div> <br>
+    <h1 class="text-success"><%= t("circuitverse.teachers.main_heading") %></h1>
+    <div class="mb-4 mx-auto" style="max-width: 768px;">
+      <p class="fs-5"><%= t("circuitverse.teachers.main_description") %></p>
+    </div>
     <h2><%= t("circuitverse.teachers.benefits") %></h2>
   </div>
 </div>
-<div class="container-fluid teacher-fill-container-fluid">
+<div class="container-fluid py-5">
   <div class="container">
-    <div class="row center-row teacher-center-content">
-      <div class="col-12 col-sm-12 col-md-6 col-lg-6 teacher-left-text">
-        <h4><%= t("circuitverse.teachers.create_group_heading") %></h4> <br>
+    <div class="row justify-content-center align-items-center">
+      <div class="col-md-6 text-start">
+        <h4><%= t("circuitverse.teachers.create_group_heading") %></h4>
         <p><%= t("circuitverse.teachers.create_group_description") %></p>
       </div>
-      <div class="col-12 col-sm-12 col-md-6 col-lg-6">
-        <img class="teacher-image" src="img/groups.png" alt="Groups screenshot">
+      <div class="col-md-6">
+        <img class="img-fluid border border-2 border-secondary" src="img/groups.png" alt="Groups screenshot">
       </div>
     </div>
   </div>
 </div>
-<div class="container-fluid teacher-container-fluid">
+<div class="container-fluid py-5">
   <div class="container">
-    <div class="row center-row teacher-center-content">
-      <div class="col-12 col-sm-12 col-md-6 col-lg-6 teacher-left-text">
-        <h4><%= t("circuitverse.teachers.post_assignment_heading") %></h4> <br>
+    <div class="row justify-content-center align-items-center">
+      <div class="col-md-6 text-start">
+        <h4><%= t("circuitverse.teachers.post_assignment_heading") %></h4>
         <p><%= t("circuitverse.teachers.post_assignment_description") %></p>
       </div>
-      <div class="col-12 col-sm-12 col-md-6 col-lg-6">
-        <img class="teacher-image" src="img/assignment.png" alt="Assignments screenshot">
+      <div class="col-md-6">
+        <img class="img-fluid border border-2 border-secondary" src="img/assignment.png" alt="Assignments screenshot">
       </div>
     </div>
   </div>
 </div>
-<div class="container-fluid teacher-fill-container-fluid">
+<div class="container-fluid py-5">
   <div class="container">
-    <div class="row center-row teacher-center-content">
-      <div class="col-12 col-sm-12 col-md-6 col-lg-6 teacher-left-text">
-        <h4><%= t("circuitverse.teachers.grade_assignment_heading") %></h4> <br>
+    <div class="row justify-content-center align-items-center">
+      <div class="col-md-6 text-start">
+        <h4><%= t("circuitverse.teachers.grade_assignment_heading") %></h4>
         <p><%= t("circuitverse.teachers.grade_assignment_description") %></p>
       </div>
-      <div class="col-12 col-sm-12 col-md-6 col-lg-6">
-        <img class="teacher-image" src="img/grading.png" alt="Grading screenshot" height="250px">
+      <div class="col-md-6">
+        <img class="img-fluid border border-2 border-secondary" src="img/grading.png" alt="Grading screenshot">
       </div>
     </div>
   </div>
 </div>
-<div class="container-fluid teacher-container-fluid">
+<div class="container-fluid py-5">
   <div class="container">
-    <div class="row center-row teacher-center-content">
-      <div class="col-12 col-sm-12 col-md-6 col-lg-6 teacher-left-text">
-        <h4><%= t("circuitverse.teachers.use_interactive_circuit_heading") %></h4> <br>
+    <div class="row justify-content-center align-items-center">
+      <div class="col-md-6 text-start">
+        <h4><%= t("circuitverse.teachers.use_interactive_circuit_heading") %></h4>
         <p><%= t("circuitverse.teachers.use_interactive_circuit_description") %></p>
       </div>
-      <div class="col-12 col-sm-12 col-md-6 col-lg-6">
-        <img class="teacher-image" src="img/embed.png" alt="Embed screenshot" height="350px">
+      <div class="col-md-6">
+        <img class="img-fluid border border-2 border-secondary" src="img/embed.png" alt="Embed screenshot">
       </div>
     </div>
   </div>


### PR DESCRIPTION
Fixes #5484 

-------
<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -
This PR refactors the Teachers page by removing unnecessary custom styles and replacing them with Bootstrap 5 utilities for better maintainability.

Changes Made:

- Removed teachers.scss as it's no longer needed.

- Standardized styling using Bootstrap 5 to improve consistency across pages.

-------

### Screenshots of the UI changes (If any) -

Screen Recording:

https://github.com/user-attachments/assets/db68784b-4082-42f8-b955-68cce8cdc1a9



## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.




Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Style**
	- Enhanced the teacher page’s layout for improved centering, spacing, and responsiveness.
	- Updated heading, text, and image styles create a cleaner and more modern appearance.
	- Removed outdated styling elements to streamline the overall design.
	- Adjusted CSS classes for better alignment and visual presentation of teacher-related content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->