### PR TITLE
Feat: Add GitHub Action to Mark Stale Issues and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-name: Close inactive issues
+name: Close inactive issues/PRs
 on:
   schedule:
     - cron: "30 1 * * *"  # Runs daily at 01:30 UTC

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -27,7 +27,7 @@ jobs:
           days-before-pr-stale: 60
           days-before-pr-close: 180
           stale-pr-label: "no-pr-activity"
-          stale-pr-message: "This PR has been marked as stale because it has been inactive for 14 days. Please update or close it if it's no longer needed. It will be closed after 180 days."
+          stale-pr-message: "This PR has been marked as stale because it has been inactive for 60 days. Please update or close it if it's no longer needed. It will be closed after 180 days."
           close-pr-message: "This PR has been closed due to inactivity for 180 days."
           exempt-pr-labels: "wip" # work in progress
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,7 +29,7 @@ jobs:
           stale-pr-label: "no-pr-activity"
           stale-pr-message: "This PR has been marked as stale because it has been inactive for 14 days. Please update or close it if it's no longer needed. It will be closed after 180 days."
           close-pr-message: "This PR has been closed due to inactivity for 180 days."
-          exempt-pr-labels: "wip"
+          exempt-pr-labels: "wip" # work in progress
 
           # Performance Settings
           remove-stale-when-updated: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,36 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"  # Runs daily at 01:30 UTC
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          
+          # issue handling
+          days-before-issue-stale: 14  
+          days-before-issue-close: 180  
+          stale-issue-label: "no-issue-activity"
+          stale-issue-message: "This issue has been marked as stale because it has been inactive for 14 days. If no further activity occurs, it will be closed after 180 days."
+          close-issue-message: "This issue has been closed due to inactivity for 180 days."
+          exempt-issue-labels: "pinned, security"
+        
+
+          # PR handling
+          days-before-pr-stale: 60
+          days-before-pr-close: 180
+          stale-pr-label: "no-pr-activity"
+          stale-pr-message: "This PR has been marked as stale because it has been inactive for 14 days. Please update or close it if it's no longer needed. It will be closed after 180 days."
+          close-pr-message: "This PR has been closed due to inactivity for 180 days."
+          exempt-pr-labels: "wip"
+
+          # Performance Settings
+          remove-stale-when-updated: true
+          operations-per-run: 50


### PR DESCRIPTION
#### Describe the changes you have made in this PR -
<!-- Do not add code diff here -->
This PR adds GitHub Action that automatically marks inactive issues after 14 days and pull requests after 60 days as stale  of inactivity and closes them after 180 days. The goal is to keep the repository organized by identifying issues and PRs that have not received updates.

### Importance
- Helps in managing the backlog of issues and PRs.
- Prevents inactive or abandoned PRs from cluttering the repository.
- Encourages contributors to keep their discussions and contributions active.

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced automation that manages inactive issues and pull requests by flagging them after a period of inactivity and eventually closing them if updates are not provided. This enhancement helps maintain an active, focused discussion environment while exempting key items from automatic closure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->