### PR TITLE
chore: Restrict username length + RuboCop cleanup

### DIFF
--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -21,7 +21,7 @@
             </div>
           <% end %>
           <div class="field mb-3">
-            <h6><%= f.label :name %> <span class="text-muted">(Max 50 characters)</span> </h6>
+            <h6><%= f.label :name %> <span class="text-muted">(Max 30 characters)</span> </h6>
               <%= f.text_field :name, placeholder: t('enter_name'), autofocus: true, class: "form-control form-input" %>
           </div>
           <div class="field mb-3">

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -11,16 +11,17 @@
         <%= form_with(model: resource, as: resource_name, url: registration_path(resource_name), local: true) do |f| %>
           <%= f.invisible_captcha :subtitle %>
           <% if !resource.errors.empty? %>
-            <div class="error-message">
-              <ul>
+            <div class="alert alert-danger alert-dismissible fade show" role="alert">
+              <ul class="mb-0">
                 <% resource.errors.full_messages.each do |message| %>
                   <li><%= message %></li>
                 <% end %>
               </ul>
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
             </div>
           <% end %>
           <div class="field mb-3">
-            <h6><%= f.label :name %></h6>
+            <h6><%= f.label :name %> <span class="text-muted">(Max 50 characters)</span> </h6>
               <%= f.text_field :name, placeholder: t('enter_name'), autofocus: true, class: "form-control form-input" %>
           </div>
           <div class="field mb-3">


### PR DESCRIPTION
Fixes # 4148

--------
<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -
Reduced the username maximum length from 50 to 30 characters for improved consistency and better user experience.

Applied rubocop -a for automatic code formatting and linting.
This resulted in multiple changes, including:

- Code indentation fixes.
- Improved spacing and alignment.
- Enhanced readability with better structure.
- Minor syntax corrections as per RuboCop guidelines.


-----------


### Screenshots of the UI changes (If any) -
<!-- Do not add code diff here -->

![image](https://github.com/user-attachments/assets/00c56604-f2b5-4598-a392-3508a957df4e)



---------
## Checklist before requesting a review
- [ ] I have added proper PR title and linked to the issue
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.




Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - User names are now automatically shortened if they exceed a 30-character limit.

- **Style**
  - The registration error messages have been revamped with enhanced alert styling and a dismissible close button.
  - The name input field now clearly displays guidance on the maximum allowed characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->