### PR TITLE
refactor: migrated projects page style to bootstrap 5

### DIFF
--- a/app/assets/stylesheets/projects.scss
+++ b/app/assets/stylesheets/projects.scss
@@ -1,13 +1,5 @@
 
 //newproject-editproject
-.projects-new-container {
-  border: 1px solid $form-border-grey;
-  margin-top: 20px;
-  max-width: 80%;
-  padding-bottom: 20px;
-  padding-top: 20px;
-}
-
 .form-control {
     border-radius: 4px;
 }
@@ -16,18 +8,10 @@
   max-width: 260px;
 }
 
-.primary-checkpoint {
-  border-radius: 4px;
-}
-
 .projects-tag-form-group {
   h6 {
     display: inline-block;
   }
-}
-
-.projects-type-field-heading {
-  margin-bottom: 0;
 }
 
 .projects-type-field-warning {
@@ -38,10 +22,6 @@
 
 //breakpoints
 @media (max-width: 400px) {
-  .projects-new-container {
-    max-width: 95%;
-  }
-
   .projects-form-container {
     max-width: 90%;
   }
@@ -49,34 +29,6 @@
 //newproject-editproject ends
 
 //project details
-.projects-iframe-container {
-  border: 1.5px solid $shadow-black;
-  margin-bottom: 20px;
-  padding: 10px;
-}
-
-.projects-details {
-  background-color: $project-card-grey;
-  padding-left: 0;
-  padding-right: 0;
-}
-
-.projects-details-heading-container {
-  background-color: $primary-green;
-  height: 55px;
-  padding-bottom: 10px;
-  padding-top: 10px;
-}
-
-.projects-details-heading {
-  color: $white;
-  font-size: 25px;
-  font-weight: 600;
-  height: 35px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
 .projects-views-count-container {
   color: $black;
   display: block;
@@ -89,29 +41,6 @@
   text-align: right;
 }
 
-.projects-star-count-icon {
-  color: $star-yellow;
-}
-
-.projects-user-details-container {
-  padding: 0 20px 15px;
-
-  >p {
-    display: block;
-    margin-bottom: 10px;
-    text-align: left;
-    width: 80%;
-  }
-}
-
-.projects-search-tags-container {
-  display: block;
-  margin-bottom: 15px;
-  padding-left: 0;
-  text-align: left;
-  width: 80%;
-}
-
 .projects-details-description {
   height: 150px;
   margin-top: -8px;
@@ -119,10 +48,6 @@
   padding-top: 0;
   text-align: left;
   word-wrap: break-word;
-}
-
-.projects-horizontal-rule {
-  width: 100%;
 }
 
 .projects-primary-button {
@@ -189,20 +114,6 @@
   width: 100%;
 }
 
-.projects-collaborators-container {
-  background-color: $project-card-grey;
-}
-
-.projects-collaborators-heading {
-  background-color: $primary-green;
-  color: $white;
-  font-size: 25px;
-  font-weight: 600;
-  height: 55px;
-  margin-bottom: 10px;
-  padding: 10px;
-}
-
 .projects-collaborators-data {
   overflow: hidden;
   padding: 5px 15px;
@@ -221,18 +132,10 @@
   border: 0;
 }
 
-.projects-collaborators-horizontal-rule {
-  width: 80%;
-}
-
 .char-counter {
   color: $tooltip-grey;
   font-size: 14px;
   margin: 5px 0 0 auto;
-}
-
-.is-invalid {
-  color: $red;
 }
 
 //breakpoints

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -5,7 +5,7 @@
     <div class="mb-3 projects-primary-checkpoint">
       <label for="featured_checkbox" class="primary-checkpoint-container"><h6><%= t("projects.form.feature_circuit_checkpoint") %></h6>
         <%= form.check_box :featured, checked: @project.featured?, id: "featured_checkbox" %>
-        <div class="primary-checkpoint"></div>
+        <div class="rounded"></div>
       </label>
     </div>
   <% end %>
@@ -31,7 +31,7 @@
     <%= form.text_field :tag_list, class: "form-control form-input" %>
   </div>
   <div class="field mb-3">
-    <h6 class="projects-type-field-heading"><%= form.label :project_access_type %></h6>
+    <h6 class="mb-0"><%= form.label :project_access_type %></h6>
     <% if @project.featured? %>
       <div class="alert alert-warning d-flex align-items-center" role="alert">
 +        <i class="fa fa-exclamation-triangle me-2"></i>
@@ -91,9 +91,9 @@
       nameCounter.textContent = `${currentLength} / ${maxLength}`;
 
       if (currentLength >= maxLength) {
-        nameCounter.classList.add('is-invalid');
+        nameCounter.classList.add('text-danger');
       } else {
-        nameCounter.classList.remove('is-invalid');
+        nameCounter.classList.remove('text-danger');
       }
     });
   });

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -1,7 +1,7 @@
 
 <% content_for :title, t("projects.edit.title", name: @project.name) %>
 
-<div class="container projects-new-container">
+<div class="container border border-light mt-3 w-75 w-sm-100 py-3">
   <div class="row center-row">
     <div class="col-12 col-sm-12 col-md-12 col-lg-12">
       <h1 class="submain-heading"><%= t("projects.edit.main_heading") %></h1> <br>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -28,23 +28,23 @@
   <br>
   <div class="row center-row">
     <div class="col-12 col-sm-12 col-md-7 col-lg-7 ">
-      <div class="projects-iframe-container">
+      <div class="border border-secondary-subtle mb-5 p-2">
         <div class="ratio ratio-4x3">
           <iframe src=<%= simulator_path(@project) %>></iframe>
         </div>
       </div>
     </div>
     <div class="col-12 col-sm-12 col-md-5 col-lg-5">
-      <div class="container projects-details">
-        <div class="row center-row projects-details-heading-container">
+      <div class="container bg-light px-0">
+        <div class="row center-row bg-success py-2 h-50">
           <div class="col-12 col-sm-12 col-md-12 col-lg-12">
-            <div class="projects-details-heading">
+            <div class="text-light fs-3 fw-bold overflow-hidden text-wrap" style="height: 35px">
               <%= @project.name %>
             </div>
           </div>
         </div>
         <div class="row projects-views-count-container noSelect">
-          <i class="fas fa-star projects-star-count-icon" aria-hidden="true"></i>
+          <i class="fas fa-star text-warning" aria-hidden="true"></i>
           <span id="star-count" class="noSelect"><%= @project.stars.count %></span>
            <%= t("projects.stars_count") %>
           &nbsp; &nbsp;
@@ -52,35 +52,35 @@
           <span id="star-count" class="noSelect"><%= @project.view %></span>
            <%= t("projects.views_count") %> &nbsp; &nbsp;
         </div>
-        <div class="row center-row projects-user-details-container">
-          <div class="projects-search-tags-container">
+        <div class="row center-row pt-0 pb-4 px-5">
+          <div class="d-block mb-4 pl-0 text-left" style="width: 80%">
             <% if !@project.tags.empty? %>
               <% @project.tags.each do |tag| %>
                 <%= link_to tag.name, tag_path(tag.name), class: "badge search-tag" %>
               <% end %>
             <% end %>
           </div>
-          <p>
+          <p class="d-block mb-2 text-start" style="width: 80%">
             <strong><%= t("projects.show.project_author") %> </strong>
             <%= link_to @project.author.name, @project.author, class: "anchor-text" %>
           </p>
           <% if !@project.forked_project.nil? %>
-            <p>
+            <p class="d-block mb-2 text-start" style="width: 80%">
               <strong><%= t("projects.show.project_forked_from") %> </strong>
               <%= link_to "#{@project.forked_project.author.name}/#{@project.forked_project.name}", user_project_path(@project.forked_project.author, @project.forked_project), class: "anchor-text" %>
             </p>
           <% end %>
-          <p>
+          <p class="d-block mb-2 text-start" style="width: 80%">
             <strong><%= t("projects.show.project_access_type") %> </strong>
             <%= @project.project_access_type %>
           </p>
           <% if !@project.description.nil? %>
-            <p>
+            <p class="d-block mb-2 text-start" style="width: 80%">
               <strong><%= t("projects.show.project_description") %> </strong>
             </p>
             <div class="projects-details-description"><%= sanitize @project.description %></div>
           <% end %>
-          <p title="<%= @project.created_at.strftime("%B %d, %Y, %l:%M %p UTC %:z") %>">
+          <p class="d-block mb-2 text-start" style="width: 80%" title="<%= @project.created_at.strftime("%B %d, %Y, %l:%M %p UTC %:z") %>">
             <strong><%= t("projects.show.project_created_at") %> </strong>
             <% if @project.created_at >= 14.days.ago %>
               <%= "#{time_ago_in_words(@project.created_at, include_seconds: true)} ago" %>
@@ -88,7 +88,7 @@
              <%= @project.created_at.strftime("%b %d, %Y") %>
             <% end %>
           </p>
-          <p title="<%= @project.updated_at.strftime("%B %d, %Y, %l:%M %p UTC %:z") %>">
+          <p class="d-block mb-2 text-start" style="width: 80%" title="<%= @project.updated_at.strftime("%B %d, %Y, %l:%M %p UTC %:z") %>">
             <strong><%= t("projects.show.project_updated_at") %> </strong>
             <% if @project.updated_at >= 14.days.ago %>
               <%= "#{time_ago_in_words(@project.updated_at, include_seconds: true)} ago" %>
@@ -97,10 +97,10 @@
             <% end %>
           </p>
           <% if user_signed_in? %>
-            <p>
-              <hr class="projects-horizontal-rule">
+            <p class="d-block mb-2 text-start" style="width: 80%">
+              <hr class="w-100">
               <% if policy(@project).user_access? %>
-                <a href="<%= simulator_edit_path(@project) %>" class="btn primary-button projects-primary-button" target="_blank" rel="noopener noreferrer"><%= t("launch_simulator") %></a>
+                <a href="<%= simulator_edit_path(@project) %>" class="btn primary-button ms-0 py-1 px-2" target="_blank" rel="noopener noreferrer"><%= t("launch_simulator") %></a>
               <% else %>
                 <a class="btn primary-button projects-self-embed-button" class="embed-trigger" href="#" data-bs-target="#embedProjectCircuit" data-bs-toggle="modal">
                 <i class="fas fa-code"></i>
@@ -119,20 +119,20 @@
                 <% end %>
               <% end %>
               <% if @project.stars.exists?(user_id: current_user.id) %>
-                <i id="toggleStarButton" class="fas fa-star btn primary-button projects-primary-button projects-button-star-icon" aria-hidden="true" onclick="toggleStar()"></i>
+                <i id="toggleStarButton" class="fas fa-star btn primary-button  project-button-star-icon ms-0" aria-hidden="true" onclick="toggleStar()"></i>
               <% else %>
-                <i id="toggleStarButton" class="far fa-star btn primary-button projects-primary-button projects-button-star-icon" aria-hidden="true" onclick="toggleStar()"></i>
+                <i id="toggleStarButton" class="far fa-star btn primary-button  project-button-star-icon ms-0" aria-hidden="true" onclick="toggleStar()"></i>
               <% end %>
             </p>
           <% end %>
           <% if policy(@project).author_access? %>
-            <p id="collaboration_button">
+            <p class="d-block mb-2 text-start" style="width: 80%" id="collaboration_button">
               <a href="#" class="anchor-text" id="<%= @project.id %>" data-bs-toggle="modal" data-bs-target="#collaboratorModal"><%= t("projects.show.project_collaborator_add") %></a>
             </p>
           <% end %>
           <% if policy(@project).user_access? %>
             <hr class="projects-horizontal-rule">
-            <p>
+            <p class="d-block mb-2 text-start" style="width: 80%">
               <%= link_to edit_user_project_path(@author, @project), class: "btn secondary-button ml-0 py-1 px-2 d-inline-flex justify-content-center align-items-center" do %>
                 <%= image_tag("SVGs/editProject.svg", alt: "Edit Project") %>
                 <span><%= t("edit") %></span>
@@ -156,9 +156,9 @@
     <% if collaborators.count!=0 %>
       <div class="row center-row">
         <div class="col-12 col-sm-12 col-md-12 col-lg-12">
-          <div class="projects-collaborators-container">
+          <div class="bg-light">
             <div class="row center-row">
-              <div class="col-12 col-sm-12 col-md-12 col-lg-12 projects-collaborators-heading">
+              <div class="col-12 col-sm-12 col-md-12 col-lg-12 bg-success text-light fs-3 fw-bold h-50 mb-2 p-2">
                 <div class="">
                   <%= t("projects.show.collaborators") %>
                 </div>
@@ -186,7 +186,7 @@
                     </div>
                   </div>
                 <% end %>
-                <hr class="projects-collaborators-horizontal-rule">
+                <hr class="w-75">
               </div>
             <% end %>
           </div>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -92,7 +92,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_10_20_082634) do
 
   create_table "assignments", force: :cascade do |t|
     t.string "name"
-    t.datetime "deadline", null: false
+    t.datetime "deadline", precision: nil, null: false
     t.text "description"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
@@ -366,7 +366,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_10_20_082634) do
     t.string "slug"
     t.tsvector "searchable"
     t.string "lis_result_sourced_id"
-    t.string "version", default: "1.0", null: false
     t.index ["assignment_id"], name: "index_projects_on_assignment_id"
     t.index ["author_id"], name: "index_projects_on_author_id"
     t.index ["forked_project_id"], name: "index_projects_on_forked_project_id"


### PR DESCRIPTION
Fixes #5484

#### Describe the changes you have made in this PR -

Altered most of the classes to use bootstrap 5 instead of custom css in the "Projects" page. 

### Screenshots of the UI changes (If any) -
- Projects page Before:
![projects before](https://github.com/user-attachments/assets/b89af1e3-5030-4df6-a7a0-e51df6dff2fc)

- Projects page After:
![projects after](https://github.com/user-attachments/assets/24634444-a58c-4862-abea-2ccda0d5aa05)

- Projects/edit page Before:
![edit before](https://github.com/user-attachments/assets/dd234f9a-edc4-4191-b5c4-1dbaff3c7c66)

- Projects/edit page After:
![edits after](https://github.com/user-attachments/assets/1fba40ab-f9c9-4146-9bad-025e033a2a38)




Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
