### PR TITLE
Switch from `pull_request` to `pull_request_target` in Percy workflow

### DIFF
--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -1,7 +1,5 @@
 name: "Percy Visual Tests"
 
-# CHANGED: Switched from 'pull_request' to 'pull_request_target' so we can use secrets
-# from the base repo context on forked PRs, while still testing the PR's code.
 on:
   push:
     branches:
@@ -35,14 +33,13 @@ jobs:
       DATABASE_URL: "postgres://rails:password@localhost:5432/rails_test"
 
     steps:
-      # 1) First checkout is the base repository (where secrets are accessible).
+      
       - name: Check out base repo code
         uses: actions/checkout@v3
         with:
           submodules: recursive
 
-      # 2) ONLY if it's a pull_request_target event, check out the forked PR code
-      #    so we actually test the external contributor's changes.
+     
       - name: Check out PR code (fork)
         if: ${{ github.event_name == 'pull_request_target' }}
         uses: actions/checkout@v3

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -12,6 +12,12 @@ on:
 
 jobs:
   percy-tests:
+    
+    if: >
+      ${{ github.event_name == 'push' 
+         || (github.event_name == 'pull_request_target' 
+             && contains(toJson(github.event.pull_request.labels), 'check-visual-regression')) }}
+
     runs-on: ubuntu-latest
 
     services:
@@ -33,13 +39,12 @@ jobs:
       DATABASE_URL: "postgres://rails:password@localhost:5432/rails_test"
 
     steps:
-      
+
       - name: Check out base repo code
         uses: actions/checkout@v3
         with:
           submodules: recursive
 
-     
       - name: Check out PR code (fork)
         if: ${{ github.event_name == 'pull_request_target' }}
         uses: actions/checkout@v3

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -1,11 +1,13 @@
 name: "Percy Visual Tests"
 
+# CHANGED: Switched from 'pull_request' to 'pull_request_target' so we can use secrets
+# from the base repo context on forked PRs, while still testing the PR's code.
 on:
   push:
     branches:
       - master
       - main
-  pull_request:
+  pull_request_target:
     branches:
       - master
       - main
@@ -33,9 +35,20 @@ jobs:
       DATABASE_URL: "postgres://rails:password@localhost:5432/rails_test"
 
     steps:
-      - name: Check out code
+      # 1) First checkout is the base repository (where secrets are accessible).
+      - name: Check out base repo code
         uses: actions/checkout@v3
         with:
+          submodules: recursive
+
+      # 2) ONLY if it's a pull_request_target event, check out the forked PR code
+      #    so we actually test the external contributor's changes.
+      - name: Check out PR code (fork)
+        if: ${{ github.event_name == 'pull_request_target' }}
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
           submodules: recursive
 
       - name: Set up Ruby


### PR DESCRIPTION
## Summary

This PR updates our `.github/workflows/percy.yml` to use **`pull_request_target`** instead of `pull_request`, allowing Percy visual tests to run on external (forked) pull requests **before** merging. It ensures our `PERCY_TOKEN` remains accessible in the base repository context, yet still tests the contributor's changes.

## Changes

- **Changed:** `pull_request:` → `pull_request_target:` in the workflow triggers.
- **Added:** A second checkout step that fetches the fork’s code (`github.event.pull_request.head.ref`) _only_ when it's a `pull_request_target` event.
- **Kept** all other steps (Ruby/Node setup, Percy install, DB prep, RSA keys, build, etc.) the same.

## Why `pull_request_target`?

- Secrets are _not_ automatically exposed to forked PRs with `pull_request_target`, because the workflow runs in the “trusted” base-repo context.
- We can still retrieve and test the fork’s code with an extra checkout step.
- Maintainers can require **manual workflow approval** for first-time contributors to avoid malicious usage.

## Security Note

- **Enable** “Require approval.  
- **Review** any suspicious code that might print secrets (e.g., `$PERCY_TOKEN`) before approving the workflow.  

Using this approach, we can preview Percy snapshots _before_ merging any external PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Enhanced our visual testing process to further ensure the quality and reliability of visual features. These improvements help maintain a smooth, consistent experience as new contributions are integrated.
  - Updated workflow configuration to securely test contributions from forks while accessing necessary secrets. 
  - Modified event triggers for the workflow to improve testing capabilities for pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->