### PR TITLE
Restrict Percy Tests to Exact Matching "check-visual-regression" Label

### DIFF
--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -14,9 +14,12 @@ jobs:
   percy-tests:
     
     if: >
-      ${{ github.event_name == 'push' 
-         || (github.event_name == 'pull_request_target' 
-             && contains(toJson(github.event.pull_request.labels), 'check-visual-regression')) }}
+      github.event_name == 'push'
+      OR (
+        github.event_name == 'pull_request_target'
+        AND
+        contains(toJson(github.event.pull_request.labels), '"name":"check-visual-regression"')
+      )
 
     runs-on: ubuntu-latest
 
@@ -39,7 +42,7 @@ jobs:
       DATABASE_URL: "postgres://rails:password@localhost:5432/rails_test"
 
     steps:
-
+     
       - name: Check out base repo code
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## Summary
This pull request updates the condition for running Percy visual tests so that it matches the PR label `"check-visual-regression"` **more precisely**. 

Previously, the workflow just searched for the substring `check-visual-regression` anywhere in the labels’ JSON. Now, it looks explicitly for the snippet `"name":"check-visual-regression"`, ensuring we only trigger Percy tests if a PR has that **exact** label name.

## Details
- **Why this helps**: Prevents any partial or accidental match and guarantees only the `"check-visual-regression"` label triggers the test.
- **Outcome**: Percy tests won’t appear for a PR unless it is explicitly labeled `"check-visual-regression"`, or if it’s a direct push to `master`/`main`.



---------------------

This is to iterate over #5547 to solve the issue encountered in #5476 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Enhanced the triggering logic for visual regression checks to ensure more consistent quality verification.

- **Style**
	- Introduced minor formatting refinements in configuration for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->