### PR TITLE
Issue#5546: Introduced deletion in batch

### DIFF
--- a/app/models/star.rb
+++ b/app/models/star.rb
@@ -17,6 +17,6 @@ class Star < ApplicationRecord
     end
 
     def cleanup_notification
-      notifications_as_star.destroy_all
+      notifications_as_star.in_batches(of: 200).delete_all
     end
 end


### PR DESCRIPTION
Fixes #5546

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -
PROBLEM
The cleanup_notification method previously used destroy_all, which loaded all records into memory before deleting them. This caused high memory usage and slow performance, leading to PG::QueryCanceled: ERROR: canceling statement due to statement timeout in PostgreSQL.
SOLUTION
-> Replaced destroy_all with delete_all to perform a direct SQL DELETE without loading records into memory.
-> This significantly improves performance and prevents timeouts while removing notifications.

### Screenshots of the UI changes (If any) -
<!-- Do not add code diff here -->


## Checklist before requesting a review
- [ ] I have added proper PR title and linked to the issue
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.




Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
