### PR TITLE
Increase Viewport Size in Notification Specs to Fix Visibility Issues

### DIFF
--- a/spec/system/notification_spec.rb
+++ b/spec/system/notification_spec.rb
@@ -7,7 +7,7 @@ describe "Notifcation", type: :system do
     @author = FactoryBot.create(:user)
     @user = sign_in_random_user
     @project = FactoryBot.create(:project, name: "Project", author: @author, project_access_type: "Public")
-    driven_by(:selenium_chrome_headless)
+    driven_by(:selenium_chrome_headless, screen_size: [1400, 900])
   end
 
   it "initiate notification" do

--- a/spec/system/notification_spec.rb
+++ b/spec/system/notification_spec.rb
@@ -11,7 +11,7 @@ describe "Notifcation", type: :system do
     page.driver.browser.manage.window.resize_to(1920, 1080)
   end
 
-  it "initiates notification" do
+  it "initiate notification" do
     sign_in @user
     visit user_project_path(@author, @project)
     perform_enqueued_jobs { click_on "Fork" }
@@ -27,21 +27,21 @@ describe "Notifcation", type: :system do
       visit notifications_path(@author)
     end
 
-    it "renders all notifications" do
+    it "render all notifications" do
       expect(page).to have_text("#{@user.name} forked your Project #{@project.name}")
     end
 
-    it "renders all unread notifications" do
+    it "render all unread notifications" do
       page.find("#unread-notifications").click
       expect(page).to have_text("#{@user.name} forked your Project #{@project.name}")
     end
 
-    it "marks all notifications as read" do
+    it "mark all notifications as read" do
       click_on "Mark all as read"
       expect(@author.noticed_notifications.unread.count).to eq(0)
     end
 
-    it "marks a notification as read" do
+    it "mark notification as read" do
       click_on "#{@user.name} forked your Project #{@project.name}"
       expect(@author.noticed_notifications.read.count).to eq(1)
     end

--- a/spec/system/notification_spec.rb
+++ b/spec/system/notification_spec.rb
@@ -8,7 +8,6 @@ describe "Notifcation", type: :system do
     @user = sign_in_random_user
     @project = FactoryBot.create(:project, name: "Project", author: @author, project_access_type: "Public")
     driven_by(:selenium_chrome_headless, screen_size: [1920, 1080])
-    page.driver.browser.manage.window.resize_to(1920, 1080)
   end
 
   it "initiate notification" do

--- a/spec/system/notification_spec.rb
+++ b/spec/system/notification_spec.rb
@@ -7,13 +7,13 @@ describe "Notifcation", type: :system do
     @author = FactoryBot.create(:user)
     @user = sign_in_random_user
     @project = FactoryBot.create(:project, name: "Project", author: @author, project_access_type: "Public")
-    driven_by(:selenium_chrome_headless, screen_size: [1920, 1080])
+    page.driver.browser.manage.window.resize_to(1920, 1080)
   end
 
   it "initiate notification" do
     sign_in @user
     visit user_project_path(@author, @project)
-    perform_enqueued_jobs { click_on "Fork" }
+    click_on "Fork"
     expect(@author.noticed_notifications.count).to eq(1)
   end
 
@@ -21,7 +21,7 @@ describe "Notifcation", type: :system do
     before do
       sign_in @user
       visit user_project_path(@author, @project)
-      perform_enqueued_jobs { click_on "Fork" }
+      click_on "Fork"
       sign_in @author
       visit notifications_path(@author)
     end

--- a/spec/system/notification_spec.rb
+++ b/spec/system/notification_spec.rb
@@ -7,7 +7,7 @@ describe "Notifcation", type: :system do
     @author = FactoryBot.create(:user)
     @user = sign_in_random_user
     @project = FactoryBot.create(:project, name: "Project", author: @author, project_access_type: "Public")
-    driven_by(:selenium_chrome_headless, screen_size: [1400, 900])
+    driven_by(:selenium_chrome_headless, screen_size: [1920, 1080])
   end
 
   it "initiate notification" do

--- a/spec/system/notification_spec.rb
+++ b/spec/system/notification_spec.rb
@@ -11,10 +11,10 @@ describe "Notifcation", type: :system do
     page.driver.browser.manage.window.resize_to(1920, 1080)
   end
 
-  it "initiate notification" do
+  it "initiates notification" do
     sign_in @user
     visit user_project_path(@author, @project)
-    click_on "Fork"
+    perform_enqueued_jobs { click_on "Fork" }
     expect(@author.noticed_notifications.count).to eq(1)
   end
 
@@ -22,26 +22,26 @@ describe "Notifcation", type: :system do
     before do
       sign_in @user
       visit user_project_path(@author, @project)
-      click_on "Fork"
+      perform_enqueued_jobs { click_on "Fork" }
       sign_in @author
       visit notifications_path(@author)
     end
 
-    it "render all notifications" do
+    it "renders all notifications" do
       expect(page).to have_text("#{@user.name} forked your Project #{@project.name}")
     end
 
-    it "render all unread notifications" do
+    it "renders all unread notifications" do
       page.find("#unread-notifications").click
       expect(page).to have_text("#{@user.name} forked your Project #{@project.name}")
     end
 
-    it "mark all notifications as read" do
+    it "marks all notifications as read" do
       click_on "Mark all as read"
       expect(@author.noticed_notifications.unread.count).to eq(0)
     end
 
-    it "mark notification as read" do
+    it "marks a notification as read" do
       click_on "#{@user.name} forked your Project #{@project.name}"
       expect(@author.noticed_notifications.read.count).to eq(1)
     end

--- a/spec/system/notification_spec.rb
+++ b/spec/system/notification_spec.rb
@@ -7,7 +7,7 @@ describe "Notifcation", type: :system do
     @author = FactoryBot.create(:user)
     @user = sign_in_random_user
     @project = FactoryBot.create(:project, name: "Project", author: @author, project_access_type: "Public")
-    page.driver.browser.manage.window.resize_to(1920, 1080)
+    page.driver.browser.manage.window.resize_to(1400, 900)
   end
 
   it "initiate notification" do

--- a/spec/system/notification_spec.rb
+++ b/spec/system/notification_spec.rb
@@ -8,6 +8,7 @@ describe "Notifcation", type: :system do
     @user = sign_in_random_user
     @project = FactoryBot.create(:project, name: "Project", author: @author, project_access_type: "Public")
     driven_by(:selenium_chrome_headless, screen_size: [1920, 1080])
+    page.driver.browser.manage.window.resize_to(1920, 1080)
   end
 
   it "initiate notification" do


### PR DESCRIPTION
## Description

This PR updates the `spec/system/notification_spec.rb` to ensure notifications are properly created and visible during tests. Instead of relying on a wait or sleep, we now wrap the “Fork” action within `perform_enqueued_jobs`, ensuring the background job that creates the notification is processed inline. We also specify a larger viewport size so the notification elements are fully visible.

## Changes

- Added `perform_enqueued_jobs { click_on "Fork" }` in both the "initiate notification" test and within the notification page context to process background jobs inline.
- Set `driven_by(:selenium_chrome_headless, screen_size: [1920, 1080])` to increase the viewport size.

## Motivation and Context

Our CI/CD tests were failing because:
1. The notification job was not always processed before assertions were made, causing a mismatch in expected notification counts.
2. The default viewport size sometimes hid the notification UI elements, making Capybara unable to find them.

By processing jobs inline and increasing the viewport size, we ensure that:
- The notifications are created and visible in time for the tests.
- All necessary UI elements are accessible during test execution.

## Additional Notes

This change is isolated to the notification specs, ensuring minimal impact on other tests. No other logic or behavior has been modified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Adjusted our automated system test configuration to resize the browser window to a resolution of 1400 by 900 pixels during headless test runs, enhancing rendering simulation for more accurate test results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->