### PR TITLE
Fix Notification System Tests Failing in CI by Forcing a Larger Viewport

### DIFF
--- a/spec/system/notification_spec.rb
+++ b/spec/system/notification_spec.rb
@@ -7,7 +7,9 @@ describe "Notifcation", type: :system do
     @author = FactoryBot.create(:user)
     @user = sign_in_random_user
     @project = FactoryBot.create(:project, name: "Project", author: @author, project_access_type: "Public")
-    driven_by(:selenium_chrome_headless)
+    driven_by(:selenium_chrome_headless) do |driver_options|
+      driver_options.add_argument '--window-size=1920,1080'
+    end
   end
 
   it "initiate notification" do

--- a/spec/system/notification_spec.rb
+++ b/spec/system/notification_spec.rb
@@ -8,7 +8,7 @@ describe "Notifcation", type: :system do
     @user = sign_in_random_user
     @project = FactoryBot.create(:project, name: "Project", author: @author, project_access_type: "Public")
     driven_by(:selenium_chrome_headless) do |driver_options|
-      driver_options.add_argument '--window-size=1920,1080'
+      driver_options.add_argument "--window-size=1920,1080"
     end
   end
 


### PR DESCRIPTION

**Issue:**  
The CI system tests for the notifications feature have been intermittently failing. Upon investigation, it was determined that the default viewport size in headless Chrome was too small, causing responsive UI elements—such as notification links and buttons—to be hidden or collapsed.

**Solution:**  
This PR updates the `notification_spec.rb` file to configure the Selenium Chrome Headless driver with a larger viewport (`1920x1080`). This change ensures that all notification UI elements are visible during tests, thereby preventing failures related to hidden elements.

**Changes Made:**  
- Modified the driver setup in `notification_spec.rb` to add the argument `--window-size=1920,1080` within the `driven_by` block.
- This change is applied locally within the notification tests to keep the test setup specific and non-intrusive to other specs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Enhanced headless browser testing by setting a fixed viewport size of 1920x1080.
  - These improvements help ensure consistent rendering and interaction during system tests, contributing to stable outcomes in quality assurance without affecting end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->