### PR TITLE
fixed misaligned embed button in projects panel and remove unnecessarry class

### DIFF
--- a/app/assets/stylesheets/projects.scss
+++ b/app/assets/stylesheets/projects.scss
@@ -143,13 +143,6 @@
   padding-top: 8px;
 }
 
-.projects-self-embed-button {
-
-  &.active {
-    background-color: $secondary-green;
-    color: $white;
-  }
-}
 
 .projects-embed-text-container {
   padding-left: 5px;

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -102,7 +102,7 @@
               <% if policy(@project).user_access? %>
                 <a href="<%= simulator_edit_path(@project) %>" class="btn primary-button projects-primary-button" target="_blank" rel="noopener noreferrer"><%= t("launch_simulator") %></a>
               <% else %>
-                <a class="btn primary-button projects-self-embed-button" class="embed-trigger" href="#" data-bs-target="#embedProjectCircuit" data-bs-toggle="modal">
+                <a class="btn primary-button projects-primary-button" class="embed-trigger" href="#" data-bs-target="#embedProjectCircuit" data-bs-toggle="modal">
                 <i class="fas fa-code"></i>
                 <span><%= t("projects.show.project_embed") %></span>
               </a>
@@ -141,7 +141,7 @@
                 <%= image_tag("SVGs/deleteProject.svg", alt: "Delete Project") %>
                 <span><%= t("delete") %></span>
               <% end %>
-              <a class="btn secondary-button ms-0 py-1 px-2 d-inline-flex justify-content-center align-items-center projects-self-embed-button embed-trigger" href="#" data-bs-target="#embedProjectCircuit" data-bs-toggle="modal">
+              <a class="btn secondary-button ms-0 py-1 px-2 d-inline-flex justify-content-center align-items-center embed-trigger" href="#" data-bs-target="#embedProjectCircuit" data-bs-toggle="modal">
                 <i class="fas fa-code me-1"></i>
                 <span><%= t("projects.show.project_embed") %></span>
               </a>


### PR DESCRIPTION


Fixes #5554 

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -
replaced projects-self-embed-button class with projects-primary-button class to add left margin 0 property, also removed
projects-self-embed-button class form projects.scss and show.html.erb because it was unnecessary and didn't affect buttons' behavior in active state

### Screenshots of the UI changes (If any) -
<!-- Do not add code diff here -->
before:
![Screenshot 2025-03-13 130657](https://github.com/user-attachments/assets/05c9156e-3158-4f58-8726-8713bde86bd9)
after:
![Screenshot 2025-03-13 130724](https://github.com/user-attachments/assets/bec118b3-a3fa-45bf-bd97-68d5a75ba154)

for embed button in self project:
before:
![Screenshot 2025-03-13 132127](https://github.com/user-attachments/assets/35e40ba2-3c7e-4e11-a44f-8f21228ebdc0)
after:
![image](https://github.com/user-attachments/assets/3cc3be3c-14f4-4593-a9f0-4e500e010ffe)

I have also checked difference in active state of both buttons and didn't find any

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code




Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
