### PR TITLE
fix: percy label not being detected

### DIFF
--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -6,7 +6,7 @@ on:
       - master
       - main
   pull_request_target:
-    types: [opened, reopened, synchronized, labeled]
+    types: [opened, reopened, synchronize, labeled]
     branches:
       - master
       - main

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -54,13 +54,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           submodules: recursive
 
-      - name: Debug: Show PR labels
-        if: ${{ github.event_name == 'pull_request_target' }}
-        run: |
-          echo "Event name: ${{ github.event_name }}"
-          echo "Pull request labels:"
-          echo "${{ toJson(github.event.pull_request.labels) }}"
-
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -6,21 +6,20 @@ on:
       - master
       - main
   pull_request_target:
+    types: [opened, reopened, synchronized, labeled]
     branches:
       - master
       - main
 
 jobs:
   percy-tests:
-    
     if: >
       github.event_name == 'push'
       OR (
         github.event_name == 'pull_request_target'
         AND
-        contains(toJson(github.event.pull_request.labels), '"name":"check-visual-regression"')
+        contains(toJson(github.event.pull_request.labels), 'check-visual-regression')
       )
-
     runs-on: ubuntu-latest
 
     services:
@@ -42,7 +41,6 @@ jobs:
       DATABASE_URL: "postgres://rails:password@localhost:5432/rails_test"
 
     steps:
-     
       - name: Check out base repo code
         uses: actions/checkout@v3
         with:
@@ -55,6 +53,13 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           submodules: recursive
+
+      - name: Debug: Show PR labels
+        if: ${{ github.event_name == 'pull_request_target' }}
+        run: |
+          echo "Event name: ${{ github.event_name }}"
+          echo "Pull request labels:"
+          echo "${{ toJson(github.event.pull_request.labels) }}"
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -6,20 +6,18 @@ on:
       - master
       - main
   pull_request_target:
-    types: [opened, reopened, synchronize, labeled]
     branches:
       - master
       - main
 
 jobs:
   percy-tests:
+    
     if: >
-      github.event_name == 'push'
-      OR (
-        github.event_name == 'pull_request_target'
-        AND
-        contains(toJson(github.event.pull_request.labels), 'check-visual-regression')
-      )
+      ${{ github.event_name == 'push' 
+         || (github.event_name == 'pull_request_target' 
+             && contains(toJson(github.event.pull_request.labels), 'check-visual-regression')) }}
+
     runs-on: ubuntu-latest
 
     services:
@@ -41,6 +39,7 @@ jobs:
       DATABASE_URL: "postgres://rails:password@localhost:5432/rails_test"
 
     steps:
+
       - name: Check out base repo code
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## Description
This PR updates the Percy GitHub Actions workflow to correctly trigger visual regression tests only when a PR has the **check-visual-regression** label. Previously, the workflow was not running even when the label was present. 

### Key Changes:
- Added `labeled` to `pull_request_target.types` to ensure the workflow runs when the label is added.
- Improved the condition checking for PR labels in the `if:` clause.
- Added a debug step to print the PR labels at runtime to help diagnose label detection issues.

With this change, Percy visual regression tests should correctly run when the `check-visual-regression` label is present on a pull request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Expanded workflow triggers to cover more pull request events.
  - Streamlined label checks for visual regression tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->