### PR TITLE
fixed ruby version in wsl documentation

### DIFF
--- a/installation_docs/manual/windows-wsl.md
+++ b/installation_docs/manual/windows-wsl.md
@@ -39,10 +39,10 @@ cd CircuitVerse
      gpg --keyserver keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
      curl -sSL https://get.rvm.io | bash -s stable
      ```
-- Ruby 3.4.1
+- Ruby 3.2.1
      ```bash
-     rvm install 3.4.1
-     rvm use 3.4.1
+     rvm install 3.2.1
+     rvm use 3.2.1
      ```
 - [Redis 7.0 [atleast]](https://redis.io/docs/getting-started/installation/install-redis-on-linux/)
      ```bash


### PR DESCRIPTION
This PR updates the Ruby version in the WSL setup documentation to avoid issues caused by missing default gems. Previously, the documentation instructed contributors to install Ruby 3.4.1, which required manually installing some default gems not listed in Gemfile. This caused inconvenience and unnecessary debugging for new contributors.

Changes:
Updated the Ruby version in the WSL setup guide to a version that includes the required default gems.
Ensured compatibility with the existing Gemfile to prevent additional manual installations.

I have manually checked issues faced by some contributors and all those errors don't occur after downgrading the ruby version to 3.2.1, also ruby 3.2.1 is recommended by all other setup instructions.

this is a screenshot from one of the contributors:
![image](https://github.com/user-attachments/assets/91b7ceb4-b5a9-4e45-bd9a-3e6f5327035d)

even if base64 gem is manually added there are 4 other gems which had to be explicitly added, namely
mutex_m
fiddle
ostruct
observer 

and only after you add those gems, the commands for database creation will execute properly.
