### PR TITLE
feat: use zxcvbn for password on signup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -224,3 +224,5 @@ gem "sentry-sidekiq", "~> 5.17"
 gem 'devise_saml_authenticatable'
 
 gem 'activerecord_cursor_paginate'
+
+gem "zxcvbn-ruby", "~> 1.2"


### PR DESCRIPTION
Fixes #5603

#### Describe the changes you have made in this PR -
Added password strength validation during user registration to enhance security measures. The implementation includes:

- Integrated the `zxcvbn` gem to evaluate password strength
- Implemented password strength check before user signup
- Set minimum password strength score requirement to 2 (on a scale of 0-4), would like to increase it to 3 at least if community agrees. 
- Added user feedback for weak passwords, including specific improvement suggestions
- Prevents common/easily crackable passwords from being used

The changes help protect users by ensuring they create stronger passwords that are:
- Less susceptible to dictionary attacks
- Not commonly used passwords
- Have sufficient complexity
- More resistant to brute force attempts

### Screenshots of the UI changes (If any) -
<img width="665" alt="Screenshot 2025-03-25 at 5 51 48 PM" src="https://github.com/user-attachments/assets/f387a8bd-9329-4bf0-9aca-479b82076d7c" />
<img width="629" alt="Screenshot 2025-03-25 at 5 52 04 PM" src="https://github.com/user-attachments/assets/e2fbf6b5-5971-4dad-9980-b10298be5616" />

### Note : Different error messages based on the password.
You can read more [about it here](https://github.com/envato/zxcvbn-ruby). 

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved the user registration process by enforcing stronger password requirements. Users now receive immediate feedback if their chosen password does not meet the new strength standards.
	- Enhanced overall account security by integrating an advanced password strength evaluation tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->