### PR TITLE
fix: API in footer

### DIFF
--- a/app/component/footer_links_component.rb
+++ b/app/component/footer_links_component.rb
@@ -22,7 +22,7 @@ class FooterLinksComponent < ViewComponent::Base
       { url: "/contribute", text: "layout.footer.link_to_contribute" },
       { url: "/teachers", text: "layout.link_to_teachers" },
       { url: "/about", text: "layout.link_to_about" },
-      { url: "https://api.circuitverse.org", text: "layout.api", target: "_blank" },
+      { url: "https://api.circuitverse.org", text: "API", target: "_blank" },
       { url: "https://docs.circuitverse.org/#/chapter8/2cvfaq", text: "layout.link_to_faq" }
     ]
   end


### PR DESCRIPTION
### Fixes #5605 

#### Describe the changes you have made in this PR  
- Standardized the capitalization of **"Api"** to **"API"** on ruby code. Removed localized.
- As API entries were missing in locale `.yml`, it was evident it was meant to be left untranslated.

## Checklist before requesting a review  
- [x] I have added a proper PR title and linked it to the issue.  
- [x] I have performed a self-review of my code.  
- [x] If it is a core feature, I have added thorough tests.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the display text of a footer link for clearer presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->