### PR TITLE
fix: buggy behaviour in creator joining group

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -27,6 +27,8 @@ class GroupsController < ApplicationController
     if Group.with_valid_token.exists?(group_token: params[:token])
       if current_user.groups.exists?(id: @group)
         notice = "Member is already present in the group."
+      elsif current_user.id == @group.primary_mentor_id
+        notice = "You cannot join this group because you are its primary mentor."
       else
         current_user.group_members.create!(group: @group)
         notice = "Group member was successfully added."


### PR DESCRIPTION
### Fixes #5608  

#### **Describe the changes you have made in this PR**  
- Added a condition to prevent the primary mentor from joining their own group via an invite link.  
- Displaying the notice: **"You cannot join this group because you are its primary mentor."**  

### **Code Change:**  
```ruby
elsif current_user.id == @group.primary_mentor_id
  notice = "You cannot join this group because you are its primary mentor."
```

### **Screenshots of the UI changes (If any)**  
![image](https://github.com/user-attachments/assets/a73a1634-cf27-4f18-b01e-14b2fac7b2a8)
## **Checklist before requesting a review**  
- [x] I have added a proper PR title and linked it to the issue.  
- [x] I have performed a self-review of my code.  
- [x] If it is a core feature, I have added thorough tests.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the group invitation process so that if a user is identified as a primary mentor, they receive a notice preventing them from joining the group.
  - Other invitation checks continue to operate as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->