### PR TITLE
Fix: Keep users in Recent Circuits section after pagination (#5616)

### DIFF
--- a/app/views/circuitverse/index.html.erb
+++ b/app/views/circuitverse/index.html.erb
@@ -202,7 +202,7 @@
       </div>
     </div>
     <% cache "recent-projects-#{params[:after]}-#{params[:before]}", expires_in: 10.minutes do %>
-      <div class="container" id="recent">
+      <div class="container" id="recent" style="scroll-margin-top: 150px;" >
         <div class="row center-row home-circuit-card-row">
           <div class="col-12 col-sm-12 col-md-12 col-lg-12">
             <h3><%= t("circuitverse.index.recent_circuits.main_heading") %></h3>
@@ -228,10 +228,10 @@
         <div class="container pagination-cont">
           <div class="pagination justify-content-center">
             <% if @projects_page.has_previous? %>
-              <%= link_to t("previous"), root_path(before: @projects_page.previous_cursor), class: "page-link" %>
+              <%= link_to t("previous"), root_path(before: @projects_page.previous_cursor, anchor: "recent"), class: "page-link" %>
             <% end %>
             <% if @projects_page.has_next? %>
-              <%= link_to t("next"), root_path(after: @projects_page.next_cursor), class: "page-link" %>
+              <%= link_to t("next"), root_path(after: @projects_page.next_cursor, anchor: "recent"), class: "page-link" %>
             <% end %>
           </div>
         </div>


### PR DESCRIPTION
Fixes #

#5616 

<!-- Add issue number above --> 




## 🔧 Changes Implemented in This PR  
- Added an **anchor tag (`#recent`)** to both **Next** and **Previous** pagination buttons.  
- Applied **CSS style** to the `#recent` container to ensure proper UI alignment.  
- Ensured that pagination now keeps users in the **Recent Circuits** section instead of scrolling to the top.  


### Screenshots of the UI changes (If any) -
https://github.com/user-attachments/assets/e9ea0fc5-53f7-445f-8113-aa19aa54d251


### 📌 Before Fix:  
- Clicking **Next** or **Previous** redirected users to the **top of the page**, causing unnecessary scrolling.  

### ✅ After Fix:  
- Clicking **Next** or **Previous** now keeps users at the **Recent Circuits** section, making navigation smoother.  

---





**Note:** I used **dummy data** for **Recent Circuits** to reproduce the **same scenario** as in production because I **don’t** have database access.  



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced navigation: When using pagination, the page now automatically scrolls to display the recent projects section, providing a more intuitive browsing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->