### PR TITLE
Fix pagination issue in search

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -7,6 +7,10 @@ class SearchController < ApplicationController
     resource = params[:resource]
     query_params = params
 
+    page = query_params[:page].to_i
+    page = 1 if page < 1
+    query_params[:page] = page
+
     @results, template = query(resource, query_params)
 
     if template.present?

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -4,13 +4,16 @@ module SearchHelper
   MAX_RESULTS_PER_PAGE = 5
 
   def query(resource, query_params)
+    page = query_params[:page].to_i
+    page = 1 if page < 1
+
     case resource
     when "Users"
       # User query
-      return UsersQuery.new(query_params).results, "/users/circuitverse/search"
+      return UsersQuery.new(query_params.merge(page: page)).results, "/users/circuitverse/search"
     when "Projects"
       # Project query
-      return ProjectsQuery.new(query_params, Project.public_and_not_forked).results,
+      return ProjectsQuery.new(query_params.merge(page: page), Project.public_and_not_forked).results,
        "/projects/search"
     end
   end

--- a/app/lib/adapters/pg_adapter.rb
+++ b/app/lib/adapters/pg_adapter.rb
@@ -14,11 +14,14 @@ module Adapters
     end
 
     def search_user(relation, query_params)
+      page = query_params[:page].to_i
+      page = 1 if page < 1
+
       if query_params[:q].present?
         relation.text_search(query_params[:q])
       else
         User.all
-      end.paginate(page: query_params[:page], per_page: MAX_RESULTS_PER_PAGE)
+      end.paginate(page: page, per_page: MAX_RESULTS_PER_PAGE)
     end
   end
 end


### PR DESCRIPTION
Related to #5599

Add validation for page number in search methods to prevent RangeError.

* **app/lib/adapters/pg_adapter.rb**
  - Add validation for `query_params[:page]` in the `search_user` method.
  - Default to page 1 if `query_params[:page]` is invalid.

* **app/helpers/search_helper.rb**
  - Add validation for `query_params[:page]` in the `query` method.
  - Default to page 1 if `query_params[:page]` is invalid.

* **app/controllers/search_controller.rb**
  - Add validation for `query_params[:page]` in the `search` method.
  - Default to page 1 if `query_params[:page]` is invalid.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CircuitVerse/CircuitVerse/pull/5631?shareId=ff4da74e-ac49-479c-be2b-66f653177cee).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced pagination handling across search functionalities so that page numbers are automatically normalized to a valid positive integer. This ensures that search queries for users and projects consistently display expected results, even when an invalid page number is submitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->