### PR TITLE
Fix bug in husky install command

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "watch:docs": "npm run watch:doc-output & npm run watch:doc-src",
     "lint": "eslint ./simulator",
     "postinstall": "opencollective-postinstall || true",
-    "prepare": "husky install",
+    "prepare": "husky .",
     "build": "node esbuild.config.js"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #5574

Update the `prepare` script in `package.json` to use the correct Husky command.

* Change the `prepare` script from `husky install` to `husky .` to resolve the deprecation error.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CircuitVerse/CircuitVerse/pull/5633?shareId=de705408-6f5f-4b91-894f-2f12191d5fe8).