### PR TITLE
Fix bug in search component to handle empty inputs

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -7,6 +7,12 @@ class SearchController < ApplicationController
     resource = params[:resource]
     query_params = params
 
+    if query_params[:q].blank?
+      flash[:alert] = "Please enter a search term."
+      redirect_to request.referer || root_path
+      return
+    end
+
     @results, template = query(resource, query_params)
 
     if template.present?

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -4,6 +4,10 @@ module SearchHelper
   MAX_RESULTS_PER_PAGE = 5
 
   def query(resource, query_params)
+    if query_params[:q].blank?
+      return [], nil
+    end
+
     case resource
     when "Users"
       # User query

--- a/app/views/circuitverse_assets/_search_bar.html.erb
+++ b/app/views/circuitverse_assets/_search_bar.html.erb
@@ -1,6 +1,6 @@
 <div class="container navbar-search-container">
   <div class="row center-row">
-  <%= form_tag("/search", method: "get", id: "search-box", class: "navbar-search-bar-form") do %>
+  <%= form_tag("/search", method: "get", id: "search-box", class: "navbar-search-bar-form", onsubmit: "return validateSearch()") do %>
     <%= select_tag :resource, options_for_select(%w[Users Projects], selected: params[:resource]), class: "navbar-search-bar-select", id: "search_type", onchange: "changePlaceholder()" %>
     <%= text_field_tag :q, params[:q], placeholder: "Search for projects or users", autocomplete: "off", class: "form-control form-input navbar-search-bar-input" %>
     <button class="btn primary-button navbar-search-bar-button" type="submit" name="button" value="Submit">Search</button>
@@ -19,5 +19,14 @@
     } else {
       inputElement.placeholder = 'Search for projects or users';
     }
+  }
+
+  function validateSearch() {
+    var inputElement = document.getElementsByClassName('navbar-search-bar-input')[0];
+    if (inputElement.value.trim() === '') {
+      alert('Please enter a search term.');
+      return false;
+    }
+    return true;
   }
 </script>


### PR DESCRIPTION
Fixes #5414

Add validation for empty search queries in the search component.

* **app/views/circuitverse_assets/_search_bar.html.erb**
  - Add `onsubmit` attribute to form tag to call `validateSearch()` function.
  - Add `validateSearch()` function to check if the search query is empty and display an alert message.

* **app/controllers/search_controller.rb**
  - Add a condition to check for empty search queries.
  - Redirect to the previous page with a flash alert message if the search query is empty.

* **app/helpers/search_helper.rb**
  - Add a check for empty search queries in the `query` method.
  - Return an empty array and nil if the search query is empty.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CircuitVerse/CircuitVerse/pull/5636?shareId=4a667e90-7029-46e0-88db-341011751a39).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the search functionality to provide clear feedback when no search term is entered.
  - Introduced validations to prevent empty search submissions, ensuring users are prompted to input a term before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->