### PR TITLE
bug: improved search rendering function

### DIFF
--- a/docs/source/javascripts/app/_search.js
+++ b/docs/source/javascripts/app/_search.js
@@ -56,36 +56,42 @@
   }
 
   function search(event) {
-
     var searchInput = $('#input-search')[0];
-
+    var searchTerm = searchInput.value;
+  
     unhighlight();
     searchResults.addClass('visible');
-
+  
     // ESC clears the field
     if (event.keyCode === 27) searchInput.value = '';
-
-    if (searchInput.value) {
-      var results = index.search(searchInput.value).filter(function(r) {
+  
+    if (searchTerm) {
+      var results = index.search(searchTerm).filter(function (r) {
         return r.score > 0.0001;
       });
-
+  
       if (results.length) {
-        searchResults.empty();
-        $.each(results, function (index, result) {
+        let resultHTML = '';
+  
+        results.forEach(function (result) {
           var elem = document.getElementById(result.ref);
-          searchResults.append("<li><a href='#" + result.ref + "'>" + $(elem).text() + "</a></li>");
+          if (elem) {
+            resultHTML += "<li><a href='#" + result.ref + "'>" + $(elem).text() + "</a></li>";
+          }
         });
-        highlight.call(searchInput);
+  
+        searchResults.html(resultHTML); // Update DOM once
+        highlight.call(searchInput);    // Call once after all updates
+  
       } else {
-        searchResults.html('<li></li>');
-        $('.search-results li').text('No Results Found for "' + searchInput.value + '"');
+        searchResults.html('<li>No Results Found for "' + searchTerm + '"</li>');
       }
     } else {
       unhighlight();
       searchResults.removeClass('visible');
     }
   }
+  
 
   function highlight() {
     if (this.value) content.highlight(this.value, highlightOpts);


### PR DESCRIPTION
Fixes #

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR - 
The Current Rendering logic inside the search function appends elements
one by one using (searchResults.append()) Here $.each(results, function
(index, result) {...} iterates over results and appends each li separately
which can make UI sluggish. I have also noticed there is calling .empty() before appending results.
searchResults.empty(); clears the existing results. Then, $.each(results,
function (index, result) {...}) iterates over each result and appends it one by
one using searchResults.append(...) This causes multiple individual updates
to the DOM instead of a single update. Thus .append() is called multiple times, once for each result which is a bad performance. highlight.call(searchInput); is called after every single li is appended. This
means each time a search result is added, it recalculates the highlight effect.
So if we have 20 results, highlight() runs 20 times instead of just once at the end. 

Instead of appending elements one by one,I have built the entire HTML for all
results as a single string. Then, updated the DOM only once by setting
searchResults.html(resultHTML). so I have made sure to reduce DOM operations from O(n) to O(1).


### Screenshots of the UI changes (If any) -


https://github.com/user-attachments/assets/4e41591a-af5f-4d7c-bf44-21c6b9237df6



## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.




Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the performance and clarity of the search feature, resulting in faster and more efficient search results display.
  - Streamlined the way "No Results Found" messages are shown for a cleaner user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->