### PR TITLE
fix(controller): allow extra args in switch_locale to prevent Argumen…

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,12 +5,12 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   before_action :store_user_location!, if: :storable_location?
-  before_action :set_notifications, if: :current_user
-  around_action :switch_locale
+  before_action :set_notifications,    if: :current_user
+  around_action  :switch_locale
 
-  rescue_from Pundit::NotAuthorizedError, with: :auth_error
-  rescue_from ApplicationPolicy::CustomAuthException, with: :custom_auth_error
-  rescue_from ActiveRecord::RecordNotFound, with: :not_found
+  rescue_from Pundit::NotAuthorizedError,                with: :auth_error
+  rescue_from ApplicationPolicy::CustomAuthException,    with: :custom_auth_error
+  rescue_from ActiveRecord::RecordNotFound,               with: :not_found
 
   def auth_error
     render plain: "You are not authorized to do the requested operation"
@@ -24,7 +24,8 @@ class ApplicationController < ActionController::Base
     render "errors/not_found", status: :not_found
   end
 
-  def switch_locale(&block)
+  # Accept any extra args from around_action without affecting the locale switch
+  def switch_locale(*_args, &block)
     logger.debug "* Accept-Language: #{request.env['HTTP_ACCEPT_LANGUAGE']}"
     locale = current_user&.locale ||
              extract_locale_from_accept_language_header ||
@@ -56,8 +57,10 @@ class ApplicationController < ActionController::Base
     end
 
     def set_notifications
-      @unread = NoticedNotification.where(recipient: current_user).unread
-      @notification = NoticedNotification.where(recipient: current_user).newest_first.limit(5)
+      @unread       = NoticedNotification.where(recipient: current_user).unread
+      @notification = NoticedNotification.where(recipient: current_user)
+                                      .newest_first
+                                      .limit(5)
     end
 
     def storable_location?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,11 +3,9 @@
 class ApplicationController < ActionController::Base
   include Pundit::Authorization
   protect_from_forgery with: :exception
-
   before_action :store_user_location!, if: :storable_location?
   before_action :set_notifications,    if: :current_user
   around_action  :switch_locale
-
   rescue_from Pundit::NotAuthorizedError,                with: :auth_error
   rescue_from ApplicationPolicy::CustomAuthException,    with: :custom_auth_error
   rescue_from ActiveRecord::RecordNotFound,               with: :not_found
@@ -59,8 +57,8 @@ class ApplicationController < ActionController::Base
     def set_notifications
       @unread       = NoticedNotification.where(recipient: current_user).unread
       @notification = NoticedNotification.where(recipient: current_user)
-                                      .newest_first
-                                      .limit(5)
+                                         .newest_first
+                                         .limit(5)
     end
 
     def storable_location?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,10 +5,10 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :store_user_location!, if: :storable_location?
   before_action :set_notifications,    if: :current_user
-  around_action  :switch_locale
+  around_action :switch_locale
   rescue_from Pundit::NotAuthorizedError,                with: :auth_error
   rescue_from ApplicationPolicy::CustomAuthException,    with: :custom_auth_error
-  rescue_from ActiveRecord::RecordNotFound,               with: :not_found
+  rescue_from ActiveRecord::RecordNotFound,              with: :not_found
 
   def auth_error
     render plain: "You are not authorized to do the requested operation"


### PR DESCRIPTION
…tError

Fixes #5669 

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -
I updated the switch_locale callback signature to def switch_locale(*_args, &block), allowing Rails to pass any extra parameters without raising an ArgumentError. Now the locale wrapping runs smoothly for all controller actions, eliminating the arity mismatch crash and preserving our I18n functionality unchanged.

### Screenshots of the UI changes (If any) -
<!-- Do not add code diff here -->


## Checklist before requesting a review
- [ ] I have added proper PR title and linked to the issue
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.




Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved compatibility of the locale-switching functionality with additional arguments.
  - Minor formatting adjustments for better code readability; no impact on functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->