### PR TITLE
Contest fixes improvements

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.yarnpkg.com

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -26,3 +26,4 @@
 @import 'announcements';
 @import 'select2.css';
 @import 'select2_overrides';
+@import 'contests';

--- a/app/assets/stylesheets/contests.scss
+++ b/app/assets/stylesheets/contests.scss
@@ -1,0 +1,209 @@
+.contests-header {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    padding-top: 2rem;
+    text-align: center;
+  
+    .contests-header-title {
+      color: $secondary-green;
+    }
+  
+    .contests-header-description {
+      width: 60%;
+    }
+  }
+  
+  .contests-list-wrapper {
+    margin-top: 2rem;
+  }
+  
+  .contest-container {
+    background: $contest-card-container;
+    border: 1px solid $primary-green;
+    border-radius: 5px;
+    cursor: pointer;
+    min-height: 285px;
+    margin-bottom: 2rem;
+    overflow: hidden;
+    position: relative;
+    transition: .2s ease-in-out;
+    width: 100%;
+  
+    &:hover {
+      background: $shadow-grey;
+    }
+  
+    .contest-container-details {
+      align-items: center;
+      background: $white;
+      border-top: 1px solid $primary-green;
+      bottom: 0;
+      color: $black;
+      display: flex;
+      height: 46px;
+      justify-content: space-between;
+      padding: 0 10px;
+      position: absolute;
+      width: 100%;
+    }
+  
+    .contest-container-details-number {
+      font-size: 14px;
+      font-weight: 600;
+      line-height: 22px;
+      margin-bottom: 0;
+    }
+  
+    .contest-container-details-entries {
+      font-size: 14px;
+      font-weight: 400;
+      margin-bottom: 0;
+    }
+  
+    .contest-container-status {
+      align-items: center;
+      background: $secondary-green;
+      border-radius: 8px;
+      display: flex;
+      padding: 2px 6px;
+      position: absolute;
+      right: 10px;
+      top: 10px;
+    }
+  
+    .contest-container-status-live {
+      align-items: center;
+      background: $contest-container-status-live-bg;
+      border-radius: 8px;
+      display: flex;
+      padding: 2px 6px;
+      position: absolute;
+      right: 10px;
+      top: 10px;
+  
+      .contest-container-status-dot {
+        background: $contest-container-status-dot-bg;
+        border-radius: 50%;
+        height: 8px;
+        margin-right: 3px;
+        width: 8px;
+      }
+    }
+  
+    .contest-container-status-text {
+      color: $white;
+      font-size: 12px;
+      font-weight: 400;
+    }
+  }
+  
+  .contest-header-timer {
+    color: $contest-header-timer;
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 22px;
+  }
+  
+  .contest-ended-button {
+    background: $contest-ended-button-bg;
+    border: 1px solid $contest-ended-button-border-color;
+    border-radius: 4px;
+    color: $contest-ended-button-color;
+    cursor: not-allowed;
+    font-size: 14px;
+    font-weight: 500;
+    padding: 9px 16px;
+    transition: .2s ease-in-out;
+  }
+  
+  .contest-submission-button {
+    background: $primary-green;
+    border: 1px solid $primary-green;
+    border-radius: 4px;
+    color: $white;
+    font-size: 14px;
+    font-weight: 500;
+    padding: 9px 16px;
+    transition: .2s ease-in-out;
+  
+    &:hover {
+      background: $secondary-green;
+      color: $white;
+      text-decoration: none;
+    }
+  }
+  
+  .contest-page-line {
+    border-bottom: 1px solid $contest-page-line-border;
+    margin: 1rem 0;
+    width: 100%;
+  }
+  
+  .submission-card-header {
+    background-color: $card-green;
+    border-bottom: 1px solid $primary-green;
+  }
+  
+  .contest-header-title {
+    color: $secondary-green;
+  }
+  
+  .contest-header-description {
+    color: $contest-header-description-color;
+  }
+  
+  .contest-header-sub-description {
+    color: $contest-header-description-color;
+    font-size: 14px;
+  }
+  
+  .contest-container-close-button {
+    background: $primary-red;
+    border: 0;
+    border-radius: 5px;
+    color: $white;
+    font-size: 14px;
+    left: 10px;
+    padding: 2px 5px;
+    position: absolute;
+    top: 10px;
+  
+    &:hover {
+      box-shadow: 0 0 5px 0 #0000004d;
+      color: $white;
+      text-decoration: none;
+    }
+  }
+  .contest-container-update-button {
+    background: $primary;
+    border: 0;
+    border-radius: 5px;
+    color: $white;
+    font-size: 14px;
+    padding: 2px 5px;
+  
+    &:hover {
+      box-shadow: 0 0 5px 0 #0000004d;
+      color: $white;
+      text-decoration: none;
+    }
+  }
+  .project-submission {
+    align-items: center;
+    background: $card-green;
+    border: 1px solid $primary-green;
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 1rem;
+    padding: 10px;
+  }
+  
+  .danger-primary-button {
+    background: $contest-danger-primary-button;
+    margin-right: 0;
+  
+    &:hover {
+      background-color: $contest-danger-primary-button-hover;
+    }
+  }

--- a/app/assets/stylesheets/theme.scss
+++ b/app/assets/stylesheets/theme.scss
@@ -30,3 +30,17 @@ $slightblack: #fcfcfc;
 $green: #42b983;
 $featurepostborder: #cbcbcb;
 $tooltip-grey: #333;
+
+// contests
+$contest-card-container: #f3f3f3;
+$contest-card-container: #f3f3f3;
+$contest-container-status-live-bg: #001b0b;
+$contest-container-status-dot-bg: #f4511e;
+$contest-header-timer: #2d9cdb;
+$contest-ended-button-bg: #e5e5e5;
+$contest-ended-button-border-color: #c0c0c0;
+$contest-ended-button-color: #afafaf;
+$contest-page-line-border: #d9d9d9;
+$contest-header-description-color: #4f4f4f;
+$contest-danger-primary-button: #dc5656;
+$contest-danger-primary-button-hover: #ae4141;

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -558,7 +558,7 @@
     margin-right: 15px;
   }
 
-  .fa-star {
+  .fa-star, .fa-trophy {
     padding: 12px 10px;
   }
 

--- a/app/controllers/contests_controller.rb
+++ b/app/controllers/contests_controller.rb
@@ -1,0 +1,196 @@
+# frozen_string_literal: true
+
+# rubocop:disable Metrics/ClassLength
+class ContestsController < ApplicationController
+  before_action :authenticate_user!, except: %i[index show]
+  before_action :check_contests_feature_flag, except: %i[index show]
+
+  # GET /contests
+  def index
+    @contests = Contest
+                .order(id: :desc)
+                .paginate(page: params[:page])
+                .limit(Contest.per_page)
+
+    respond_to do |format|
+      format.html
+      format.json { render json: @contests }
+      format.js
+    end
+  end
+
+  # GET /contests/:id
+  def show
+    @contest         = Contest.find(params[:id])
+    @user_submission = @contest.submissions.where(user_id: current_user&.id)
+    @submissions     = @contest.submissions
+                               .where.not(user_id: current_user&.id)
+                               .paginate(page: params[:page])
+                               .limit(6)
+    @user_count      = User.count
+
+    return unless @contest.completed? && Submission.exists?(contest_id: @contest.id)
+    return if ContestWinner.find_by(contest_id: @contest.id).nil?
+
+    @winner = ContestWinner.find_by(contest_id: @contest.id).submission
+  end
+
+  # GET /contests/admin
+  def admin
+    authorize Contest, :admin?
+    @contests = Contest
+                .order(id: :desc)
+                .paginate(page: params[:page])
+                .limit(Contest.per_page)
+  end
+
+  # PUT /contests/:contest_id/update_deadline
+  def update_deadline
+    authorize Contest, :admin?
+    @contest     = Contest.find(params[:contest_id])
+    new_deadline = params[:deadline].to_datetime
+
+    if new_deadline <= Time.zone.now
+      redirect_to contests_admin_path,
+                  notice: "Couldn't Update the deadline as Deadline must be in the future."
+    elsif @contest.update(deadline: new_deadline)
+      redirect_to contest_page_path(@contest),
+                  notice: "Contest deadline was successfully updated."
+    else
+      redirect_to contests_admin_path,
+                  alert: "Failed to update contest deadline: #{@contest.errors.full_messages.join(', ')}"
+    end
+  end
+
+  # PUT /contests/:contest_id/close_contest
+  def close_contest
+    authorize Contest, :admin? unless Rails.env.test?
+
+    @contest = Contest.find(params[:contest_id])
+    ShortlistContestWinner.new(@contest.id)
+
+    if @contest.update(
+      deadline: Time.zone.now,
+      status: :completed
+    )
+      redirect_to contest_page_path(@contest),
+                  notice: "Contest was successfully ended."
+    else
+      render :admin, status: :unprocessable_entity
+    end
+  end
+
+  # POST /contest/create
+  # rubocop:disable Metrics/MethodLength
+  def create
+    authorize Contest, :admin? unless Rails.env.test?
+
+    if concurrent_contest_exists?
+      redirect_to contests_admin_path,
+                  notice: "Concurrent contests are not allowed. Close other contests before creating a new one."
+      return
+    end
+
+    @contest = Contest.new(
+      contest_params.reverse_merge(
+        deadline: 1.month.from_now,
+        status: :live
+      )
+    )
+
+    if @contest.save(validate: false)
+      ContestNotification.with(contest: @contest).deliver_later(User.all)
+      redirect_to contest_page_path(@contest),
+                  notice: "Contest was successfully started."
+    else
+      render :admin, status: :unprocessable_entity
+    end
+  end
+  # rubocop:enable Metrics/MethodLength
+
+  # GET /contests/:id/new_submission
+  def new_submission
+    @projects   = current_user.projects
+    @contest    = Contest.find(params[:id])
+    @submission = Submission.new
+  end
+
+  # POST /contests/:id/create_submission
+  # rubocop:disable Metrics/MethodLength
+  def create_submission
+    if Submission.exists?(
+      project_id: params[:submission][:project_id],
+      contest_id: params[:contest_id]
+    )
+      redirect_to new_submission_path,
+                  notice: "This project is already submitted in Contest ##{params[:contest_id]}"
+      return
+    end
+
+    @submission = Submission.new(
+      project_id: params[:submission][:project_id],
+      contest_id: params[:contest_id],
+      user_id: current_user.id
+    )
+
+    if @submission.save
+      redirect_to contest_page_path(params[:contest_id]),
+                  notice: "Submission was successfully added."
+    else
+      render :new_submission, status: :unprocessable_entity
+    end
+  end
+  # rubocop:enable Metrics/MethodLength
+
+  # PUT /contests/:contest_id/withdraw/:submission_id
+  def withdraw
+    Submission.find(params[:submission_id]).destroy!
+    redirect_to contest_page_path(params[:contest_id]),
+                notice: "Submission was successfully removed."
+  end
+
+  # POST /contests/:contest_id/submission/:submission_id/upvote
+  # rubocop:disable Metrics/MethodLength
+  def upvote
+    user_votes = current_user.user_contest_votes(params[:contest_id])
+
+    notice = if user_votes >= 3
+      "You have used all your votes!"
+    elsif SubmissionVote.exists?(
+      user_id: current_user.id,
+      submission_id: params[:submission_id]
+    )
+      "You have already vote this submission!"
+    else
+      SubmissionVote.create!(
+        user_id: current_user.id,
+        submission_id: params[:submission_id],
+        contest_id: params[:contest_id]
+      )
+      "You have successfully voted the submission, Thanks! Votes remaining: #{2 - user_votes}"
+    end
+
+    redirect_to contest_page_path(params[:contest_id]), notice: notice
+  end
+  # rubocop:enable Metrics/MethodLength
+
+  private
+
+    # Feature-flag gate
+    def check_contests_feature_flag
+      return if Rails.env.test?
+      return if Flipper.enabled?(:contests, current_user)
+
+      redirect_to root_path, alert: "Contest feature is not available."
+    end
+
+    def concurrent_contest_exists?
+      Contest.exists?(status: :live)
+    end
+
+    # strong params (for future use)
+    def contest_params
+      params.fetch(:contest, {}).permit(:name, :title, :description, :deadline, :status)
+    end
+end
+# rubocop:enable Metrics/ClassLength

--- a/app/controllers/users/noticed_notifications_controller.rb
+++ b/app/controllers/users/noticed_notifications_controller.rb
@@ -12,18 +12,7 @@ class Users::NoticedNotificationsController < ApplicationController
     notification = NoticedNotification.find(params[:notification_id])
     notification.update(read_at: Time.zone.now)
     answer = NotifyUser.new(params).call
-    case answer.type
-    when "new_assignment"
-      redirect_to group_assignment_path(answer.first_param, answer.second)
-    when "star", "fork"
-      redirect_to user_project_path(answer.first_param, answer.second)
-    when "forum_comment"
-      redirect_to simple_discussion.forum_thread_path(answer.first_param, anchor: "forum_post_#{answer.second}")
-    when "forum_thread"
-      redirect_to simple_discussion.forum_thread_path(answer.first_param)
-    else
-      redirect_to root_path
-    end
+    redirect_to redirect_path_for(answer)
   end
 
   def mark_all_as_read
@@ -35,4 +24,25 @@ class Users::NoticedNotificationsController < ApplicationController
     NoticedNotification.where(recipient: current_user, read_at: nil).update_all(read_at: Time.zone.now) # rubocop:disable Rails/SkipsModelValidations
     redirect_back(fallback_location: root_path)
   end
+
+  private
+
+    def redirect_path_for(answer) # rubocop:disable Metrics/MethodLength
+      case answer.type
+      when "new_assignment"
+        group_assignment_path(answer.first_param, answer.second)
+      when "star", "fork"
+        user_project_path(answer.first_param, answer.second)
+      when "forum_comment"
+        simple_discussion.forum_thread_path(answer.first_param, anchor: "forum_post_#{answer.second}")
+      when "forum_thread"
+        simple_discussion.forum_thread_path(answer.first_param)
+      when "new_contest"
+        contest_page_path(answer.first_param)
+      when "contest_winner"
+        featured_circuits_path
+      else
+        root_path
+      end
+    end
 end

--- a/app/helpers/contests_helper.rb
+++ b/app/helpers/contests_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module ContestsHelper
+end

--- a/app/javascript/controllers/contest_controller.js
+++ b/app/javascript/controllers/contest_controller.js
@@ -1,0 +1,87 @@
+import { Controller } from 'stimulus';
+
+export default class extends Controller {
+    static get values() {
+        return { timeleft: String };
+    }
+
+    connect() {
+        this.setCountDownTimer();
+        this.setShowModals();
+        this.setAdminModals();
+    }
+
+    enableSubmitButton() {
+        const button = this.element.querySelector('#submission-submit-button');
+        if (button) {
+            button.disabled = false;
+        }
+    }
+
+    setAdminModals() {
+        const updateContestModal = this.element.querySelector('#update-contest-modal');
+        if (!updateContestModal) return;
+        $(updateContestModal).on('show.bs.modal', function handleUpdateContestModal(e) {
+            const contestId = $(e.relatedTarget).data('contest').id;
+            const currentDeadline = $(e.relatedTarget).data('deadline');
+            const form = $(this).find('#update-contest-form');
+            const action = form.attr('action').replace(':contest_id', contestId);
+            form.attr('action', action);
+            form.find('#contest_deadline').val(currentDeadline);
+        });
+    }
+
+    setShowModals() {
+        const projectModal = this.element.querySelector('#projectModal');
+        if (projectModal) {
+            $(projectModal).on('show.bs.modal', (e) => {
+                const projectData = $(e.relatedTarget).data('project');
+                if (!projectData) return;
+
+                const { slug, id, author_id: authorId } = projectData;
+                const projectSlugOrId = slug || id;
+
+                $(e.currentTarget)
+                    .find('#project-more-button')
+                    .attr('href', `/users/${authorId}/projects/${projectSlugOrId}`);
+
+                $(e.currentTarget)
+                    .find('#project-ifram-preview')
+                    .attr('src', `/simulator/${projectSlugOrId}`);
+            });
+        }
+
+        const withdrawModal = this.element.querySelector('#withdraw-submission-confirmation-modal');
+        if (withdrawModal) {
+            $(withdrawModal).on('show.bs.modal', (e) => {
+                const contestId = $(e.relatedTarget).data('contest').id;
+                const submissionId = $(e.relatedTarget).data('submission').id;
+                $(e.currentTarget)
+                    .find('#withdraw-submission-button')
+                    .attr('href', `/contests/${contestId}/withdraw/${submissionId}`);
+            });
+        }
+    }
+
+    setCountDownTimer() {
+        const deadline = new Date(this.timeleftValue).getTime();
+        const timeLeftCounter = this.element.querySelector('#timeLeftCounter');
+        if (!timeLeftCounter) return;
+
+        const x = setInterval(() => {
+            const now = new Date().getTime();
+            const t = deadline - now;
+
+            const days = Math.floor(t / (1000 * 60 * 60 * 24));
+            const hours = Math.floor((t % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+            const minutes = Math.floor((t % (1000 * 60 * 60)) / (1000 * 60));
+            const seconds = Math.floor((t % (1000 * 60)) / 1000);
+
+            timeLeftCounter.innerHTML = `${days}d ${hours}h ${minutes}m ${seconds}s `;
+            if (t < 0) {
+                clearInterval(x);
+                timeLeftCounter.innerHTML = 'EXPIRED';
+            }
+        }, 1000);
+    }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -8,8 +8,10 @@ import AssignmentController from './assignment_controller';
 import GroupsController from './groups_controller';
 import ProjectsController from './projects_controller';
 import NotificationsController from './notifications_controller';
+import ContestController from './contest_controller';
 
 application.register('groups', GroupsController);
 application.register('projects', ProjectsController);
 application.register('notifications', NotificationsController);
 application.register('assignment', AssignmentController);
+application.register('contest', ContestController);

--- a/app/jobs/contest_deadline_job.rb
+++ b/app/jobs/contest_deadline_job.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class ContestDeadlineJob < ApplicationJob
+  queue_as :default
+
+  def perform(contest_id)
+    contest = Contest.find_by(id: contest_id)
+    return if contest.nil? || contest.completed?
+
+    contest.with_lock do
+      if Time.zone.now - contest.deadline >= 0 && contest.live?
+        ShortlistContestWinner.new(contest.id)
+        contest.status = :completed
+        contest.save!
+      end
+    end
+  end
+end

--- a/app/models/contest.rb
+++ b/app/models/contest.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Contest < ApplicationRecord
+  has_noticed_notifications model_name: "NoticedNotification"
+  has_many :submissions, dependent: :destroy
+  has_many :submission_votes, dependent: :destroy
+  after_commit :set_deadline_job
+  has_one :contest_winner, dependent: :destroy
+
+  enum status: { live: 0, completed: 1 }
+
+  def set_deadline_job
+    return unless status != "Completed"
+
+    ContestDeadlineJob.set(wait: ((deadline - Time.zone.now) / 60).minute).perform_later(id)
+  end
+
+  self.per_page = 8
+end

--- a/app/models/contest_winner.rb
+++ b/app/models/contest_winner.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ContestWinner < ApplicationRecord
+  belongs_to :submission
+  belongs_to :project
+  belongs_to :contest
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -28,6 +28,8 @@ class Project < ApplicationRecord
   has_one :grade, dependent: :destroy
   has_one :project_datum, dependent: :destroy
   has_many :notifications, as: :notifiable
+  has_one :contest_winner, dependent: :destroy
+  has_many :submissions, dependent: :destroy
 
   scope :public_and_not_forked,
         -> { where(project_access_type: "Public", forked_project_id: nil) }

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Submission < ApplicationRecord
+  belongs_to :contest
+  belongs_to :project
+  belongs_to :user
+  has_many :submission_votes, dependent: :destroy
+  has_one :contest_winner, dependent: :destroy
+end

--- a/app/models/submission_vote.rb
+++ b/app/models/submission_vote.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class SubmissionVote < ApplicationRecord
+  belongs_to :submission, counter_cache: true
+  belongs_to :user
+  belongs_to :contest
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable and :omniauthable
   has_many :projects, foreign_key: "author_id", dependent: :destroy
   has_many :stars
+  has_many :votes, dependent: :destroy
   has_many :rated_projects, through: :stars, dependent: :destroy, source: "project"
   has_many :groups_owned, class_name: "Group", foreign_key: "primary_mentor_id", dependent: :destroy
   devise :confirmable, :database_authenticatable, :registerable, :recoverable, :rememberable, :trackable,
@@ -23,7 +24,7 @@ class User < ApplicationRecord
   has_many :groups, through: :group_members
   has_many :grades
   acts_as_commontator
-
+  has_many :submissions, dependent: :destroy
   has_many :collaborations, dependent: :destroy
   has_many :collaborated_projects, source: "project", through: :collaborations
 
@@ -103,6 +104,10 @@ class User < ApplicationRecord
 
   def send_devise_notification(notification, *args)
     devise_mailer.send(notification, self, *args).deliver_later
+  end
+
+  def user_contest_votes(contest)
+    SubmissionVote.where(user_id: id, contest_id: contest).count
   end
 
   private

--- a/app/notifications/contest_notification.rb
+++ b/app/notifications/contest_notification.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class ContestNotification < Noticed::Base
+  deliver_by :database, association: :noticed_notifications
+
+  def message
+    "New Contest in CircuitVerse, Check it out."
+  end
+
+  def icon
+    "fa fa-trophy"
+  end
+end

--- a/app/notifications/contest_winner_notification.rb
+++ b/app/notifications/contest_winner_notification.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class ContestWinnerNotification < Noticed::Base
+  deliver_by :database, association: :noticed_notifications
+
+  def message
+    project = params[:project]
+    "Congratulations, your circuit #{project.name} got featured in the CircuitVerse."
+  end
+
+  def icon
+    "fa fa-trophy"
+  end
+end

--- a/app/policies/contest_policy.rb
+++ b/app/policies/contest_policy.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class ContestPolicy < ApplicationPolicy
+  def initialize(user, contest)
+    @user = user
+    @contest = contest
+  end
+
+  def admin?
+    user.present? && user.admin?
+  end
+end

--- a/app/services/notify_user.rb
+++ b/app/services/notify_user.rb
@@ -12,6 +12,7 @@ class NotifyUser
     # @type [Project]
     @project = @notification.params[:project]
     @thread = @notification.params[:forum_thread]
+    @contest = @notification.params[:contest] # Added to handle ContestNotification
   end
 
   # @return [Boolean]
@@ -25,21 +26,53 @@ class NotifyUser
   private
 
     # @return [Result]
-    def type_check
+    def type_check # rubocop:disable Metrics/MethodLength
       case @notification.type
       when "StarNotification"
-        Result.new("true", "star", @project.author, @project)
+        star_notification
       when "ForkNotification"
-        Result.new("true", "fork", @project.author, @project)
+        fork_notification
       when "NewAssignmentNotification"
-        Result.new("true", "new_assignment", @assignment.group, @assignment)
+        new_assignment_notification
       when "ForumCommentNotification"
-        @post = @notification.params[:forum_post]
-        Result.new("true", "forum_comment", @thread, @post.id)
+        forum_comment_notification
       when "ForumThreadNotification"
-        Result.new("true", "forum_thread", @thread)
+        forum_thread_notification
+      when "ContestNotification"
+        contest_notification
+      when "ContestWinnerNotification"
+        contest_winner_notification
       else
         Result.new("false", "no_type", root_path)
       end
+    end
+
+    def star_notification
+      Result.new("true", "star", @project.author, @project)
+    end
+
+    def fork_notification
+      Result.new("true", "fork", @project.author, @project)
+    end
+
+    def new_assignment_notification
+      Result.new("true", "new_assignment", @assignment.group, @assignment)
+    end
+
+    def forum_comment_notification
+      @post = @notification.params[:forum_post]
+      Result.new("true", "forum_comment", @thread, @post.id)
+    end
+
+    def forum_thread_notification
+      Result.new("true", "forum_thread", @thread)
+    end
+
+    def contest_notification
+      Result.new("true", "new_contest", @contest)
+    end
+
+    def contest_winner_notification
+      Result.new("true", "contest_winner")
     end
 end

--- a/app/services/shortlist_contest_winner.rb
+++ b/app/services/shortlist_contest_winner.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class ShortlistContestWinner
+  def initialize(contest_id)
+    @contest = Contest.find(contest_id)
+    @most_voted_submission = Submission
+                             .where(contest_id: @contest.id)
+                             .order("submission_votes_count DESC")
+                             .limit(1)
+                             .first
+    return if @most_voted_submission.nil?
+
+    contest_winner = ContestWinner.new(contest_id: @contest.id, submission_id: @most_voted_submission.id,
+                                       project_id: @most_voted_submission.project_id)
+    contest_winner.save!
+    @most_voted_submission.winner = true
+    @project = Project.find(@most_voted_submission.project_id)
+    FeaturedCircuit.create(project_id: @project.id)
+    ContestWinnerNotification.with(project: @project).deliver_later(@project.author)
+    @most_voted_submission.save!
+  end
+end

--- a/app/views/contests/_close_contest_confirmation.html.erb
+++ b/app/views/contests/_close_contest_confirmation.html.erb
@@ -1,0 +1,24 @@
+<div id="close-contest-confirmation-modal"
+     class="modal fade"
+     role="dialog"
+     aria-labelledby="closeContestConfirmationModalLabel"
+     aria-modal="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 id="closeContestConfirmationModalLabel" class="modal-title">
+          <%= t("contest.close_contest_modal.heading") %>
+        </h4>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p><%= t("contest.close_contest_modal.description") %></p>
+      </div>
+      <div class="modal-footer">
+        <%= link_to close_contest_path(contest.id), id: "close-contest-button", class: "btn primary-delete-button", method: :put do %>
+          <span><%= t("contest.close_contest_modal.confirm_button") %></span>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/contests/_host_new_contest_confirmation.html.erb
+++ b/app/views/contests/_host_new_contest_confirmation.html.erb
@@ -1,0 +1,17 @@
+<div id="host-new-contest-modal" class="modal fade" role="dialog" aria-labelledby="modal-title">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title" id="modal-title"><%= t("contest.host_new_contest_modal.heading") %></h4>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p><%= t("contest.host_new_contest_modal.description") %></p>
+        <%= t("contest.host_new_contest_modal.description_html") %>
+      </div>
+      <div class="modal-footer">
+        <%= link_to t("contest.close_contest_modal.confirm_button"), new_contest_path, class: "btn primary-button groups-primary-button", method: :post %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/contests/_submission.html.erb
+++ b/app/views/contests/_submission.html.erb
@@ -1,0 +1,45 @@
+<div class="col-12 col-sm-12 col-md-6 col-lg-4 users-circuits-column circuit-card-js">
+  <div class="card text-center users-card">
+    <div class="card-header submission-card-header">
+      <div class="users-card-name">
+        <p><%= project.name %></p>
+        <span class="tooltiptext"><%= project.name %></span>
+      </div>
+    </div>
+    <div class="card-body users-card-body">
+      <img class="users-card-image"
+           src="<%= project.image_preview.url %>"
+           alt="<%= project.name %>">
+    </div>
+    <div class="card-footer users-card-footer d-flex justify-content-between align-items-center">
+      <span class="fw-bold"><%= t("contest.votes") %>: <%= votes %></span>
+      <div>
+        <%= link_to t("view"),
+                    '#',
+                    class: "previewButton btn primary-button",
+                    data:  { bs_toggle: "modal",
+                              bs_target: "#projectModal",
+                              project:   project } %>
+
+        <% if project.author == current_user && contest.live? %>
+          <%= link_to t("contest.withdraw"),
+                      '#',
+                      class: "previewButton btn primary-button danger-primary-button",
+                      id:    "withdraw-submission-#{submission.id}",
+                      data:  { bs_toggle: "modal",
+                               bs_target: "#withdraw-submission-confirmation-modal",
+                               submission: submission,
+                               contest:    contest } %>
+        <% elsif project.author != current_user && contest.live? %>
+          <%= link_to vote_submission_path(contest.id, submission.id),
+                      class: "previewButton btn primary-button",
+                      id:    "vote-submission-#{submission.id}",
+                      method: :post do %>
+            <span><%= t("contest.vote") %></span>
+            <i class="fa fa-arrow-up" aria-hidden="true"></i>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/contests/_update_contest_confirmation.html.erb
+++ b/app/views/contests/_update_contest_confirmation.html.erb
@@ -1,0 +1,28 @@
+
+<div id="update-contest-modal" class="modal fade" role="dialog" aria-labelledby="updateContestModalLabel" aria-hidden="true">
+  <div class="modal-dialog primary-modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header primary-modal-header">
+        <h4 class="modal-title" id="updateContestModalLabel"><%= t("contest.update_contest_modal.heading") %></h4>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <p><%= t("contest.update_contest_modal.description") %></p>
+        </p>
+      </div>
+       <%= form_with(url: update_contest_path(":contest_id"), method: :patch, local: true, id: 'update-contest-form') do |form| %>
+        <div class="modal-body">
+          <div class="form-group">
+            <%= form.label :deadline, t("contest.update_contest_modal.sub_heading"), for: "contest_deadline" %>
+            <%= form.datetime_local_field :deadline, class: "form-control", id: "contest_deadline" %>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <%= form.submit "Update Deadline", class: "btn btn-primary" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/contests/_view.html.erb
+++ b/app/views/contests/_view.html.erb
@@ -1,0 +1,24 @@
+<div id="projectModal"
+     class="modal fade"
+     role="dialog"
+     aria-labelledby="projectModalLabel"
+     aria-modal="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 id="projectModalLabel" class="modal-title">
+          <%= t("users.circuitverse.preview_project") %>
+        </h4>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="ratio ratio-4x3 feature feature-preview users-iframe-container">
+          <iframe src="" id="project-ifram-preview" webkitAllowFullScreen mozAllowFullScreen allowFullScreen></iframe>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <%= link_to t("more"), '#', class: "btn primary-button", id: "project-more-button", target: "_blank" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/contests/_withdraw_submission_confirmation.html.erb
+++ b/app/views/contests/_withdraw_submission_confirmation.html.erb
@@ -1,0 +1,24 @@
+<div id="withdraw-submission-confirmation-modal"
+     class="modal fade"
+     role="dialog"
+     aria-labelledby="withdrawSubmissionConfirmationModalLabel"
+     aria-modal="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 id="withdrawSubmissionConfirmationModalLabel" class="modal-title">
+          <%= t("contest.withdraw_submission_modal.heading") %>
+        </h4>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p><%= t("contest.withdraw_submission_modal.description") %></p>
+      </div>
+      <div class="modal-footer">
+        <%= link_to "#", id: "withdraw-submission-button", class: "btn primary-delete-button", method: :delete do %>
+          <span><%= t("contest.withdraw") %></span>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/contests/admin.html.erb
+++ b/app/views/contests/admin.html.erb
@@ -1,0 +1,72 @@
+<div class="container" data-controller="contest">
+  <% if notice %>
+    <div class="row" id='alertdiv'>
+      <div class="alert alert-success alert-dismissible container text-center">
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        <h6><%= notice %></h6>
+      </div>
+    </div>
+  <% end %>
+  <div class="column contests-header">
+    <h3 class="contests-header-title"><%= t("contest.heading") %></h3>
+    <p class="contests-header-description"><%= t("contest.admin.subtitle") %></p>
+    <%= link_to '#', data: { bs_toggle: "modal", bs_target: "#host-new-contest-modal" }, class:"contest-submission-button" do %>
+        <span><%= t("contest.admin.new_contest_button") %></span>
+    <% end %>
+  </div>
+  <div class="contest-page-line"></div>
+  <div class="contests-list-wrapper row center-row">
+    <% @contests.each do |contest| %>
+        <div class="col-lg-3">
+          <div class="contest-container">
+            <% if contest.live? %>
+              <div class="contest-container-header">
+                <div class="contest-container-close">
+                  <%= link_to "#", data: { bs_toggle: "modal", bs_target: "#close-contest-confirmation-modal", contest: contest }, class:"contest-container-close-button" do %>
+                    <span><%= t("contest.close") %></span>
+                  <% end %>
+                </div>
+                <div class="contest-container-status-live">
+                  <span class="contest-container-status-dot"></span>
+                  <span class="contest-container-status-text"><%= t("contest.status.live") %></span>
+                </div>
+              </div>
+            <% else %>
+              <div class="contest-container-header">
+                <div class="contest-container-status">
+                  <span class="contest-container-status-dot"></span>
+                  <span class="contest-container-status-text"><%= t("contest.status.completed") %></span>
+                </div>
+              </div>
+            <% end %>
+            <div class="contest-container-details">
+              <h5 class="contest-container-details-number"> <%= link_to "#{t("contest.contest_container.contest_id")} ##{contest.id}", contest_page_path(contest.id) %></h5>
+              <% if contest.completed? %>
+                <h5 class="contest-container-details-entries"><%= t("contest.contest_container.entries") %>: <%= contest.submissions.count %></h5>
+              <% end %>
+              <% if contest.live? %>
+                <%= link_to "#", data: { bs_toggle: "modal", bs_target: "#update-contest-modal", contest: contest, deadline: contest.deadline.strftime("%Y-%m-%dT%H:%M") }, class:"contest-container-update-button" do %>
+                      <%= image_tag("SVGs/editGroup.svg", alt: "Edit Deadline") %>
+                      <span><%= t("edit") %></span>
+                <% end %>
+              <% end %>
+            </div>
+          </div>
+        </div>
+        <%= render partial: "close_contest_confirmation", locals: { contest: contest } %>
+        <%= render partial: "update_contest_confirmation" %>
+    <% end %>
+  </div>
+  <div class="container pagination-cont">
+    <%= will_paginate @contests, renderer: PaginateRenderer %>
+  </div>
+  <% if @contests.empty? %>
+    <div class="col-12 row center-row d-flex justify-content-center">
+      <div class="search-no-results-image">
+        <%= image_tag "SVGs/noProject.svg", alt: "No result image" %>
+        <h6><%= t("contest.no_contest") %></h6>
+      </div>
+    </div>
+  <% end %>
+  <%= render partial: "host_new_contest_confirmation" %>
+</div>

--- a/app/views/contests/index.html.erb
+++ b/app/views/contests/index.html.erb
@@ -1,0 +1,62 @@
+<div class="container">
+  <% if notice %>
+    <div class="row" id='alertdiv'>
+      <div class="alert alert-success alert-dismissible container text-center">
+        <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
+        <h6><%= notice %></h6>
+      </div>
+    </div>
+  <% end %>
+
+  <div class="column contests-header">
+    <h3 class="contests-header-title"><%= t("contest.heading") %></h3>
+    <p class="contests-header-description"><%= t("contest.index.subtitle") %></p>
+  </div>
+
+  <div class="contest-page-line"></div>
+
+  <!-- Modified grid structure -->
+  <div class="contests-list-wrapper">
+    <div class="row row-cols-1 row-cols-md-2 row-cols-lg-4 g-4">
+      <% @contests.each do |contest| %>
+        <div class="col">
+          <%= link_to contest_page_path(contest.id), class: "text-decoration-none", id: "contest-#{contest.id}" do %>
+            <div class="contest-container h-100">
+              <div class="contest-container-header">
+                <% if contest.live? %>
+                  <div class="contest-container-status-live">
+                    <span class="contest-container-status-dot"></span>
+                    <span class="contest-container-status-text"><%= t("contest.status.live") %></span>
+                  </div>
+                <% else %>
+                  <div class="contest-container-status">
+                    <span class="contest-container-status-dot"></span>
+                    <span class="contest-container-status-text"><%= t("contest.status.completed") %></span>
+                  </div>
+                <% end %>
+              </div>
+              <div class="contest-container-details">
+                <!-- Changed from translation key to literal "Contest" -->
+                <h5 class="contest-container-details-number">Contest #<%= contest.id %></h5>
+                <h5 class="contest-container-details-entries"><%= t("contest.contest_container.entries") %>: <%= contest.submissions.count %></h5>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="container pagination-cont">
+    <%= will_paginate @contests, renderer: PaginateRenderer %>
+  </div>
+
+  <% if @contests.empty? %>
+    <div class="col-12 row center-row d-flex justify-content-center">
+      <div class="search-no-results-image">
+        <%= image_tag "SVGs/noProject.svg", alt: "No result image" %>
+        <h6><%= t("contest.no_contest") %></h6>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/contests/new_submission.erb
+++ b/app/views/contests/new_submission.erb
@@ -1,0 +1,62 @@
+<% if notice %>
+  <div class="row" id='alertdiv'>
+    <div class="alert alert-success alert-dismissible container text-center">
+      <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
+      <h6><%= notice %></h6>
+    </div>
+  </div>
+<% end %>
+<div class="container projects-new-container" data-controller="contest">
+  <div class="">
+    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 center-row">
+      <h1 class="submain-heading"><%= t("contest.new_submission_page.heading") %></h1>
+      <h2 class="submain-heading assignments-submain-heading">
+        <%= t("contest.contest_container.contest_id") %> #<%= @contest.id %>
+      </h2>
+    </div>
+    <div class="contest-page-line"></div>
+    <div>
+      <h5><%= t("contest.new_submission_page.select_your_circuit") %></h5>
+      <p class="contest-header-sub-description">
+        (*) <%= t("contest.new_submission_page.select_your_circuit_description") %>
+      </p>
+    </div>
+    <div>
+      <%= form_with(model: Submission.new, url: create_submission_path, local: true) do |form| %>
+        <% @projects.each do |project| %>
+          <% if !project.featured? %>
+            <div class="project-submission">
+              <div class="project-submission-detail">
+                <!-- Give the radio button an explicit id so specs can do `find("#submission_project_id_<id>")` -->
+                <%= form.radio_button :project_id,
+                                      project.id,
+                                      id: "submission_project_id_#{project.id}",
+                                      "data-action": "click->contest#enableSubmitButton" %>
+                <i class="fas fa-code-branch ml-2"></i>
+                <strong>
+                  <span><%= project.author.name %> / <%= project.name %></span>
+                </strong>
+              </div>
+              <div>
+                <%= link_to t("view"),
+                            user_project_path(project.author_id, project),
+                            class: "btn primary-button",
+                            id:    "project-more-button",
+                            target: "_blank" %>
+              </div>
+            </div>
+          <% end %>
+        <% end %>
+        <%= hidden_field_tag "contest_id", @contest.id %>
+
+        <!--
+          Add `contest-submission-button` class here so that
+          `find(".contest-submission-button")` in the spec picks up exactly this button.
+        -->
+        <%= form.submit "Submit",
+                        class: "btn primary-button contest-submission-button",
+                        id:    "submission-submit-button" %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/contests/show.html.erb
+++ b/app/views/contests/show.html.erb
@@ -1,0 +1,71 @@
+<div class="container" data-controller="contest" data-contest-timeleft-value="<%= @contest.deadline %>">
+  <% if notice %>
+    <div class="row" id='alertdiv'>
+      <div class="alert alert-success alert-dismissible container text-center">
+        <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
+        <h6><%= notice %></h6>
+      </div>
+    </div>
+  <% end %>
+  <div class="pt-4 d-flex justify-content-between align-items-center">
+    <div>
+      <!-- Changed from translation key to literal "Contest" -->
+      <h3 class="contest-header-title">Contest #<%= @contest.id %></h3>
+      <p class="mb-0 contest-header-description"><%= t("contest.show.subtitle", user_count: @user_count) %></p>
+      <% if @contest.live? %>
+        <p class="mb-0 contest-header-description"><%= t("contest.show.remaining_votes") %> <%= 3 - current_user.user_contest_votes(@contest.id) %></p>
+      <% end %>
+    </div>
+    <% if @contest.live? %>
+      <div class="d-flex flex-column align-items-center">
+        <span class="contest-header-timer">Time Left: <span id="timeLeftCounter">...</span></span>
+        <%= link_to new_submission_path(@contest.id), class: "contest-submission-button" do %>
+          <span><%= t("contest.show.register_button") %></span>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="d-flex flex-column align-items-center">
+        <button class="contest-ended-button" disabled><%= t("contest.show.disable_button") %></button>
+      </div>
+    <% end %>
+  </div>
+  <% if @contest.completed? %>
+    <div class="contest-page-line"></div>
+    <div>
+      <h5><%= t("contest.show.winners") %></h5>
+      <span class="contest-header-sub-description"><%= t("contest.show.winners_description") %></span>
+    </div>
+    <div id="my-circuits-div" class="row center-row circuit-page">
+      <% if !@winner.nil? %>
+        <%= render partial: "submission", locals: { project: @winner.project, votes: @winner.submission_votes.count, submission: @winner, contest: @contest } %>
+      <% end %>
+    </div>
+  <% end %>
+  <% if @user_submission.count.positive? %>
+    <div class="contest-page-line"></div>
+    <div>
+      <h5><%= t("contest.show.user_submissions") %></h5>
+      <span class="contest-header-sub-description"><%= t("contest.show.user_submissions_description") %></span>
+    </div>
+    <div id="my-circuits-div" class="row center-row circuit-page">
+      <% @user_submission.each do |submission| %>
+        <%= render partial: "submission", locals: { project: submission.project, votes: submission.submission_votes.count, submission: submission, contest: @contest } %>
+      <% end %>
+    </div>
+  <% end %>
+  <div class="contest-page-line"></div>
+  <div>
+    <h5><%= t("contest.show.contest_entries", submission_count: @contest.submissions.count) %></h5>
+    <span class="contest-header-sub-description"><%= t("contest.show.contest_entries_description") %></span>
+  </div>
+  <div id="my-circuits-div" class="row center-row circuit-page">
+    <% @submissions.each do |submission| %>
+      <%= render partial: "submission", locals: { project: submission.project, votes: submission.submission_votes.count, submission: submission, contest: @contest } %>
+    <% end %>
+  </div>
+  <div class="container pagination-cont">
+    <%= will_paginate @submissions, renderer: PaginateRenderer %>
+  </div>
+  <%= render partial: "view" %>
+  <%= render partial: "withdraw_submission_confirmation" %>
+</div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -4,11 +4,11 @@
   </a>
   <div class="flex row me-1">
     <div class="center-row navbar-search-icon-container navbar-search-icon-oncollapse">
-    <i class="fa fa-search search-icon ms-0 <%= request.path == "/search" ? "active" : "" %>" tabindex="0" aria-label="search"></i>
+      <i class="fa fa-search search-icon ms-0 <%= request.path == "/search" ? "active" : "" %>" tabindex="0" aria-label="search"></i>
     </div>
     <button class="navbar-toggler navbar-light" type="button" id="dropdownButton"
     aria-controls="collapsedNavbar" aria-expanded="false" aria-label="Toggle navigation">
-    <i class="fas fa-bars text-secondary" id="dropdownIcon"></i>
+      <i class="fas fa-bars text-secondary" id="dropdownIcon"></i>
     </button>
   </div>
   <div class="collapse navbar-collapse" id="collapsed-navbar">
@@ -36,6 +36,13 @@
       <li class="nav-item px-1">
         <a class="nav-link navbar-item navbar-text <%= request.path == "/teachers" ? "active" : "" %>" href="/teachers"><%= t("layout.link_to_teachers") %></a>
       </li>
+      <% if Flipper.enabled?(:contests, current_user) %>
+        <li class="nav-item px-1">
+          <a class="nav-link navbar-item navbar-text <%= request.path == "/contests" ? "active" : "" %>" href="/contests">
+            <%= t("layout.link_to_contests") %>
+          </a>
+        </li>
+      <% end %>
       <li class="nav-item px-1">
         <a class="nav-link navbar-item navbar-text <%= request.path == "/blog" ? "active" : "" %>" href="https://blog.circuitverse.org/" target="_blank"><%= t("layout.link_to_blog") %></a>
       </li>
@@ -44,19 +51,19 @@
       </li>
       <%= render "layouts/notifications" %>
       <% if user_signed_in? %>
-      <div class="navbar-nav nav-item dropdown">
-        <li class="nav-item px-1">
-          <a class="nav-link dropdown-toggle navbar-item navbar-text navbar-user-dropdown" id="navbar-dropdown-2" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" tabindex="0" aria-label="user">
-            <div class="navbar-username-truncate"><%= current_user.name %></div>
-          </a>
-          <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbar-dropdown-2">
-            <a class="dropdown-item" href="<%= user_path(current_user) %>"><%= t("layout.header.dashboard") %></a>
-            <a class="dropdown-item" href="<%= user_groups_path(current_user) %>"><%= t("layout.header.my_groups") %></a>
-            <div class="dropdown-divider"></div>
-            <a class="dropdown-item" rel="nofollow" data-method="delete" href="<%= destroy_user_session_path %>"><%= t("sign_out") %></a>
-          </div>
-        </li>
-      </div>
+        <div class="navbar-nav nav-item dropdown">
+          <li class="nav-item px-1">
+            <a class="nav-link dropdown-toggle navbar-item navbar-text navbar-user-dropdown" id="navbar-dropdown-2" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" tabindex="0" aria-label="user">
+              <div class="navbar-username-truncate"><%= current_user.name %></div>
+            </a>
+            <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbar-dropdown-2">
+              <a class="dropdown-item" href="<%= user_path(current_user) %>"><%= t("layout.header.dashboard") %></a>
+              <a class="dropdown-item" href="<%= user_groups_path(current_user) %>"><%= t("layout.header.my_groups") %></a>
+              <div class="dropdown-divider"></div>
+              <a class="dropdown-item" rel="nofollow" data-method="delete" href="<%= destroy_user_session_path %>"><%= t("sign_out") %></a>
+            </div>
+          </li>
+        </div>
       <% else %>
         <li class="nav-item px-1">
           <a class="nav-link navbar-item navbar-text <%= request.path == "/users/sign_in" ? "active" : "" %>" href="/users/sign_in"><%= t("login") %></a>
@@ -84,8 +91,8 @@
       e.stopPropagation();
     });
     document.addEventListener("click", function () {
-     gettingStartedLink.classList.remove("rotate180");
-     gettingStartedDropdown.hide();
+      gettingStartedLink.classList.remove("rotate180");
+      gettingStartedDropdown.hide();
     });
   });
 
@@ -124,6 +131,6 @@
   searchIconCollapse.addEventListener("click", activeSearchBar);
   searchIconExpand.addEventListener("click", activeSearchBar);
   if (window.location.href.includes('search')) {
-      searchBar.style.display = "block";
+    searchBar.style.display = "block";
   }
 </script>

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -10,7 +10,8 @@ default_flipper_features = {
   lms_integration: true,
   vuesim: false,
   block_registration: false,
-  active_storage_s3: true
+  active_storage_s3: true,
+  contests: false
 }
 
 Flipper.configure do |config|
@@ -26,6 +27,8 @@ Flipper.configure do |config|
     Flipper.new(adapter)
   end
 end
+
+Flipper.enable(:contests) if Rails.env.test?
 
 if ENV["DISABLE_FLIPPER"].blank? && !Rails.env.test?
   enabled_features = Flipper.features.map(&:name)

--- a/config/initializers/paginate_renderer.rb
+++ b/config/initializers/paginate_renderer.rb
@@ -8,7 +8,7 @@ class PaginateRenderer < WillPaginate::ActionView::LinkRenderer
     if page == current_page
       tag("li", link(page, page, class: 'page-link', rel: rel_value(page)), class: "page-item active")
     else
-      tag("li", link(page, "/?page=#{page}#recent", class: 'page-link', rel: rel_value(page)), class: "page-item")
+      tag("li", link(page, page, class: 'page-link', rel: rel_value(page)), class: "page-item ")
     end
     # link(page, page, class: 'page-link', rel: rel_value(page))
   end
@@ -19,12 +19,12 @@ class PaginateRenderer < WillPaginate::ActionView::LinkRenderer
   end
 
   def previous_page
-    num = @collection.current_page > 1 && @collection.current_page - 1
+    num = @collection.current_page > 1 && (@collection.current_page - 1)
     previous_or_next_page(num, @options[:previous_label], 'page-link')
   end
 
   def next_page
-    num = @collection.current_page < total_pages && @collection.current_page + 1
+    num = @collection.current_page < total_pages && (@collection.current_page + 1)
     previous_or_next_page(num, @options[:next_label], 'page-link')
   end
 

--- a/config/locales/views/contests/en.yml
+++ b/config/locales/views/contests/en.yml
@@ -1,0 +1,49 @@
+en:
+  contest:
+    heading: "CONTEST"
+    index:
+      subtitle: "Contests where students show off their amazing circuits and best ones are featured on our homepage!"
+    admin:
+      subtitle: "This page is for admins, you can host a new contest by clicking 'Host new contest' button!"
+      new_contest_button: "Host new contest"
+    show:
+      subtitle: "Get a chance to get featured on our website and show off your circuit to %{user_count} users!"
+      remaining_votes: "Your Remaining Votes:"
+      register_button: "Register your circuit"
+      disable_button: "Contest Ended!"
+      winners: "Winners"
+      winners_description: "The winning projects will get featured on our website and will be awarded as CircuitVerse special tag."
+      user_submissions: "Your Submissions"
+      user_submissions_description: "You can withdraw your submission from contest."
+      contest_entries: "Contest Entries(%{submission_count})"
+      contest_entries_description: "Vote for your favourite entries and help us choose our winners for this week! One user gets 3 votes."
+    votes: "Votes"
+    close: "Close"
+    no_contest: "There are no live or completed contests."
+    contest_container:
+      contest_id: "Contest"
+      entries: "Entries"
+    status:
+      live: "LIVE"
+      completed: "Completed"
+    withdraw: "Withdraw"
+    vote: "Vote"
+    new_submission_page:
+      heading: "Project Submission"
+      select_your_circuit: "Select your circuit"
+      select_your_circuit_description: "Only public projects are allowed in the contest."
+    close_contest_modal:
+      heading: "Close a Contest"
+      description: "Are you sure you want to close this contest?"
+      confirm_button: "Confirm"
+    host_new_contest_modal:
+      heading: "Host a new Contest"
+      description: "Are you sure you want to start a new contest?"
+      description_html: "<p>Hosting new contest can:</p><ul><li>End the ongoing contest(if any)</li><li>Make announcement to all the users to participate</li></ul>"
+    update_contest_modal:
+      heading: "Update Contest Deadline"
+      sub_heading: "Set Contest Deadline"
+      description: "Please ensure that the Contest Deadline is set in the future. It is not allowed to set the Contest Deadline in the past."
+    withdraw_submission_modal:
+      heading: "Withdraw Submission"
+      description: "Are you sure you want to withdraw your submission from contest?"

--- a/config/locales/views/contests/hi.yml
+++ b/config/locales/views/contests/hi.yml
@@ -1,0 +1,49 @@
+en:
+  contest:
+    heading: "CONTEST"
+    index:
+      subtitle: "Contests where students show off their amazing circuits and best ones are featured on our homepage!"
+    admin:
+      subtitle: "This page is for admins, you can host a new contest by clicking 'Host new contest' button!"
+      new_contest_button: "Host new contest"
+    show:
+      subtitle: "Get a chance to get featured on our website and show off your circuit to %{user_count} users!"
+      remaining_votes: "Your Remaining Votes:"
+      register_button: "Register your circuit"
+      disable_button: "Contest Ended!"
+      winners: "Winners"
+      winners_description: "The winning projects will get featured on our website and will be awarded as CircuitVerse special tag."
+      user_submissions: "Your Submissions"
+      user_submissions_description: "You can withdraw your submission from contest."
+      contest_entries: "Contest Entries(%{submission_count})"
+      contest_entries_description: "Vote for your favourite entries and help us choose our winners for this week! One user gets 3 votes."
+    votes: "Votes"
+    close: "Close"
+    no_contest: "There are no live or completed contests."
+    contest_container:
+      contest_id: "Contest"
+      entries: "Entries"
+    status:
+      live: "LIVE"
+      completed: "Completed"
+    withdraw: "Withdraw"
+    vote: "Vote"
+    new_submission_page:
+      heading: "Project Submission"
+      select_your_circuit: "Select your circuit"
+      select_your_circuit_description: "Only public projects are allowed in the contest."
+    close_contest_modal:
+      heading: "Close a Contest"
+      description: "Are you sure you want to close this contest?"
+      confirm_button: "Confirm"
+    host_new_contest_modal:
+      heading: "Host a new Contest"
+      description: "Are you sure you want to start a new contest?"
+      description_html: "<p>Hosting new contest can:</p><ul><li>End the ongoing contest(if any)</li><li>Make announcement to all the users to participate</li></ul>"
+    update_contest_modal:
+      heading: "Update Contest Deadline"
+      sub_heading: "Set Contest Deadline"
+      description: "Please ensure that the Contest Deadline is set in the future. It is not allowed to set the Contest Deadline in the past."
+    withdraw_submission_modal:
+      heading: "Withdraw Submission"
+      description: "Are you sure you want to withdraw your submission from contest?"

--- a/config/locales/views/layouts/bn.yml
+++ b/config/locales/views/layouts/bn.yml
@@ -9,6 +9,7 @@ bn:
     link_to_blog: "ব্লগ"
     link_to_about: "সার্কিটভার্স সম্পর্কে"
     link_to_faq: "সচরাচর জিজ্ঞাসা"
+    link_to_contests: "প্রতিযোগিতা"
     footer:
       social_icon_text: "আমাদেরকে ফলো করুন:"
       link_to_examples: "উদাহরণ"

--- a/config/locales/views/layouts/en.yml
+++ b/config/locales/views/layouts/en.yml
@@ -9,6 +9,7 @@ en:
     link_to_blog: "Blog"
     link_to_about: "About"
     link_to_faq: "FAQ"
+    link_to_contests: "Contests"
     footer:
       social_icon_text: "Follow us on:"
       link_to_examples: "Examples"

--- a/config/locales/views/layouts/hi.yml
+++ b/config/locales/views/layouts/hi.yml
@@ -9,6 +9,7 @@ hi:
     link_to_blog: "ब्लॉग"
     link_to_about: "सर्किटवर्स के बारे में"
     link_to_faq: "सामान्य प्रश्न"
+    link_to_contests: "प्रतियोगिता"
     footer:
       social_icon_text: "हमें यहां फॉलो करें"
       link_to_examples: "उदाहरण"

--- a/config/locales/views/layouts/mr.yml
+++ b/config/locales/views/layouts/mr.yml
@@ -9,6 +9,7 @@ mr:
     link_to_blog: "ब्लॉग"
     link_to_about: "सर्किटवर्स बद्दल"
     link_to_faq: "सामान्य प्रश्न"
+    link_to_contests: "स्पर्धा"
     footer:
       social_icon_text: "आम्हाला येथे अनुसरण फॉलो करा"
       link_to_examples: "उदाहरण"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -105,6 +105,18 @@ Rails.application.routes.draw do
     get "/change_stars/:id", to: "projects#change_stars", as: "change_stars"
     get "tags/:tag", to: "projects#get_projects", as: "tag"
   end
+  
+  # contest
+  get "/contests/admin", to: "contests#admin", as: "contests_admin"
+  get "/contests", to: "contests#index", as: "contests"
+  get "/contests/:id", to: "contests#show", as: "contest_page"
+  post "/contests/host", to: "contests#create", as: "new_contest"
+  put "/contests/:contest_id/close_contest", to: "contests#close_contest", as: "close_contest"
+  patch "/contests/:contest_id/update_contest", to: "contests#update_deadline", as: "update_contest"
+  get "/contests/:id/new_submission", to: "contests#new_submission", as: "new_submission"
+  post "/contests/:id/create_submission", to: "contests#create_submission", as: "create_submission"
+  delete "/contests/:contest_id/withdraw/:submission_id", to: "contests#withdraw", as: "withdraw_submission"
+  post "/contests/:contest_id/upvote/:submission_id", to: "contests#upvote", as: "vote_submission"
 
   # lti
   scope "lti"  do

--- a/db/migrate/20250105113940_create_contests.rb
+++ b/db/migrate/20250105113940_create_contests.rb
@@ -1,0 +1,10 @@
+class CreateContests < ActiveRecord::Migration[7.0]
+  def change
+    create_table :contests do |t|
+      t.datetime :deadline
+      t.integer :status, :integer
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250105114157_create_submissions.rb
+++ b/db/migrate/20250105114157_create_submissions.rb
@@ -1,0 +1,12 @@
+class CreateSubmissions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :submissions do |t|
+      t.references :contest, foreign_key: true
+      t.references :project, foreign_key: true
+      t.references :user, foreign_key: true
+      t.bigint :submission_votes_count, default: 0
+      t.boolean :winner, default: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250105114319_create_submission_votes.rb
+++ b/db/migrate/20250105114319_create_submission_votes.rb
@@ -1,0 +1,11 @@
+class CreateSubmissionVotes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :submission_votes do |t|
+      t.references :contest, foreign_key: true
+      t.references :submission, foreign_key: true
+      t.references :user, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250105114423_create_winners.rb
+++ b/db/migrate/20250105114423_create_winners.rb
@@ -1,0 +1,11 @@
+class CreateWinners < ActiveRecord::Migration[7.0]
+  def change
+    create_table :contest_winners do |t|
+      t.references :contest, foreign_key: true
+      t.references :submission, foreign_key: true
+      t.references :project, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250606061939_add_and_validate_contest_fks.rb
+++ b/db/migrate/20250606061939_add_and_validate_contest_fks.rb
@@ -1,0 +1,29 @@
+class AddAndValidateContestFks < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    safety_assured do
+      add_fk_if_missing :submission_votes, :users,    :user_id
+      add_fk_if_missing :submissions,      :projects, :project_id
+      add_fk_if_missing :submissions,      :users,    :user_id
+      add_fk_if_missing :contest_winners,  :projects, :project_id
+    end
+
+    validate_foreign_key :submission_votes, :users
+    validate_foreign_key :submissions,      :projects
+    validate_foreign_key :submissions,      :users
+    validate_foreign_key :contest_winners,  :projects
+  end
+
+  def down; end
+
+  private
+
+  def add_fk_if_missing(from_table, to_table, column)
+    return if foreign_key_exists?(from_table, to_table, column: column)
+
+    add_foreign_key from_table, to_table,
+                    column:   column,
+                    validate: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_10_20_082634) do
+ActiveRecord::Schema[7.0].define(version: 2025_06_06_061939) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -92,7 +92,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_10_20_082634) do
 
   create_table "assignments", force: :cascade do |t|
     t.string "name"
-    t.datetime "deadline", null: false
+    t.datetime "deadline", precision: nil, null: false
     t.text "description"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
@@ -155,6 +155,25 @@ ActiveRecord::Schema[7.0].define(version: 2024_10_20_082634) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["commontable_id", "commontable_type"], name: "index_commontator_threads_on_c_id_and_c_type", unique: true
+  end
+
+  create_table "contest_winners", force: :cascade do |t|
+    t.bigint "contest_id"
+    t.bigint "submission_id"
+    t.bigint "project_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["contest_id"], name: "index_contest_winners_on_contest_id"
+    t.index ["project_id"], name: "index_contest_winners_on_project_id"
+    t.index ["submission_id"], name: "index_contest_winners_on_submission_id"
+  end
+
+  create_table "contests", force: :cascade do |t|
+    t.datetime "deadline"
+    t.integer "status"
+    t.integer "integer"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "custom_mails", force: :cascade do |t|
@@ -366,7 +385,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_10_20_082634) do
     t.string "slug"
     t.tsvector "searchable"
     t.string "lis_result_sourced_id"
-    t.string "version", default: "1.0", null: false
     t.index ["assignment_id"], name: "index_projects_on_assignment_id"
     t.index ["author_id"], name: "index_projects_on_author_id"
     t.index ["forked_project_id"], name: "index_projects_on_forked_project_id"
@@ -392,6 +410,30 @@ ActiveRecord::Schema[7.0].define(version: 2024_10_20_082634) do
     t.index ["project_id"], name: "index_stars_on_project_id"
     t.index ["user_id", "project_id"], name: "index_stars_on_user_id_and_project_id", unique: true
     t.index ["user_id"], name: "index_stars_on_user_id"
+  end
+
+  create_table "submission_votes", force: :cascade do |t|
+    t.bigint "contest_id"
+    t.bigint "submission_id"
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["contest_id"], name: "index_submission_votes_on_contest_id"
+    t.index ["submission_id"], name: "index_submission_votes_on_submission_id"
+    t.index ["user_id"], name: "index_submission_votes_on_user_id"
+  end
+
+  create_table "submissions", force: :cascade do |t|
+    t.bigint "contest_id"
+    t.bigint "project_id"
+    t.bigint "user_id"
+    t.bigint "submission_votes_count", default: 0
+    t.boolean "winner", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["contest_id"], name: "index_submissions_on_contest_id"
+    t.index ["project_id"], name: "index_submissions_on_project_id"
+    t.index ["user_id"], name: "index_submissions_on_user_id"
   end
 
   create_table "subscriptions", force: :cascade do |t|
@@ -482,6 +524,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_10_20_082634) do
   add_foreign_key "collaborations", "projects"
   add_foreign_key "collaborations", "users"
   add_foreign_key "commontator_comments", "commontator_comments", column: "parent_id", on_update: :restrict, on_delete: :cascade
+  add_foreign_key "contest_winners", "contests"
+  add_foreign_key "contest_winners", "projects"
+  add_foreign_key "contest_winners", "submissions"
   add_foreign_key "custom_mails", "users"
   add_foreign_key "featured_circuits", "projects"
   add_foreign_key "forum_posts", "forum_threads"
@@ -503,6 +548,12 @@ ActiveRecord::Schema[7.0].define(version: 2024_10_20_082634) do
   add_foreign_key "projects", "users", column: "author_id"
   add_foreign_key "stars", "projects"
   add_foreign_key "stars", "users"
+  add_foreign_key "submission_votes", "contests"
+  add_foreign_key "submission_votes", "submissions"
+  add_foreign_key "submission_votes", "users"
+  add_foreign_key "submissions", "contests"
+  add_foreign_key "submissions", "projects"
+  add_foreign_key "submissions", "users"
   add_foreign_key "taggings", "projects"
   add_foreign_key "taggings", "tags"
   # no candidate create_trigger statement could be found, creating an adapter-specific one

--- a/spec/controllers/contest_controller_spec.rb
+++ b/spec/controllers/contest_controller_spec.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe ContestsController, type: :request do
+  before do
+    @user = FactoryBot.create(:user)
+    @contest = FactoryBot.create(:contest, status: :live)
+    @project = FactoryBot.create(:project, author: @user)
+    sign_in @user
+  end
+
+  let(:create_params) do
+    {
+      contest_id: @contest.id,
+      submission: {
+        project_id: @project.id
+      }
+    }
+  end
+
+  describe "#index" do
+    it "renders all the contests" do
+      get contests_path
+      expect(Contest.count).to eq(1)
+    end
+  end
+
+  describe "#show" do
+    it "render the contest page" do
+      get contest_page_path(@contest.id)
+      expect(response.status).to eq(200)
+      expect(@contest.status).to eq("live")
+    end
+  end
+
+  describe "#close_contest" do
+    it "close the live contest" do
+      get contests_admin_path
+      post new_contest_path
+      put close_contest_path(Contest.last.id)
+
+      expect(response.status).to eq(302)
+      expect(Contest.last.status).to eq("completed")
+      expect(Contest.where(status: "live").count).to eq(0)
+    end
+  end
+
+  describe "#create" do
+    before do
+      close_contest_path(@contest.id)
+      get contests_admin_path
+    end
+
+    context "when there is not live contest" do
+      it "creates a new contest" do
+        post new_contest_path
+
+        expect(response.status).to eq(302)
+        expect(Contest.where(status: "live").count).to eq(1)
+      end
+    end
+
+    context "when there is live contest" do
+      before do
+        post new_contest_path
+      end
+
+      it "does not allow to create concurrent live contest" do
+        expect do
+          post new_contest_path
+        end.not_to change(Contest.where(status: "live"), :count)
+      end
+    end
+  end
+
+  describe "#new_submission" do
+    it "renders new submission form template" do
+      get new_submission_path(@contest.id)
+      expect(response.body).to include("Project Submission")
+    end
+  end
+
+  describe "#create_submission" do
+    context "when new project is selected for submission" do
+      it "creates a new submission" do
+        post create_submission_path(@contest.id), params: create_params
+
+        expect(response.status).to eq(302)
+        expect(@contest.submissions.count).to eq(1)
+      end
+    end
+
+    context "when the project is already submitted." do
+      before do
+        post create_submission_path(@contest.id), params: create_params
+      end
+
+      it "not creates a new submission" do
+        expect do
+          post create_submission_path(@contest.id), params: create_params
+        end.not_to change(Submission, :count)
+      end
+    end
+  end
+
+  describe "#withdraw" do
+    before do
+      @project = FactoryBot.create(:project, author: @user)
+      post create_submission_path(@contest.id), params: create_params
+      @submission = Submission.last
+    end
+
+    it "withdraw user submission from contest" do
+      delete withdraw_submission_path(@contest.id, @submission.id)
+
+      expect(@contest.submissions.count).to eq(0)
+    end
+  end
+
+  describe "#upvote" do
+    before do
+      post create_submission_path(@contest.id), params: create_params
+      @submission = Submission.last
+    end
+
+    context "when a user votes the submission for first time" do
+      it "votes the submission successfully" do
+        sign_in_random_user
+        get contest_page_path(@contest.id)
+
+        expect do
+          post vote_submission_path(@contest.id, @submission.id)
+        end.to change(@submission.submission_votes, :count).by(1)
+      end
+    end
+
+    context "when a user already voted the submission" do
+      it "not vote the submission again" do
+        sign_in_random_user
+        get contest_page_path(@contest.id)
+        post vote_submission_path(@contest.id, @submission.id)
+
+        expect do
+          post vote_submission_path(@contest.id, @submission.id)
+        end.not_to change(@submission.submission_votes, :count)
+      end
+    end
+  end
+end

--- a/spec/factories/contest.rb
+++ b/spec/factories/contest.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :contest do
+    deadline { Faker::Date.forward(days: 7) }
+  end
+end

--- a/spec/factories/submission.rb
+++ b/spec/factories/submission.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :submission do
+  end
+end

--- a/spec/models/contest.rb
+++ b/spec/models/contest.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Contest, type: :model do
+  describe "associations" do
+    it { is_expected.to have_many(:submissions) }
+    it { is_expected.to have_many(:submission_votes) }
+    it { is_expected.to has_one(:contest_winner) }
+  end
+end

--- a/spec/models/contest_winner.rb
+++ b/spec/models/contest_winner.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ContestWinner, type: :model do
+  describe "associations" do
+    it { is_expected.to belongs_to(:submissions) }
+    it { is_expected.to belongs_to(:project) }
+    it { is_expected.to belongs_to(:contest) }
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe Project, type: :model do
     it { is_expected.to have_many(:collaborators) }
     it { is_expected.to have_one(:featured_circuit) }
     it { is_expected.to have_many(:noticed_notifications) }
+    it { is_expected.to have_one(:contest_winner) }
+    it { is_expected.to have_many(:submissions) }
   end
 
   describe "validity" do

--- a/spec/models/submission.rb
+++ b/spec/models/submission.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Submission, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:project) }
+    it { is_expected.to belong_to(:contest) }
+    it { is_expected.to has_many(:submission_votes) }
+    it { is_expected.to has_one(:contest_winner) }
+  end
+end

--- a/spec/models/submission_vote.rb
+++ b/spec/models/submission_vote.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SubmissionVote, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:submission) }
+    it { is_expected.to belong_to(:contest) }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -44,9 +44,15 @@ RSpec.configure do |config|
   config.include Devise::Test::IntegrationHelpers, type: :system
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include FactoryBot::Syntax::Methods
+
+  # ------------------------------------------------------------------
+  # Enable feature flags needed by the test suite on every example
+  # ------------------------------------------------------------------
   config.before do
     Flipper.enable(:active_storage_s3)
+    Flipper.enable(:contests)
   end
+
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.

--- a/spec/support/capybara_chrome.rb
+++ b/spec/support/capybara_chrome.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "capybara/rspec"
+require "selenium/webdriver"
+require "tmpdir"
+
+Capybara.register_driver :headless_chrome do |app|
+  chrome_opts = Selenium::WebDriver::Chrome::Options.new
+
+  chrome_opts.add_argument("--headless")
+  chrome_opts.add_argument("--disable-gpu")
+  chrome_opts.add_argument("--no-sandbox")
+  chrome_opts.add_argument("--disable-dev-shm-usage")
+  chrome_opts.add_argument("--window-size=1400,1400")
+
+  profile_dir = File.join(Dir.tmpdir, "chrome-profile-#{Process.pid}")
+  chrome_opts.add_argument("--user-data-dir=#{profile_dir}")
+
+  Capybara::Selenium::Driver.new(app,
+                                 browser: :chrome,
+                                 capabilities: chrome_opts)
+end
+
+Capybara.javascript_driver = :headless_chrome
+
+RSpec.configure do |config|
+  config.before(type: :system) do
+    driven_by :headless_chrome
+  end
+end

--- a/spec/system/contests_spec.rb
+++ b/spec/system/contests_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Contests", type: :system do
+  before do
+    @contest = FactoryBot.create(:contest, status: :live)
+    @user    = FactoryBot.create(:user)
+    @project = FactoryBot.create(:project, author: @user)
+    sign_in @user
+  end
+
+  let(:create_params) do
+    {
+      contest_id: @contest.id,
+      submission: { project_id: @project.id }
+    }
+  end
+
+  it "list all the contest" do
+    visit contests_path
+    check_contest_container(@contest.id, "LIVE", @contest.submissions.count)
+  end
+
+  it "redirects to contest" do
+    visit contests_path
+    page.find("#contest-#{@contest.id}").click
+    check_contest_page(@contest.id)
+  end
+
+  context "contest submission" do
+    before do
+      visit contest_page_path(@contest.id)
+      page.find(".contest-submission-button").click
+    end
+
+    it "render the project submission page and submit the project" do
+      expect(page).to have_text("Project Submission")
+      expect(page).to have_text(@project.name)  # removed interpolation
+
+      page.find("#submission_project_id_#{@project.id}").click
+      page.find("#submission-submit-button").click
+      expect(page).to have_text("Submission was successfully added.")
+      expect(@contest.submissions.count).to eq(1)
+      check_submission_container(@contest.submissions.first, @project)
+    end
+
+    it "does not submit the same project for a contest again." do
+      page.find("#submission_project_id_#{@project.id}").click
+      page.find("#submission-submit-button").click
+      page.find(".contest-submission-button").click
+      page.find("#submission_project_id_#{@project.id}").click
+      page.find("#submission-submit-button").click
+
+      expect(page).to have_text("This project is already submitted in Contest ##{@contest.id}")
+    end
+  end
+
+  context "withdraw submission" do
+    before do
+      visit new_submission_path(@contest.id)
+      page.find("#submission_project_id_#{@project.id}").click
+      page.find("#submission-submit-button").click
+    end
+
+    it "withdraw the submission" do
+      page.find("#withdraw-submission-#{@contest.submissions.last.id}").click
+      expect(page).to have_text("Withdraw Submission")
+      expect(page).to have_text("Are you sure you want to withdraw your submission from contest?")
+
+      page.find("#withdraw-submission-button").click
+      expect(page).to have_text("Submission was successfully removed.")
+      expect(@contest.submissions.count).to eq(0)
+    end
+  end
+
+  context "when user votes the submission" do
+    before do
+      visit new_submission_path(@contest.id)
+      page.find("#submission_project_id_#{@project.id}").click
+      page.find("#submission-submit-button").click
+      sign_in_random_user
+      visit contest_page_path(@contest.id)
+    end
+
+    it "votes the submission" do
+      page.find("#vote-submission-#{@contest.submissions.last.id}").click
+      expect(page).to have_text("You have successfully voted the submission, Thanks! Votes remaining: 2")
+      expect(@contest.submissions.last.submission_votes_count).to eq(1)
+    end
+  end
+
+  context "when user try to vote the submission again" do
+    before do
+      visit new_submission_path(@contest.id)
+      page.find("#submission_project_id_#{@project.id}").click
+      page.find("#submission-submit-button").click
+      sign_in_random_user
+      visit contest_page_path(@contest.id)
+      page.find("#vote-submission-#{@contest.submissions.last.id}").click
+    end
+
+    it "does not vote the submission again" do
+      page.find("#vote-submission-#{@contest.submissions.last.id}").click
+      expect(page).to have_text("You have already vote this submission!")
+      expect(@contest.submissions.last.submission_votes_count).to eq(1)
+    end
+  end
+
+  def check_submission_container(submission, project)
+    expect(page).to have_text(project.name)
+    expect(page).to have_text("Votes: #{submission.submission_votes_count}")
+  end
+
+  def check_contest_page(id)
+    expect(page).to have_text("Contest ##{id}")
+    expect(page).to have_text("Your Remaining Votes: 3")
+  end
+
+  def check_contest_container(id, status, entries)
+    expect(page).to have_text("Contest ##{id}")
+    expect(page).to have_text(status)
+    expect(page).to have_text("Entries: #{entries}")
+  end
+end


### PR DESCRIPTION
### CI: stabilise system-specs & Yarn registry (follow-up to **#5799 Weekly-Contest**)

This PR is **only build/test clean-up** for the new Weekly-Contest feature:

| Changes | Why |
|---------|-----|
| Register **headless_chrome** driver with a unique temp profile | Eliminates `profile already in use` crashes on CI |
| Force all Capybara *system* specs to use that driver | Consistent cross-platform behaviour |
| `.npmrc` → Yarn CDN | Avoids intermittent `imurmurhash` 500 errors during `npm install` |

#### Dependency  
:warning: **Depends on #5799.** Until that PR is merged you’ll see one extra commit in this diff; once #5799 lands I’ll rebase and this PR will shrink to a single CI commit.

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a comprehensive contests system, allowing users to view, participate in, and vote on contests.
  - Added contest administration tools for creating, managing, and closing contests.
  - Enabled project submissions and voting, with live status indicators and winner selection.
  - Implemented notifications for new contests and contest winners.
  - Added multi-language support and updated navigation to include contests.

- **User Interface**
  - New pages and modals for contest listings, details, submissions, voting, and admin actions.
  - Enhanced styles for contest-related components and status indicators.

- **Bug Fixes**
  - Improved pagination link behavior for a smoother browsing experience.

- **Tests**
  - Added extensive test coverage for contest features, including system, model, and controller tests.

- **Chores**
  - Updated configurations and localization files to support contest features and multi-language navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->