### PR TITLE
Migrate Team Section to view component

### DIFF
--- a/app/component/about_page_components/team_section_component.html.erb
+++ b/app/component/about_page_components/team_section_component.html.erb
@@ -1,0 +1,21 @@
+<div class="container" <%= "id=\"#{section_id}\"" if section_id %>>
+  <div class="row center-row">
+    <div class="col-12 col-sm-12 col-md-12 col-lg-12">
+      <h2 class="main-heading"><%= title %></h2>
+      <p class="main-description"><%= description %></p>
+    </div>
+  </div>
+  <div class="row center-row teams-section">
+    <% members.each do |member| %>
+      <div class="team-member-container team-link">
+        <div class="team-underline">
+          <a target="_blank" rel="noopener noreferrer" href="<%= member[:link] %>">
+            <%= image_tag member[:img], alt: "#{member[:name]} Profile Image", class: "about-contributor-image" %>
+            <p class="team-footer"><%= member[:name] %></p>
+          </a>
+        </div>
+      </div>
+    <% end %>
+    <br><br>
+  </div>
+</div> 

--- a/app/component/about_page_components/team_section_component.rb
+++ b/app/component/about_page_components/team_section_component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AboutPageComponents::TeamSectionComponent < ViewComponent::Base
+  def initialize(title:, description:, members:, section_id: nil)
+    super
+    @title = title
+    @description = description
+    @members = members
+    @section_id = section_id
+  end
+
+  private
+
+    attr_reader :title, :description, :members, :section_id
+end

--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -31,86 +31,38 @@
     </div>
   </div>
   <hr>
-  <div class="container">
-    <div class="row center-row">
-        <div class="col-12 col-sm-12 col-md-12 col-lg-12">
-          <h2 class="main-heading"><%= t("about.core_team_heading") %></h2>
-          <p class="main-description"><%= t("about.core_team_description") %></p>
-        </div>
-    </div>
-    <div class="row center-row teams-section ">
-        <% @cores.each do |member| %>
-        <div class="team-member-container team-link ">
-          <div class="team-underline">
-            <a target="_blank" href="<%= member[:link] %>"><%= image_tag member[:img], class: "about-contributor-image" %><p class="team-footer "><%= member[:name] %></p></a>
-          </div>
-        </div>
-        <% end %>
-        <br><br>
-    </div>
-  </div>
+  <%= render AboutPageComponents::TeamSectionComponent.new(
+    title: t("about.core_team_heading"),
+    description: t("about.core_team_description"),
+    members: @cores,
+    section_id: "core-team"
+  ) %>
   <br><br>
   <hr>
-  <div class="container">
-    <div class="row center-row">
-        <div class="col-12 col-sm-12 col-md-12 col-lg-12">
-          <h2 class="main-heading"><%= t("about.mentors_team_heading") %></h2>
-          <p class="main-description"><%= t("about.mentors_team_description") %></p>
-        </div>
-    </div>
-    <div class="row center-row teams-section">
-        <% @mentors.each do |member| %>
-        <div class="team-member-container team-link">
-          <div class="team-underline">
-            <a target="_blank" href="<%= member[:link] %>"><%= image_tag member[:img], class: "about-contributor-image" %><p class="team-footer"><%= member[:name] %></p></a>
-          </div>
-        </div>
-        <% end %>
-        <br><br>
-    </div>
-  </div>
+  <%= render AboutPageComponents::TeamSectionComponent.new(
+    title: t("about.mentors_team_heading"),
+    description: t("about.mentors_team_description"),
+    members: @mentors,
+    section_id: "mentors"
+  ) %>
   <br><br>
   <hr>
 
-  <div class="container">
-    <div class="row center-row">
-        <div class="col-12 col-sm-12 col-md-12 col-lg-12">
-          <h2 class="main-heading"><%= t("about.issues_triaging_team") %></h2>
-          <p class="main-description"><%= t("about.issues_triaging_team_description") %></p>
-        </div>
-    </div>
-    <div class="row center-row teams-section">
-        <% @issues_triaging.each do |member| %>
-        <div class="team-member-container team-link">
-          <div class="team-underline">
-            <a target="_blank" href="<%= member[:link] %>"><%= image_tag member[:img],alt: "User Image", class: "about-contributor-image" %><p class="team-footer"><%= member[:name] %></p></a>
-          </div>
-        </div>
-        <% end %>
-        <br><br>
-    </div>
-  </div>
+  <%= render AboutPageComponents::TeamSectionComponent.new(
+    title: t("about.issues_triaging_team"),
+    description: t("about.issues_triaging_team_description"),
+    members: @issues_triaging,
+    section_id: "issues-triaging"
+  ) %>
   <br><br>
   <hr>
 
-  <div class="container">
-    <div class="row center-row">
-        <div class="col-12 col-sm-12 col-md-12 col-lg-12">
-          <h2 class="main-heading"><%= t("about.alumni_team_heading") %></h2>
-          <p class="main-description"><%= t("about.alumni_team_description") %></p>
-        </div>
-    </div>
-    <div class="row center-row teams-section">
-        <% @alumni.each do |member| %>
-        <div class="team-member-container team-link">
-          <div class="team-underline">
-            <a target="_blank" href="<%= member[:link] %>"><%= image_tag member[:img], class: "about-contributor-image " %><p class="team-footer underline"><%= member[:name] %></p></a>
-          </div>
-        </div>
-        <% end %>
-        <br><br>
-    </div>
-  </div>
+  <%= render AboutPageComponents::TeamSectionComponent.new(
+    title: t("about.alumni_team_heading"),
+    description: t("about.alumni_team_description"),
+    members: @alumni,
+    section_id: "alumni"
+  ) %>
   <br><br>
   <hr>
     <div class="row center-row">

--- a/spec/components/previews/team_section_component_preview.rb
+++ b/spec/components/previews/team_section_component_preview.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class TeamSectionComponentPreview < ViewComponent::Preview
+  def default
+    render(AboutPageComponents::TeamSectionComponent.new(
+             title: "CORE TEAM",
+             description: "CircuitVerse is lead by an experienced team that is dedicated to innovation and excellence.",
+             members: sample_core_members,
+             section_id: "core-team"
+           ))
+  end
+
+  private
+
+    def sample_core_members
+      [
+        { name: "Aboobacker MK", img: "https://avatars.githubusercontent.com/u/3112976?s=96&v=4",
+          link: "https://github.com/tachyons" },
+        { name: "Ruturaj Mohite", img: "https://avatars.githubusercontent.com/u/53974118?v=4",
+          link: "https://github.com/gr455" },
+        { name: "Nitin Singhal", img: "https://avatars.githubusercontent.com/u/16988558?s=96&v=4", link: "https://github.com/nitin10s" }
+      ]
+    end
+end

--- a/spec/components/team_section_component_spec.rb
+++ b/spec/components/team_section_component_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AboutPageComponents::TeamSectionComponent, type: :component do
+  include ViewComponent::TestHelpers
+
+  let(:sample_members) do
+    [
+      { name: "John Doe", img: "https://example.com/john.jpg", link: "https://github.com/johndoe" },
+      { name: "Jane Smith", img: "https://example.com/jane.jpg", link: "https://github.com/janesmith" }
+    ]
+  end
+
+  let(:title) { "Test Team" }
+  let(:description) { "This is a test team description" }
+
+  describe "rendering" do
+    it "renders the component with title and description" do
+      render_inline(described_class.new(
+                      title: title,
+                      description: description,
+                      members: sample_members
+                    ))
+
+      expect(page).to have_css(".container")
+      expect(page).to have_css("h2.main-heading", text: title)
+      expect(page).to have_css("p.main-description", text: description)
+      expect(page).to have_css(".teams-section")
+    end
+
+    it "renders all team members" do
+      render_inline(described_class.new(
+                      title: title,
+                      description: description,
+                      members: sample_members
+                    ))
+
+      sample_members.each do |member|
+        expect(page).to have_css(".team-member-container")
+        expect(page).to have_css("a[href='#{member[:link]}']")
+        expect(page).to have_css("img[src='#{member[:img]}']")
+        expect(page).to have_css("p.team-footer", text: member[:name])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #5801 

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -
Migrated Team Sections to View Component

### Screenshots of the UI changes (If any) -
<img width="1912" alt="Screenshot 2025-06-08 at 8 23 51 AM" src="https://github.com/user-attachments/assets/c2f9afd0-d336-4cb3-8644-bafe599c91c5" />

<!-- Do not add code diff here -->


## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.




Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a reusable team section component on the About page, displaying team members with their profiles, images, and descriptions in a responsive layout.

- **Refactor**
  - Simplified the About page by replacing repeated team section markup with the new reusable component.

- **Tests**
  - Added tests to ensure the team section component renders correctly with various team data.

- **Documentation**
  - Provided a preview for the team section component to showcase its appearance with sample data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->