### PR TITLE
Fix: Handle nil project_datum.data in JSON.parse

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -154,7 +154,7 @@ class ProjectsController < ApplicationController
     def set_name_project_datum(project_params)
       return unless @project.project_datum
 
-      datum_data = JSON.parse(@project.project_datum.data)
+      datum_data = JSON.parse(@project.project_datum.data || '{}')
       datum_data["name"] = project_params["name"]
       @project.project_datum.data = JSON.generate(datum_data)
     end


### PR DESCRIPTION
Fixes #5770 

This PR fixes a bug where JSON.parse(@project.project_datum.data) throws a TypeError if the data is nil.
Now, it safely falls back to an empty JSON object.

Checks:
- [ ] I have added proper PR title and linked to the issue
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.

