### PR TITLE
Add nil Check to Notification Partial

### DIFF
--- a/app/views/layouts/_notifications.html.erb
+++ b/app/views/layouts/_notifications.html.erb
@@ -2,8 +2,8 @@
   <div class="navbar-nav nav-item dropdown">
   <li class="nav-item px-1 navbar-3" id="navbar-dropdown-3" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="notification-dropdown-menu" tabindex="0" aria-label="Notifications">
       <i class="fas fa-bell notification-icon" id="notification-button"></i>
-      <% if @unread.count != 0 %>
-        <span class="notification-count"><%= @unread.count %></span>
+      <% if @unread&.count != 0 %>
+        <span class="notification-count"><%= @unread&.count %></span>
       <% end %>
     </li>
     <div class="dropdown-menu dropdown-menu-end dropdown-notification" aria-labelledby="navbar-dropdown-3">
@@ -11,7 +11,7 @@
         <strong><h4><%= t("users.notifications.heading") %></h4></strong>
         <button class="cancel-button">&#10005;</button>
       </div>
-      <% @notification.each do |notification| %>
+      <% (@notification || []).each do |notification| %>
         <%= link_to mark_as_read_path(id: current_user, notification_id: notification.id), method: :post do %>
           <div class="d-flex align-items-center nb-notification">
             <span><i class="<%= notification.to_notification.icon %>"></i></span>
@@ -30,7 +30,7 @@
           </div>
         <% end %>
       <% end %>
-      <% if @notification.count == 0 %>
+      <% if (@notification || []).count == 0 %>
         <div class="col-12 row center-row">
           <div class="search-no-results-image">
             <h6><%= t("users.notifications.no_unread_notifications") %></h6>
@@ -38,7 +38,7 @@
         </div>
       <% end %>
       <div class="d-flex align-items-center justify-content-center mb-2 mt-3">
-        <% if @unread.count.positive? %>
+        <% if @unread&.count&.positive? %>
           <%= link_to t("users.notifications.mark_as_read_button"), read_all_notifications_url(current_user), method: :patch, class: "anchor-text-left" %>
           <%= link_to t("users.notifications.see_all"), notifications_path(current_user), class: "anchor-text-right" %>
         <% else %>

--- a/app/views/layouts/_notifications.html.erb
+++ b/app/views/layouts/_notifications.html.erb
@@ -2,8 +2,8 @@
   <div class="navbar-nav nav-item dropdown">
   <li class="nav-item px-1 navbar-3" id="navbar-dropdown-3" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="notification-dropdown-menu" tabindex="0" aria-label="Notifications">
       <i class="fas fa-bell notification-icon" id="notification-button"></i>
-      <% if @unread&.count != 0 %>
-        <span class="notification-count"><%= @unread&.count %></span>
+      <% if @unread&.count&.positive?  %>
+        <span class="notification-count"><%= @unread.count %></span>
       <% end %>
     </li>
     <div class="dropdown-menu dropdown-menu-end dropdown-notification" aria-labelledby="navbar-dropdown-3">

--- a/app/views/layouts/_notifications.html.erb
+++ b/app/views/layouts/_notifications.html.erb
@@ -2,7 +2,7 @@
   <div class="navbar-nav nav-item dropdown">
   <li class="nav-item px-1 navbar-3" id="navbar-dropdown-3" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="notification-dropdown-menu" tabindex="0" aria-label="Notifications">
       <i class="fas fa-bell notification-icon" id="notification-button"></i>
-      <% if @unread&.count&.positive?  %>
+      <% if @unread&.count&.positive? %>
         <span class="notification-count"><%= @unread.count %></span>
       <% end %>
     </li>


### PR DESCRIPTION
Fixes #5824

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -
Add nil Check for notifications partial to access preview in isolated environment.

### Screenshots of the UI changes (If any) -
<!-- Do not add code diff here -->
<img width="1906" alt="Screenshot 2025-06-17 at 5 49 18 PM" src="https://github.com/user-attachments/assets/8dc480b3-e1b3-4607-bef2-2d1e00ca8dcd" />


## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.




Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of notifications to prevent errors when there are no unread or available notifications. The notifications area now displays correctly even if notification data is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->