### PR TITLE
chore: add `bullet` & `counter_culture`; enable Bullet in development and test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -136,6 +136,8 @@ group :development, :test do
   gem "rbs_rails"
   gem "steep"
   gem 'solargraph-rails', '~> 0.3.1'
+  gem 'bullet'
+  gem 'counter_culture'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,6 +150,9 @@ GEM
     bootsnap (1.15.0)
       msgpack (~> 1.2)
     builder (3.3.0)
+    bullet (8.0.8)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     bundler-audit (0.9.1)
       bundler (>= 1.2.0, < 3)
       thor (~> 1.0)
@@ -185,6 +188,9 @@ GEM
       will_paginate
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
+    counter_culture (3.11.1)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
     countries (5.3.0)
       unaccent (~> 0.3)
     country_select (8.0.1)
@@ -878,6 +884,7 @@ GEM
     unf_ext (0.0.8.2)
     unf_ext (0.0.8.2-x64-mingw32)
     unicode-display_width (2.6.0)
+    uniform_notifier (1.17.0)
     version_gem (1.1.1)
     view_component (3.9.0)
       activesupport (>= 5.2.0, < 8.0)
@@ -932,12 +939,14 @@ DEPENDENCIES
   aws-sdk-rails
   aws-sdk-s3 (~> 1.176)
   bootsnap
+  bullet
   bundler-audit (~> 0.9.1)
   capybara (~> 3.39)
   carrierwave (~> 3.0)
   coffee-rails (~> 5.0)
   commontator (~> 7.0.0)
   concurrent-ruby (= 1.3.4)
+  counter_culture
   country_select (~> 8.0)
   coveralls_reborn (~> 0.26.0)
   database_consistency

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
   config.active_record.migration_error = :page_load
   
   # Disable origin check for Cross-Site Request Forgery (CSRF) protection for codespaces
-  if(ENV["DEV_CONTAINER"] === "true")
+  if (ENV["DEV_CONTAINER"] == "true")
     config.action_controller.forgery_protection_origin_check = false
   end
 
@@ -65,22 +65,22 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.smtp_settings = {
-    :address              => ENV["SMTP_ADDRESS"],
-    :port                 => ENV["SMTP_PORT"],
-    :user_name            => ENV["CIRCUITVERSE_EMAIL_ID"],
-    :password             =>  ENV["CIRCUITVERSE_EMAIL_PASSWORD"],
-    :ssl                  => true,
-    :authentication       => :login,
-    :enable_starttls_auto => true,
+    address:              ENV["SMTP_ADDRESS"],
+    port:                 ENV["SMTP_PORT"],
+    user_name:            ENV["CIRCUITVERSE_EMAIL_ID"],
+    password:             ENV["CIRCUITVERSE_EMAIL_PASSWORD"],
+    ssl:                  true,
+    authentication:       :login,
+    enable_starttls_auto: true
   }
   config.action_mailer.delivery_method = :smtp
   if ENV['DOCKER_ENVIRONMENT']
-    config.action_mailer.smtp_settings = { :address => "mailcatcher", :port => 1025 }
+    config.action_mailer.smtp_settings = { address: "mailcatcher", port: 1025 }
   else
-    config.action_mailer.smtp_settings = { :address => "localhost", :port => 1025 }
+    config.action_mailer.smtp_settings = { address: "localhost",    port: 1025 }
   end
 
-  config.vapid_public_key = ENV["VAPID_PUBLIC_KEY"] || "BGxnigbQCa435vZ8_3uFdqLC0XJHXtONgEdI-ydMMs0JaBsnpUfLxR1UDagq6_cDwHyhqjw77tTlp0ULZkx8Xos="
+  config.vapid_public_key  = ENV["VAPID_PUBLIC_KEY"]  || "BGxnigbQCa435vZ8_3uFdqLC0XJHXtONgEdI-ydMMs0JaBsnpUfLxR1UDagq6_cDwHyhqjw77tTlp0ULZkx8Xos="
   config.vapid_private_key = ENV["VAPID_PRIVATE_KEY"] || "FkEMkOQHvMybUlCGH-DsOljTJlLzYGb3xEYsFY5Roxk="
 
   Rails.application.configure do
@@ -88,4 +88,11 @@ Rails.application.configure do
   end
 
   Paperclip.options[:command_path] = "/usr/local/bin/"
+
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.bullet_logger = true
+    Bullet.rails_logger  = true
+    Bullet.raise         = true
+  end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
   config.active_record.migration_error = :page_load
   
   # Disable origin check for Cross-Site Request Forgery (CSRF) protection for codespaces
-  if (ENV["DEV_CONTAINER"] == "true")
+  if(ENV["DEV_CONTAINER"] === "true")
     config.action_controller.forgery_protection_origin_check = false
   end
 
@@ -65,22 +65,22 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.smtp_settings = {
-    address:              ENV["SMTP_ADDRESS"],
-    port:                 ENV["SMTP_PORT"],
-    user_name:            ENV["CIRCUITVERSE_EMAIL_ID"],
-    password:             ENV["CIRCUITVERSE_EMAIL_PASSWORD"],
-    ssl:                  true,
-    authentication:       :login,
-    enable_starttls_auto: true
+    :address              => ENV["SMTP_ADDRESS"],
+    :port                 => ENV["SMTP_PORT"],
+    :user_name            => ENV["CIRCUITVERSE_EMAIL_ID"],
+    :password             =>  ENV["CIRCUITVERSE_EMAIL_PASSWORD"],
+    :ssl                  => true,
+    :authentication       => :login,
+    :enable_starttls_auto => true,
   }
   config.action_mailer.delivery_method = :smtp
   if ENV['DOCKER_ENVIRONMENT']
-    config.action_mailer.smtp_settings = { address: "mailcatcher", port: 1025 }
+    config.action_mailer.smtp_settings = { :address => "mailcatcher", :port => 1025 }
   else
-    config.action_mailer.smtp_settings = { address: "localhost",    port: 1025 }
+    config.action_mailer.smtp_settings = { :address => "localhost", :port => 1025 }
   end
 
-  config.vapid_public_key  = ENV["VAPID_PUBLIC_KEY"]  || "BGxnigbQCa435vZ8_3uFdqLC0XJHXtONgEdI-ydMMs0JaBsnpUfLxR1UDagq6_cDwHyhqjw77tTlp0ULZkx8Xos="
+  config.vapid_public_key = ENV["VAPID_PUBLIC_KEY"] || "BGxnigbQCa435vZ8_3uFdqLC0XJHXtONgEdI-ydMMs0JaBsnpUfLxR1UDagq6_cDwHyhqjw77tTlp0ULZkx8Xos="
   config.vapid_private_key = ENV["VAPID_PRIVATE_KEY"] || "FkEMkOQHvMybUlCGH-DsOljTJlLzYGb3xEYsFY5Roxk="
 
   Rails.application.configure do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,26 +8,12 @@ require File.expand_path("../config/environment", __dir__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require "rspec/rails"
 require "devise"
+require "bullet"
 
 # Including support files for tests
 Rails.root.glob("spec/support/**/*.rb").each { |f| require f }
 
 # Add additional requires below this line. Rails is not loaded until this point!
-
-# Requires supporting ruby files with custom matchers and macros, etc, in
-# spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
-# run as spec files by default. This means that files in spec/support that end
-# in _spec.rb will both be required and run as specs, causing the specs to be
-# run twice. It is recommended that you do not name files matching this glob to
-# end with _spec.rb. You can configure this pattern with the --pattern
-# option on the command line or in ~/.rspec, .rspec or `.rspec-local`.
-#
-# The following line is provided for convenience purposes. It has the downside
-# of increasing the boot-up time by auto-requiring all files in the support
-# directory. Alternatively, in the individual `*_spec.rb` files, manually
-# require only the support files necessary.
-#
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -53,6 +39,20 @@ RSpec.configure do |config|
   # examples within a transaction, remove the following line or assign false
   # instead of true.
   config.use_transactional_fixtures = true
+
+  config.before(:suite) do
+    Bullet.enable        = true
+    Bullet.bullet_logger = true
+    Bullet.raise         = true
+  end
+
+  config.before(:each) do
+    Bullet.start_request
+  end
+
+  config.after(:each) do
+    Bullet.end_request
+  end
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -15,6 +15,21 @@ Rails.root.glob("spec/support/**/*.rb").each { |f| require f }
 
 # Add additional requires below this line. Rails is not loaded until this point!
 
+# Requires supporting ruby files with custom matchers and macros, etc, in
+# spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
+# run as spec files by default. This means that files in spec/support that end
+# in _spec.rb will both be required and run as specs, causing the specs to be
+# run twice. It is recommended that you do not name files matching this glob to
+# end with _spec.rb. You can configure this pattern with the --pattern
+# option on the command line or in ~/.rspec, .rspec or `.rspec-local`.
+#
+# The following line is provided for convenience purposes. It has the downside
+# of increasing the boot-up time by auto-requiring all files in the support
+# directory. Alternatively, in the individual `*_spec.rb` files, manually
+# require only the support files necessary.
+#
+# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
 begin


### PR DESCRIPTION


## What changed
* Added `bullet` and `counter_culture` to the **development / test** group in `Gemfile`
* Enabled Bullet in `config/environments/development.rb`
* Integrated Bullet into `spec/rails_helper.rb` so specs fail on N+1 queries

## Why
These changes lay the groundwork for the upcoming N+1 query audit.  
Bullet will highlight N+1 queries during local development and fail any test that triggers one, preventing new regressions.

## How to verify
```bash
bundle install
rails s          # navigate through the app; Bullet should log or raise on N+1s
bundle exec rspec   # test suite should pass
