### PR TITLE
fix: remove obsolete 2-arg calls to project_image_preview

### DIFF
--- a/app/views/circuitverse/index.html.erb
+++ b/app/views/circuitverse/index.html.erb
@@ -181,7 +181,7 @@
             <% @featured_circuits.each do |circuit| %>
               <div class="col-12 col-sm-12 col-md-6 col-lg-4">
                 <div class="card circuit-card">
-                  <%= image_tag project_image_preview(circuit, current_user), alt: circuit.name, class: "card-img-top circuit-card-image", height: "180", width: "288" %>
+                  <%= image_tag project_image_preview(circuit), alt: circuit.name, class: "card-img-top circuit-card-image", height: "180", width: "288" %>
                   <div class="card-footer circuit-card-footer">
                     <div class="circuit-card-name">
                       <p><%= circuit.name %></p>
@@ -213,7 +213,7 @@
           <% @projects.each do |project| %>
             <div class="col-12 col-sm-12 col-md-6 col-lg-4">
               <div class="card circuit-card">
-                <%= image_tag project_image_preview(project, current_user), alt: project.name, class: "card-img-top circuit-card-image" %>
+                <%= image_tag project_image_preview(project), alt: project.name, class: "card-img-top circuit-card-image" %>
                 <div class="card-footer circuit-card-footer">
                   <div class="circuit-card-name">
                     <p><%= project.name %></p>

--- a/app/views/featured_circuits/index.html.erb
+++ b/app/views/featured_circuits/index.html.erb
@@ -11,7 +11,7 @@
     <% @projects.each do |project| %>
       <div class="col-12 col-sm-12 col-md-6 col-lg-4">
         <div class="card circuit-card">
-          <%= image_tag project_image_preview(project, current_user), alt: project.name, class: "card-img-top circuit-card-image" %>
+          <%= image_tag project_image_preview(project), alt: project.name, class: "card-img-top circuit-card-image" %>
           <div class="card-footer circuit-card-footer">
             <div class="circuit-card-name">
               <p><%= project.name %></p>


### PR DESCRIPTION
## Summary

Fixes #5885 

## Context 

| Commit / PR | What changed | Impact |
|-------------|--------------|--------|
| **PR #5815** – “Migrate Project Card to View Component” | Removed the `current_user` positional parameter from `project_image_preview(project)` | Any view still calling the *old* two-arg form now fails with an arity mismatch. |

---

## Changes in This PR

| File | Old Call | New Call |
|------|----------|----------|
| `app/views/circuitverse/index.html.erb` | `project_image_preview(circuit, current_user)`<br>`project_image_preview(project, current_user)` | `project_image_preview(circuit)`<br>`project_image_preview(project)` |
| `app/views/featured_circuits/index.html.erb` | `project_image_preview(project, current_user)` | `project_image_preview(project)` |

---
