### PR TITLE
perf: eager-load image_preview for projects & featured circuits on home page (fix CORE-8)

### DIFF
--- a/app/controllers/circuitverse_controller.rb
+++ b/app/controllers/circuitverse_controller.rb
@@ -16,7 +16,7 @@ class CircuitverseController < ApplicationController
 
     @featured_circuits = Project.joins(:featured_circuit)
                                 .order("featured_circuits.created_at DESC")
-                                .includes(:author, image_preview_attachment: :blob)
+                                .includes(:author, circuit_preview_attachment: :blob)
                                 .limit(MAXIMUM_FEATURED_CIRCUITS)
 
     respond_to do |format|
@@ -49,11 +49,14 @@ class CircuitverseController < ApplicationController
 
   private
 
+    # Builds the cursor-paginated, eager-loaded query for the landing-page carousel.
     def build_projects_query(skip_cursor: false)
-      query = Project.select(:id, :author_id, :image_preview, :name, :slug)
-                     .public_and_not_forked
-                     .where.not(image_preview: "default.png")
-                     .includes(:author, image_preview_attachment: :blob)
+      query = Project
+              .select(:id, :author_id, :image_preview, :name, :slug)
+              .public_and_not_forked
+              .where.not(image_preview: "default.png")
+              .with_attached_circuit_preview
+              .includes(:author)
 
       cursor_params = {
         order: { id: :desc },

--- a/app/controllers/circuitverse_controller.rb
+++ b/app/controllers/circuitverse_controller.rb
@@ -16,7 +16,7 @@ class CircuitverseController < ApplicationController
 
     @featured_circuits = Project.joins(:featured_circuit)
                                 .order("featured_circuits.created_at DESC")
-                                .includes(:author)
+                                .includes(:author, image_preview_attachment: :blob)
                                 .limit(MAXIMUM_FEATURED_CIRCUITS)
 
     respond_to do |format|
@@ -53,7 +53,7 @@ class CircuitverseController < ApplicationController
       query = Project.select(:id, :author_id, :image_preview, :name, :slug)
                      .public_and_not_forked
                      .where.not(image_preview: "default.png")
-                     .includes(:author)
+                     .includes(:author, image_preview_attachment: :blob)
 
       cursor_params = {
         order: { id: :desc },


### PR DESCRIPTION
Fixes : #5907

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized loading of image previews for circuits, resulting in faster page rendering when viewing featured circuits and project listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->