### PR TITLE
fix: Fix broken link in SETUP.md

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -8,7 +8,7 @@ If you have any setup problems, please ensure you have read through all the inst
 ---
 
 ## Note
-If you are facing any issues with the setup, first checkout the [troubleshooting guide](https://github.com/CircuitVerse/CircuitVerse/tree/master/installation_docs/troubleshooting_guide.md) and if you are still facing issues, feel free to ask in the [slack](https://github.com/CircuitVerse/CircuitVerse/blob/master/README.md#community) channel.
+If you are facing any issues with the setup, first checkout the [troubleshooting guide](installation_docs/troubleshooting_guide.md) and if you are still facing issues, feel free to ask in the [slack](https://github.com/CircuitVerse/CircuitVerse/blob/master/README.md#community) channel.
 
 ## Installation
 There are several ways to run your own instance of CircuitVerse:


### PR DESCRIPTION
## Changes Made
- Fixed broken link to troubleshooting guide in SETUP.md
- Changed from absolute GitHub URL to relative link
- Link now correctly points to `installation_docs/troubleshooting_guide.md`

## Problem
The troubleshooting guide link was pointing to an absolute GitHub URL which doesn't work properly when viewing the file on GitHub or locally.

## Solution
Converted the link to a relative path that works correctly in all contexts.

## Files Changed
- SETUP.md (line 12)

##Closes issue 
- #5917

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the troubleshooting guide link in the setup instructions to use a local path for easier access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->