### PR TITLE
Fix withdraw behaviour post contest

### DIFF
--- a/app/components/contest/submission_card_component.html.erb
+++ b/app/components/contest/submission_card_component.html.erb
@@ -24,7 +24,7 @@
         </a>
         <% project = @submission.project %>
 
-        <% if @current_user && project.author == @current_user %>
+        <% if @current_user && project.author == @current_user && @contest.live? %>
           <%= link_to "#",
                       class:  "previewButton btn primary-button danger-primary-button withdraw-button",
                       id:     "withdraw-submission-#{@submission.id}",

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,10 +26,8 @@ class ApplicationController < ActionController::Base
 
   def switch_locale(&)
     logger.debug "* Accept-Language: #{request.env['HTTP_ACCEPT_LANGUAGE']}"
-    locale = params[:locale]&.to_sym || current_user&.locale || extract_locale_from_accept_language_header 
-    unless I18n.available_locales.include?(locale)
-      locale = I18n.default_locale
-    end
+    locale = params[:locale]&.to_sym || current_user&.locale || extract_locale_from_accept_language_header
+    locale = I18n.default_locale unless I18n.available_locales.include?(locale)
     logger.debug "* Locale set to '#{locale}'"
     I18n.with_locale(locale, &)
   end

--- a/app/controllers/contests/submissions_controller.rb
+++ b/app/controllers/contests/submissions_controller.rb
@@ -4,6 +4,7 @@ class Contests::SubmissionsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_contest
   before_action :check_contests_feature_flag
+  before_action :prevent_withdraw_if_contest_completed, only: :destroy
 
   def new
     @projects = current_user.projects
@@ -64,5 +65,11 @@ class Contests::SubmissionsController < ApplicationController
       return if Flipper.enabled?(:contests, current_user)
 
       redirect_to root_path, alert: t("feature_not_available")
+    end
+
+    def prevent_withdraw_if_contest_completed
+      return unless @contest.completed?
+
+      redirect_to contest_path(@contest), alert: t("contests.submissions.destroy.withdraw_closed")
     end
 end

--- a/config/locales/views/contests/en.yml
+++ b/config/locales/views/contests/en.yml
@@ -78,6 +78,7 @@ en:
         duplicate_submission: "This project is already submitted in Contest #%{contest_id}"
       destroy:
         success: "Submission was successfully removed."
+        withdraw_closed: "Withdrawals are closed as the contest has ended."
       votes:
         create:
           voting_closed: "Voting is closed."

--- a/spec/components/contest/submission_card_component_spec.rb
+++ b/spec/components/contest/submission_card_component_spec.rb
@@ -45,4 +45,23 @@ RSpec.describe Contest::SubmissionCardComponent, type: :component do
       expect(page).not_to have_link("Withdraw")
     end
   end
+
+  context "when contest is completed and current user is the author" do
+    it "does not show Withdraw button" do
+      contest    = create(:contest, status: :completed)
+      author     = create(:user)
+      project    = create(:project, author: author)
+      submission = create(:submission,
+                          contest: contest,
+                          project: project,
+                          submission_votes_count: 0)
+
+      render_inline described_class.new(submission: submission,
+                                        contest: contest,
+                                        current_user: author)
+
+      expect(page).to have_css("a.previewButton", text: "View")
+      expect(page).not_to have_link("Withdraw")
+    end
+  end
 end

--- a/spec/requests/contests_submissions_create_guards_spec.rb
+++ b/spec/requests/contests_submissions_create_guards_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Contest submissions create guards", type: :request do
+  let(:contest) { create(:contest, :live) }
+
+  it "redirects when submitting a project the user does not own" do
+    owner   = create(:user)
+    thief   = create(:user)
+    project = create(:project, author: owner)
+
+    sign_in thief
+
+    expect do
+      post contest_submissions_path(contest),
+           params: { submission: { project_id: project.id } }
+    end.not_to change(Submission, :count)
+
+    expect(response).to redirect_to(contest_path(contest))
+    expect(flash[:alert]).to eq(I18n.t("contests.submissions.create.unauthorized_project"))
+  end
+
+  it "redirects when submitting a duplicate project to the same contest" do
+    author  = create(:user)
+    project = create(:project, author: author)
+    create(:submission, contest: contest, project: project)
+
+    sign_in author
+
+    expect do
+      post contest_submissions_path(contest),
+           params: { submission: { project_id: project.id } }
+    end.not_to change(Submission, :count)
+
+    expect(response).to redirect_to(new_contest_submission_path(contest))
+    expect(flash[:notice]).to eq(
+      I18n.t("contests.submissions.create.duplicate_submission", contest_id: contest.id)
+    )
+  end
+end

--- a/spec/requests/contests_withdraw_guard_spec.rb
+++ b/spec/requests/contests_withdraw_guard_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Withdraw guard", type: :request do
+  it "does not allow withdrawing after contest completion" do
+    author     = create(:user)
+    project    = create(:project, author: author)
+    contest    = create(:contest, status: :completed)
+    submission = create(:submission, contest: contest, project: project)
+
+    sign_in author
+
+    expect do
+      delete contest_submission_path(contest, submission)
+    end.not_to change(Submission, :count)
+
+    expect(response).to redirect_to(contest_path(contest))
+    expect(flash[:alert]).to eq(I18n.t("contests.submissions.destroy.withdraw_closed"))
+  end
+end


### PR DESCRIPTION
Fixes #5954


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The "Withdraw" button for contest submissions is now only visible if the contest is live, preventing withdrawals after contest completion.
  * Attempting to withdraw a submission after a contest has ended now shows a clear alert message and blocks the action.

* **New Features**
  * Added a user-facing alert message when withdrawal is attempted after contest completion.

* **Tests**
  * Added tests to verify that the "Withdraw" button is hidden for completed contests and that withdrawal is blocked with an appropriate alert.
  * Added tests to prevent unauthorized and duplicate contest submissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->