### PR TITLE
fix(i18n): add missing Arabic translations for contests UI buttons and votes

### DIFF
--- a/config/locales/views/contests/ar.yml
+++ b/config/locales/views/contests/ar.yml
@@ -54,6 +54,7 @@ ar:
     buttons:
       submit: "إرسال"
       update_deadline: "تحديث الموعد النهائي"
+
   contests:
     index:
       title: "مسابقات"
@@ -83,6 +84,12 @@ ar:
           all_votes_used: "لقد استخدمت جميع تصويتاتك!"
           already_voted: "لقد قمت بالفعل بالتصويت لهذا المسلم!"
           success: "لقد قمت بالتصويت بنجاح على التقديم، شكراً! الأصوات المتبقية: %{votes_remaining}"
+    buttons:
+      withdraw: "سحب"
+      view: "عرض"
+    votes:
+      label: "الأصوات"
+
   admin:
     contests:
       index:
@@ -98,9 +105,12 @@ ar:
         invalid_deadline: "تنسيق الموعد النهائي غير صالح."
       parse_deadline_or_redirect:
         invalid_deadline: "تنسيق الموعد النهائي غير صالح."
+
   layout:
     link_to_contests: "مسابقات"
+
   users:
     circuitverse:
       preview_project: "معاينة المشروع"
+
   feature_not_available: "ميزة التنافس غير متوفرة."


### PR DESCRIPTION
Fixes #5958

Added missing Arabic translations for the "Withdraw" and "View" buttons as well as the "Votes" label in the contests UI.

N/A

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.

Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Arabic translations for "withdraw" and "view" contest buttons, as well as a "votes" label.

* **Style**
  * Improved spacing and formatting in the Arabic contest localization file for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->