### PR TITLE
refactor(api): remove duplicate image_preview attr in ProjectSerializer

### DIFF
--- a/app/serializers/api/v1/project_serializer.rb
+++ b/app/serializers/api/v1/project_serializer.rb
@@ -4,7 +4,7 @@ class Api::V1::ProjectSerializer
   include FastJsonapi::ObjectSerializer
 
   attributes :name, :project_access_type, :created_at,
-             :updated_at, :image_preview, :description,
+             :updated_at, :description,
              :view, :tags
 
   attributes :is_starred do |project, params|


### PR DESCRIPTION
Duplicate image_preview attribute (Fast JSON:API)

Api::V1::ProjectSerializer declares :image_preview twice, first as a plain attribute, then as a computed block.

CC : @tachyons

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the image preview field from the project data returned by the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->