### PR TITLE
fix(users): make votes use ActsAsVotable::Vote (as: :voter) to prevent NameError on user destroy

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable and :omniauthable
   has_many :projects, foreign_key: "author_id", dependent: :destroy
   has_many :stars
-  has_many :votes, dependent: :destroy
+  has_many :votes, class_name: "ActsAsVotable::Vote", as: :voter, dependent: :destroy
   has_many :rated_projects, through: :stars, dependent: :destroy, source: "project"
   has_many :groups_owned, class_name: "Group", foreign_key: "primary_mentor_id", dependent: :destroy
   devise :confirmable, :database_authenticatable, :registerable, :recoverable, :rememberable, :trackable,


### PR DESCRIPTION
Fixes : #5961 