### PR TITLE
Update all Explore specs to use direct english text instead of I18n keys #5982

### DIFF
--- a/spec/requests/explore_controller_spec.rb
+++ b/spec/requests/explore_controller_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe "Explore", type: :request do
     it "renders explore page" do
       get "/explore"
       expect(response.status).to eq(200)
-      expect(response.body).to include(I18n.t("explore.sections.cotw.heading"))
-      expect(response.body).to include(I18n.t("explore.sections.picks.heading"))
+      expect(response.body).to include("Circuit of the week")
+      expect(response.body).to include("Editor Picks")
     end
   end
 end

--- a/spec/requests/explore_pagination_spec.rb
+++ b/spec/requests/explore_pagination_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Explore pagination (cursor)", type: :request do
     it "renders empty state and no pagination" do
       get "/explore"
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include(I18n.t("explore.empty"))
+      expect(response.body).to include("Nothing to show yet.")
       expect(response.body).not_to include("pagination justify-content-center")
     end
   end

--- a/spec/requests/explore_spec.rb
+++ b/spec/requests/explore_spec.rb
@@ -19,6 +19,6 @@ RSpec.describe "Explore", type: :request do
     Flipper.enable(:circuit_explore_page)
     get "/explore"
     expect(response).to have_http_status(:ok)
-    expect(response.body).to include(I18n.t("explore.main_heading"))
+    expect(response.body).to include("Explore Circuits")
   end
 end

--- a/spec/system/explore_entrypoints_spec.rb
+++ b/spec/system/explore_entrypoints_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe "Explore entrypoints", type: :system do
   it "does not show nav Explore when flag off" do
     Flipper.disable(:circuit_explore_page)
     visit "/"
-    expect(page).not_to have_link(I18n.t("layout.link_to_explore"), href: "/explore")
+    expect(page).not_to have_link("Explore", href: "/explore")
   end
 
   it "shows nav Explore when flag on" do
     Flipper.enable(:circuit_explore_page)
     visit "/"
-    expect(page).to have_link(I18n.t("layout.link_to_explore"), href: "/explore")
+    expect(page).to have_link("Explore", href: "/explore")
   end
 end

--- a/spec/system/explore_page_spec.rb
+++ b/spec/system/explore_page_spec.rb
@@ -15,14 +15,14 @@ RSpec.describe "Explore page", :js, type: :system do
     end
 
     visit "/explore"
-    expect(page).to have_content(I18n.t("explore.sections.cotw.heading"))
-    expect(page).to have_content(I18n.t("explore.sections.picks.heading"))
+    expect(page).to have_content("Circuit of the week")
+    expect(page).to have_content("Editor Picks")
 
-    click_button I18n.t("explore.tabs.recent")
-    expect(page).to have_content(I18n.t("explore.sections.recent.heading"))
+    click_button "Recent Circuits"
+    expect(page).to have_content("Recent Circuits")
 
     expect(page).to have_selector(".project-card", minimum: 1)
-    click_link I18n.t("pagination.next", default: "Next")
+    click_link "Next"
     expect(page).to have_current_path(%r{/explore\?section=recent&after=[^#&]+(#recent)?})
   end
 end

--- a/spec/system/explore_tabs_spec.rb
+++ b/spec/system/explore_tabs_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe "Explore tabs", :js, type: :system do
   # rubocop:disable RSpec/MultipleExpectations
   it "switches sections without reload" do
     visit "/explore"
-    expect(page).to have_button(I18n.t("explore.tabs.cotw"))
-    expect(page).to have_button(I18n.t("explore.tabs.recent"))
+    expect(page).to have_button("Circuit of the week")
+    expect(page).to have_button("Recent Circuits")
 
     expect(page).to have_css('.explore-section[data-key="cotw"]:not(.d-none)')
     expect(page).to have_css('.explore-section[data-key="recent"].d-none', visible: :all)
 
-    click_button I18n.t("explore.tabs.recent")
+    click_button "Recent Circuits"
     expect(page).to have_css('.explore-section[data-key="recent"]:not(.d-none)')
     expect(page).to have_css('.explore-section[data-key="cotw"].d-none', visible: :all)
   end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Updated automated tests for the Explore experience to assert visible English text for headings, tabs, empty states, pagination, and navigation links instead of translation lookups.
  - Improves test clarity and reliability without altering app behavior.
  - No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->