### PR TITLE
fix: prevent unwanted horizontal scroll on teachers page

### DIFF
--- a/app/assets/stylesheets/teacher.scss
+++ b/app/assets/stylesheets/teacher.scss
@@ -20,10 +20,19 @@
 
 .teacher-image {
   border: 2px solid $shadow-grey;
-  max-height: 100%;
+  width: 100%;           
   max-width: 100%;
+  height: auto;
+  display: block;
+  box-sizing: border-box; 
 }
 
 .teacher-left-text {
   text-align: left;
+}
+
+.teachers-page .col, 
+.teachers-page [class^="col-"],
+.teachers-page [class*=" col-"] {
+  overflow-wrap: anywhere;
 }

--- a/app/views/circuitverse/teachers.html.erb
+++ b/app/views/circuitverse/teachers.html.erb
@@ -1,63 +1,56 @@
 <% content_for :title, t("circuitverse.teachers.title") %>
-
-<div class="row justify-content-center text-center mt-5">
-  <div class="col-12">
-    <h1 class="text-success"><%= t("circuitverse.teachers.main_heading") %></h1>
-    <div class="mb-4 mx-auto mw-100">
-      <p class="fs-5"><%= t("circuitverse.teachers.main_description") %></p>
+<div class="teachers-page container">
+  <div class="row justify-content-center text-center mt-5">
+    <div class="col-12">
+      <h1 class="text-success"><%= t("circuitverse.teachers.main_heading") %></h1>
+      <div class="mb-4 mx-auto mw-100">
+        <p class="fs-5"><%= t("circuitverse.teachers.main_description") %></p>
+      </div>
+      <h2><%= t("circuitverse.teachers.benefits") %></h2>
     </div>
-    <h2><%= t("circuitverse.teachers.benefits") %></h2>
   </div>
-</div>
-<div class="container-fluid py-5">
-  <div class="container">
-    <div class="row justify-content-center align-items-center">
+  <section class="py-5">
+    <div class="row justify-content-center align-items-center g-4">
       <div class="col-md-6 text-start">
         <h4><%= t("circuitverse.teachers.create_group_heading") %></h4>
         <p><%= t("circuitverse.teachers.create_group_description") %></p>
       </div>
       <div class="col-md-6">
-        <img class="img-fluid border border-2 border-secondary" src="img/groups.png" alt="Groups screenshot">
+        <img class="img-fluid teacher-image" src="img/groups.png" alt="Groups screenshot">
       </div>
     </div>
-  </div>
-</div>
-<div class="container-fluid py-5">
-  <div class="container">
-    <div class="row justify-content-center align-items-center">
+  </section>
+  <section class="py-5">
+    <div class="row justify-content-center align-items-center g-4">
       <div class="col-md-6 text-start">
         <h4><%= t("circuitverse.teachers.post_assignment_heading") %></h4>
         <p><%= t("circuitverse.teachers.post_assignment_description") %></p>
       </div>
       <div class="col-md-6">
-        <img class="img-fluid border border-2 border-secondary" src="img/assignment.png" alt="Assignments screenshot">
+        <img class="img-fluid teacher-image" src="img/assignment.png" alt="Assignments screenshot">
       </div>
     </div>
-  </div>
-</div>
-<div class="container-fluid py-5">
-  <div class="container">
-    <div class="row justify-content-center align-items-center">
+  </section>
+  <section class="py-5">
+    <div class="row justify-content-center align-items-center g-4">
       <div class="col-md-6 text-start">
         <h4><%= t("circuitverse.teachers.grade_assignment_heading") %></h4>
         <p><%= t("circuitverse.teachers.grade_assignment_description") %></p>
       </div>
       <div class="col-md-6">
-        <img class="img-fluid border border-2 border-secondary" src="img/grading.png" alt="Grading screenshot">
+        <img class="img-fluid teacher-image" src="img/grading.png" alt="Grading screenshot">
       </div>
     </div>
-  </div>
-</div>
-<div class="container-fluid py-5">
-  <div class="container">
-    <div class="row justify-content-center align-items-center">
+  </section>
+  <section class="py-5">
+    <div class="row justify-content-center align-items-center g-4">
       <div class="col-md-6 text-start">
         <h4><%= t("circuitverse.teachers.use_interactive_circuit_heading") %></h4>
         <p><%= t("circuitverse.teachers.use_interactive_circuit_description") %></p>
       </div>
       <div class="col-md-6">
-        <img class="img-fluid border border-2 border-secondary" src="img/embed.png" alt="Embed screenshot">
+        <img class="img-fluid teacher-image" src="img/embed.png" alt="Embed screenshot">
       </div>
     </div>
-  </div>
+  </section>
 </div>


### PR DESCRIPTION
Closes: #6026 

Fixes unwanted horizontal scrolling on the Teachers page by ensuring column content wraps and removing margin_overflows.

Before:
<img width="1917" height="960" alt="Screenshot 2025-08-31 131333" src="https://github.com/user-attachments/assets/cf415bb3-83a4-4e95-b43d-a84439d3a5d2" />


After:
<img width="1919" height="975" alt="Screenshot 2025-08-31 131324" src="https://github.com/user-attachments/assets/8a4cd1c4-38fe-42c3-bf7b-5fa456322f76" />


Tests:
- Visual inspection on Chrome/Firefox
- Confirmed no horizontal scrollbar at 320/480/768/1366 widths

Notes:
- Husky pre-commit hooks passed locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refreshed Teachers page layout with consistent section-based structure for clearer reading and spacing.
  * Standardized image styling for a cleaner, uniform look across content blocks.
* **Bug Fixes**
  * Teacher images now scale to full width while preserving aspect ratio, reducing layout issues on various screens.
  * Long words and URLs now wrap within columns to prevent overflow and clipping on smaller devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->