### PR TITLE
feat: Improve Email Verification Flow 

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -14,6 +14,10 @@ html {
 body {
   font-family: 'Inter';
   padding-top: 90px;
+  
+  &.has-verification-banner {
+    padding-top: 140px; // 90px navbar + ~50px banner
+  }
 }
 
 .noSelect {

--- a/app/assets/stylesheets/navbar.scss
+++ b/app/assets/stylesheets/navbar.scss
@@ -1,9 +1,12 @@
-.navbar {
-  background-color: $white;
+.fixed-header-container {
   position: fixed;
   top: 0;
   width: 100%;
   z-index: 100;
+}
+
+.navbar {
+  background-color: $white;
 }
 
 .navbar-logo {
@@ -46,6 +49,10 @@
 
 .rotate180::after {
   transform: rotate(180deg);
+}
+
+.email-verification-banner {
+  border-radius: 0;
 }
 
 .dropdown-toggle.navbar-user-dropdown {

--- a/app/controllers/users/circuitverse_controller.rb
+++ b/app/controllers/users/circuitverse_controller.rb
@@ -5,7 +5,7 @@ class Users::CircuitverseController < ApplicationController
 
   include UsersCircuitverseHelper
 
-  before_action :authenticate_user!, only: %i[edit update groups]
+  before_action :authenticate_user!, only: %i[edit update groups resend_confirmation]
   before_action :set_user, except: [:typeahead_educational_institute]
   before_action :remove_previous_profile_picture, only: [:update]
 
@@ -40,6 +40,15 @@ class Users::CircuitverseController < ApplicationController
                          .select("groups.*, COUNT(group_members.id) as group_member_count")
                          .left_outer_joins(:group_members)
                          .group("groups.id")
+  end
+
+  def resend_confirmation
+    if current_user.confirmed?
+      render json: { success: false, message: "Email is already confirmed" }, status: :unprocessable_entity
+    else
+      current_user.send_confirmation_instructions
+      render json: { success: true, message: "Confirmation email sent successfully" }
+    end
   end
 
   private

--- a/app/views/layouts/_email_verification_banner.html.erb
+++ b/app/views/layouts/_email_verification_banner.html.erb
@@ -1,0 +1,16 @@
+<% if current_user && !current_user.confirmed? %>
+  <div id="email-verification-banner" class="alert alert-warning alert-dismissible fade show mb-0 alert-permanent email-verification-banner" role="alert">
+    <div class="container">
+      <div class="d-flex align-items-center justify-content-between">
+        <div class="d-flex align-items-center">
+          <i class="fas fa-exclamation-triangle me-2"></i>
+          <span>
+            <%= t("layout.email_verification_banner.message") %>
+            <%= link_to t("layout.email_verification_banner.verify_now"), profile_edit_path(current_user), class: "alert-link ms-1" %>
+          </span>
+        </div>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close" onclick="dismissVerificationBanner()"></button>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,3 +1,4 @@
+<div class="fixed-header-container">
 <nav class="navbar navbar-expand-lg bg-white">
   <div class="container">
     <a class="navbar-brand" href="/">
@@ -87,6 +88,10 @@
     current_filters: @current_filters
   )) %>
 </div>
+
+<%= render "layouts/email_verification_banner" %>
+</div>
+
 <script type="text/javascript">
   document.addEventListener("DOMContentLoaded", function() {
     const searchIcons = document.getElementsByClassName("fa-search");

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,6 +32,7 @@
   <!-- Custom Script for Alert -->
   <script>
     document.addEventListener('DOMContentLoaded', () => {
+      // Auto-dismiss alerts (except permanent ones)
       document.querySelectorAll('.alert').forEach(alert => {
         const bsAlert = new bootstrap.Alert(alert);
         if (!alert.classList.contains('alert-permanent')) {
@@ -41,7 +42,26 @@
           }, 3000);
         }
       });
+
+      // Email verification banner dismiss functionality
+      const verificationBanner = document.getElementById('email-verification-banner');
+      if (verificationBanner) {
+        // Check if banner was dismissed recently (within 1 week)
+        const dismissedTime = localStorage.getItem('emailVerificationBannerDismissedAt');
+        if (dismissedTime) {
+          const oneWeekInMs = 7 * 24 * 60 * 60 * 1000; // 1 week in milliseconds
+          const timeSinceDismissal = Date.now() - parseInt(dismissedTime);
+          
+          if (timeSinceDismissal < oneWeekInMs) {
+            verificationBanner.style.display = 'none';
+          }
+        }
+      }
     });
+
+    function dismissVerificationBanner() {
+      localStorage.setItem('emailVerificationBannerDismissedAt', Date.now().toString());
+    }
   </script>
 </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -48,19 +48,29 @@
       if (verificationBanner) {
         // Check if banner was dismissed recently (within 1 week)
         const dismissedTime = localStorage.getItem('emailVerificationBannerDismissedAt');
+        let shouldHideBanner = false;
+        
         if (dismissedTime) {
           const oneWeekInMs = 7 * 24 * 60 * 60 * 1000; // 1 week in milliseconds
           const timeSinceDismissal = Date.now() - parseInt(dismissedTime);
           
           if (timeSinceDismissal < oneWeekInMs) {
-            verificationBanner.style.display = 'none';
+            shouldHideBanner = true;
           }
+        }
+        
+        if (shouldHideBanner) {
+          verificationBanner.style.display = 'none';
+          document.body.classList.remove('has-verification-banner');
+        } else {
+          document.body.classList.add('has-verification-banner');
         }
       }
     });
 
     function dismissVerificationBanner() {
       localStorage.setItem('emailVerificationBannerDismissedAt', Date.now().toString());
+      document.body.classList.remove('has-verification-banner');
     }
   </script>
 </body>

--- a/app/views/users/circuitverse/edit.html.erb
+++ b/app/views/users/circuitverse/edit.html.erb
@@ -49,6 +49,14 @@
               <div class="primary-checkpoint"></div>
             </label>
           </div>
+          <% unless current_user.confirmed? %>
+            <div class="field mb-3">
+              <button type="button" id="resend-verification-btn" class="btn btn-secondary users-resend-verification-button">
+                <%= t("users.circuitverse.edit_profile.resend_verification") %>
+              </button>
+              <div id="verification-message" class="mt-2" style="display: none;"></div>
+            </div>
+          <% end %>
           <button type="submit" class="btn primary-button users-edit-primary-button"><%= t("save") %></button>
           <%= link_to t("back"), :back, class: "anchor-text" %>
         <% end %>
@@ -131,4 +139,42 @@
   document.querySelector('#remove_pic').addEventListener('change', function() {
       document.querySelector('#imgedit').src = '<%= image_path('thumb/Default.jpg') %>';
   });
+
+  // Resend email verification functionality
+  const resendBtn = document.getElementById('resend-verification-btn');
+  const messageDiv = document.getElementById('verification-message');
+  
+  if (resendBtn) {
+    resendBtn.addEventListener('click', function() {
+      const originalText = resendBtn.textContent;
+      resendBtn.disabled = true;
+      resendBtn.textContent = 'Sending...';
+      messageDiv.style.display = 'none';
+      
+      fetch('<%= resend_confirmation_path(current_user) %>', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
+        }
+      })
+      .then(response => response.json())
+      .then(data => {
+        messageDiv.style.display = 'block';
+        if (data.success) {
+          messageDiv.innerHTML = '<div class="alert alert-success">' + data.message + '</div>';
+        } else {
+          messageDiv.innerHTML = '<div class="alert alert-danger">' + data.message + '</div>';
+        }
+      })
+      .catch(error => {
+        messageDiv.style.display = 'block';
+        messageDiv.innerHTML = '<div class="alert alert-danger">An error occurred. Please try again.</div>';
+      })
+      .finally(() => {
+        resendBtn.disabled = false;
+        resendBtn.textContent = originalText;
+      });
+    });
+  }
 </script>

--- a/config/locales/views/layouts/en.yml
+++ b/config/locales/views/layouts/en.yml
@@ -30,6 +30,9 @@ en:
       my_groups: "My Groups"
       notifications: "Notifications"
       language: "Language"
+    email_verification_banner:
+      message: "Please verify your email address to access all features."
+      verify_now: "Verify now"
     mailer:
       join_us: "Join Us"
       copyright_text: "Copyright © %{time_current_year} CircuitVerse. All rights reserved. For any issues, reach out to us support@circuitverse.org"

--- a/config/locales/views/users/en.yml
+++ b/config/locales/views/users/en.yml
@@ -25,6 +25,7 @@ en:
         country_select_placeholder: "Prefer Not To Enter"
         select_locale_prompt: "Select the locale"
         subscribe_mail_checkpoint: "Subscribed to mails?"
+        resend_verification: "Resend Email Verification"
         delete_account_heading: "Delete your Account"
         delete_account_notice: "Proceed with caution! This action cannot be reversed."
         delete_account: "Delete Account"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,6 +90,7 @@ Rails.application.routes.draw do
     get "/:id/profile", to: redirect('/users/%{id}'), as: "profile"
     get "/:id/profile/edit", to: "users/circuitverse#edit", as: "profile_edit"
     patch "/:id/update", to: "users/circuitverse#update", as: "profile_update"
+    post "/:id/resend_confirmation", to: "users/circuitverse#resend_confirmation", as: "resend_confirmation"
     get "/:id/groups", to: "users/circuitverse#groups", as: "user_groups"
     get "/:id/", to: "users/circuitverse#index", as: "user_projects"
     get "/educational_institute/typeahead/:query" => "users/circuitverse#typeahead_educational_institute"


### PR DESCRIPTION
Fixes #5940

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -
Improves the Email Verification Flow by adding a "resend verification button" in profile edit page for easy access and displays a dismissible banner to notify user to verify if email is not verified. 

### Screenshots of the UI changes (If any) -
<!-- Do not add code diff here -->

https://github.com/user-attachments/assets/a0984d5a-6d6a-4a4a-b467-427b2180daf2



## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.




Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Dismissible email verification banner for unverified users with a “Verify now” link; dismissal persists for one week.
  - “Resend Email Verification” button on the profile page with inline success/error feedback.

- Bug Fixes
  - Removed duplicate client handler registration for the resend flow (prevents double requests/notifications).

- UI/Style
  - Header fixed at the top; header/banner spacing adjusted; navbar visuals refined (user menu shows pointer).

- Localization
  - Added English copy for banner and resend action.

- API
  - Added endpoint to trigger resending confirmation emails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->