### PR TITLE
Fix: ActiveJob::SerializationError due to reserved key "_aj_globalid" in Users::NoticedNotificationsController (#6075)

### DIFF
--- a/app/controllers/users/noticed_notifications_controller.rb
+++ b/app/controllers/users/noticed_notifications_controller.rb
@@ -11,7 +11,7 @@ class Users::NoticedNotificationsController < ApplicationController
   def mark_as_read
     notification = NoticedNotification.find(params[:notification_id])
     notification.update(read_at: Time.zone.now)
-    answer = NotifyUser.new(params).call
+    answer = NotifyUser.new(params.permit(:notification_id)).call
     redirect_to redirect_path_for(answer)
   end
 


### PR DESCRIPTION
Fixes #6075 

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -

**Issue:**  
The controller was passing the entire `params` hash to `NotifyUser.new` in the `mark_as_read` action. This could include Rails internal keys (like `_aj_globalid`), which causes ActiveJob to raise a `SerializationError` because those keys are reserved.

**Solution:**  
I updated the `mark_as_read` method to only pass permitted and safe parameters (`notification_id`) to `NotifyUser.new` using strong parameters. This ensures no reserved/internal keys are passed, preventing the serialization error.

**Code change:**  
```diff
- answer = NotifyUser.new(params).call
+ answer = NotifyUser.new(params.permit(:notification_id)).call
```
If more params are needed, they can be added to the permit list.

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.

