### PR TITLE
  Fix PostgreSQL index size limit error for projects

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -8,7 +8,7 @@ class Project < ApplicationRecord
   friendly_id :name, use: %i[slugged history]
   self.ignored_columns += %w[data searchable]
 
-  validates :name, length: { minimum: 1 }
+  validates :name, length: { minimum: 1, maximum: 500 }
   validates :slug, uniqueness: true
 
   belongs_to :author, class_name: "User", counter_cache: true


### PR DESCRIPTION
Fixes #6074 

## Problem

Projects with really long slugs were causing PostgreSQL to error out:
This happened in the simulator when saving projects - the composite index on slug and author_id was exceeding PostgreSQL's btree size limit (~2704 bytes).

## Solution

Added a max length validation on project names:
- Set maximum: 500 on the existing name validation
- Since slugs come from project names, this stops slugs from ever hitting the PostgreSQL limit
- No migrations or schema changes needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added maximum character limit (500 characters) for project names to improve data consistency and prevent potential display issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->