### PR TITLE
  Fix: handle mixed parameter types in notification classes to prevent TypeError

### DIFF
--- a/app/notifications/contest_winner_notification.rb
+++ b/app/notifications/contest_winner_notification.rb
@@ -4,7 +4,12 @@ class ContestWinnerNotification < Noticed::Base
   deliver_by :database, association: :noticed_notifications
 
   def message
-    project = params[:project]
+    project = params[:project] if params[:project].is_a?(Project)
+    project ||= Project.find_by(id: params[:project_id] || params["project_id"])
+    if params[:project].is_a?(Integer) || params[:project].is_a?(String)
+      project ||= Project.find_by(id: params[:project])
+    end
+
     return "Congratulations, your circuit got featured in CircuitVerse." unless project
 
     "Congratulations, your circuit #{project.name} got featured in CircuitVerse."

--- a/app/notifications/fork_notification.rb
+++ b/app/notifications/fork_notification.rb
@@ -4,8 +4,12 @@ class ForkNotification < Noticed::Base
   deliver_by :database, association: :noticed_notifications
 
   def message
-    user = params[:user]
-    project = params[:project]
+    user = params[:user] if params[:user].is_a?(User)
+    user ||= User.find_by(id: params[:user_id])
+
+    project = params[:project] if params[:project].is_a?(Project)
+    project ||= Project.find_by(id: params[:project_id])
+
     t("users.notifications.fork_notification", user: user&.name, project: project&.name)
   end
 

--- a/app/notifications/fork_notification.rb
+++ b/app/notifications/fork_notification.rb
@@ -5,10 +5,14 @@ class ForkNotification < Noticed::Base
 
   def message
     user = params[:user] if params[:user].is_a?(User)
-    user ||= User.find_by(id: params[:user_id])
+    user ||= User.find_by(id: params[:user_id] || params["user_id"])
+    user ||= User.find_by(id: params[:user]) if params[:user].is_a?(Integer) || params[:user].is_a?(String)
 
     project = params[:project] if params[:project].is_a?(Project)
-    project ||= Project.find_by(id: params[:project_id])
+    project ||= Project.find_by(id: params[:project_id] || params["project_id"])
+    if params[:project].is_a?(Integer) || params[:project].is_a?(String)
+      project ||= Project.find_by(id: params[:project])
+    end
 
     t("users.notifications.fork_notification", user: user&.name, project: project&.name)
   end

--- a/app/notifications/forum_comment_notification.rb
+++ b/app/notifications/forum_comment_notification.rb
@@ -4,10 +4,13 @@ class ForumCommentNotification < Noticed::Base
   deliver_by :database, association: :noticed_notifications
 
   def message
-    user = params[:user]
+    user = params[:user] if params[:user].is_a?(User)
+    user ||= User.find_by(id: params[:user_id] || params["user_id"])
+    user ||= User.find_by(id: params[:user]) if params[:user].is_a?(Integer) || params[:user].is_a?(String)
+
     # post = params[:forum_post]
     thread = params[:forum_thread]
-    t("users.notifications.comment_notif", user: user.name, thread: thread.title) # , mssg: post.body.truncate_words(4))
+    t("users.notifications.comment_notif", user: user&.name, thread: thread&.title) # , mssg: post.body.truncate_words(4))
   end
 
   def icon

--- a/app/notifications/forum_thread_notification.rb
+++ b/app/notifications/forum_thread_notification.rb
@@ -4,9 +4,12 @@ class ForumThreadNotification < Noticed::Base
   deliver_by :database, association: :noticed_notifications
 
   def message
-    user = params[:user]
+    user = params[:user] if params[:user].is_a?(User)
+    user ||= User.find_by(id: params[:user_id] || params["user_id"])
+    user ||= User.find_by(id: params[:user]) if params[:user].is_a?(Integer) || params[:user].is_a?(String)
+
     thread = params[:forum_thread]
-    t("users.notifications.forum_thread_notification", user: user.name, thread: thread.title.truncate_words(4))
+    t("users.notifications.forum_thread_notification", user: user&.name, thread: thread&.title&.truncate_words(4))
   end
 
   def icon

--- a/app/notifications/star_notification.rb
+++ b/app/notifications/star_notification.rb
@@ -4,8 +4,12 @@ class StarNotification < Noticed::Base
   deliver_by :database, association: :noticed_notifications
 
   def message
-    user = params[:user]
-    project = params[:project]
+    user = params[:user] if params[:user].is_a?(User)
+    user ||= User.find_by(id: params[:user_id])
+
+    project = params[:project] if params[:project].is_a?(Project)
+    project ||= Project.find_by(id: params[:project_id])
+
     t("users.notifications.star_notification", user: user&.name, project: project&.name)
   end
 

--- a/app/notifications/star_notification.rb
+++ b/app/notifications/star_notification.rb
@@ -5,10 +5,14 @@ class StarNotification < Noticed::Base
 
   def message
     user = params[:user] if params[:user].is_a?(User)
-    user ||= User.find_by(id: params[:user_id])
+    user ||= User.find_by(id: params[:user_id] || params["user_id"])
+    user ||= User.find_by(id: params[:user]) if params[:user].is_a?(Integer) || params[:user].is_a?(String)
 
     project = params[:project] if params[:project].is_a?(Project)
-    project ||= Project.find_by(id: params[:project_id])
+    project ||= Project.find_by(id: params[:project_id] || params["project_id"])
+    if params[:project].is_a?(Integer) || params[:project].is_a?(String)
+      project ||= Project.find_by(id: params[:project])
+    end
 
     t("users.notifications.star_notification", user: user&.name, project: project&.name)
   end

--- a/app/services/notify_user.rb
+++ b/app/services/notify_user.rb
@@ -10,7 +10,11 @@ class NotifyUser
     # @type [Assignment]
     @assignment = @notification.params[:assignment]
     # @type [Project]
-    @project = @notification.params[:project]
+    @project = if @notification.params[:project].is_a?(Project)
+      @notification.params[:project]
+    else
+      Project.find_by(id: @notification.params[:project_id])
+    end
     @thread = @notification.params[:forum_thread]
     @contest = @notification.params[:contest] # Added to handle ContestNotification
   end

--- a/app/services/notify_user.rb
+++ b/app/services/notify_user.rb
@@ -10,11 +10,14 @@ class NotifyUser
     # @type [Assignment]
     @assignment = @notification.params[:assignment]
     # @type [Project]
-    @project = if @notification.params[:project].is_a?(Project)
-      @notification.params[:project]
-    else
-      Project.find_by(id: @notification.params[:project_id])
-    end
+    raw_project = @notification.params[:project] || @notification.params["project"]
+    @project =
+      case raw_project
+      when Project then raw_project
+      when String, Integer then Project.find_by(id: raw_project)
+      else
+        Project.find_by(id: @notification.params[:project_id] || @notification.params["project_id"])
+      end
     @thread = @notification.params[:forum_thread]
     @contest = @notification.params[:contest] # Added to handle ContestNotification
   end
@@ -52,10 +55,14 @@ class NotifyUser
     end
 
     def star_notification
+      return Result.new("false", "missing_project", root_path) unless @project&.author
+
       Result.new("true", "star", @project.author, @project)
     end
 
     def fork_notification
+      return Result.new("false", "missing_project", root_path) unless @project&.author
+
       Result.new("true", "fork", @project.author, @project)
     end
 


### PR DESCRIPTION
Fixes #6083 
 ## Summary
  Fixes Sentry issue CIRCUITVERSE-CORE-M8: "TypeError: no implicit conversion of Symbol into Integer" in notification rendering.

  ## Root Cause
  Data migration stored notification params as `{ user_id: 123, project_id: 456 }` while notification classes expected `{ user:
  User, project: Project }`, causing parameter access mismatch.

## Changes
  - **ForkNotification & StarNotification**: Added type safety checks using `is_a?()` before accessing model objects
  - **NotifyUser service**: Updated project parameter handling with type validation
  - Maintains backward compatibility with both parameter formats (objects and IDs)

  ## Solution:
 Added type checks to safely handle both formats - if we get an actual User object, use it; otherwise look up by
  ID.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Fork, star, contest winner and forum notifications more reliably display correct user and project/thread names.
  - Reduced blank or incorrect names when notifications are triggered with either objects or IDs.
  - Notifications now fail gracefully when a required project or author is missing, preventing broken alerts.

- Refactor
  - Improved robustness to accept both object- and ID-based inputs across notification flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->