### PR TITLE
[CD] Deploy when release is cut from master

### DIFF
--- a/.github/workflows/deploy-from-release.yml
+++ b/.github/workflows/deploy-from-release.yml
@@ -1,0 +1,28 @@
+name: Deploy Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+    if: ${{ github.event.release.target_commitish == 'master' }}
+
+    steps:
+      - name: Set up SSH
+        uses: webfactory/ssh-agent@v0.8.1
+        with:
+          ssh-private-key: ${{ secrets.PRODVM_SSH_PRIVATE_KEY }}
+
+      - name: Trust remote host key
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan -H "${{ vars.VM_HOST }}" >> ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+
+      - name: Run deployment script on remote server
+        run: |
+          ssh -o BatchMode=yes -o ConnectTimeout=30 "${{ vars.VM_USER }}@${{ vars.VM_HOST }}" \
+          "cd '${{ vars.CIRCUITVERSE_WORKDIR }}' && RELEASE_COMMIT='${{ github.event.release.target_commitish }}' bash update-with-release.sh"


### PR DESCRIPTION
Deploys the commit on a release cut from master. Pretty basic, the script pulls the commit and applies it like we do manually today.

The script is on the server. secrets and vars are set.

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated deployment that runs when a release is published, streamlining delivery to production.
  * Ensures deployments align with the released commit, improving consistency and reliability for users.
  * Uses a secure remote execution process to standardize and reduce manual deployment steps, helping updates reach users faster.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->