### PR TITLE
fix: update Brewfile to use node@22 instead of deprecated node@16 and…

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
-tap "homebrew/core"
-tap "homebrew/bundle"
-tap "homebrew/services"
-tap "homebrew/cask"
-brew "node@16"
+brew "node@22"
 brew "redis"
 brew "imagemagick"
 brew "yarn"


### PR DESCRIPTION
… removed homebrew/core , homebrew/bundle, homebrew/services, homebrew/cask

Fixes #6292


#### Describe the changes you have made in this PR -updated Brewfile to use node@22 instead of deprecated node@16 and removed homebrew/core , homebrew/bundle, homebrew/services, homebrew/cask


## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Node.js runtime from version 16 to version 22
  * Optimized development environment configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->