### PR TITLE
Fix Redis timeout by updating Sidekiq and cache store settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,5 @@ NEW_RELIC_API_KEY=<new-relic-license-key-here>
 SENTRY_DSN=''
 SMTP_ADDRESS=<smtp-address>
 SMTP_PORT=<smtp-port>
+REDIS_URL=redis://localhost:6379/0
+REDIS_TIMEOUT=15

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -8,3 +8,6 @@ production:
   adapter: redis
   url: redis://localhost:6379/1
   channel_prefix: logix_production
+  connect_timeout: 15
+  read_timeout: 15
+  write_timeout: 15

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,7 +71,13 @@ Rails.application.configure do
   config.active_support.report_deprecations = false
 
   # Redis cache store (preserved from Rails 7)
-  config.cache_store = :redis_cache_store
+  config.cache_store = :redis_cache_store, {
+  url: ENV.fetch("REDIS_URL", "redis://localhost:6379/0"),
+  connect_timeout: 15,
+  read_timeout: 15,
+  write_timeout: 15,
+  reconnect_attempts: 3
+}
 
   # Sidekiq for background jobs (preserved from Rails 7)
   config.active_job.queue_adapter = :sidekiq

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,5 +1,6 @@
 ---
 :concurrency: 3
+:timeout: 15
 :queues:
   - default
   - mailers


### PR DESCRIPTION
Fixes #6094 

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -

Fixed the Redis ReadTimeout issue by increasing Sidekiq and Redis timeouts, adding reconnect attempts, and ensuring the correct Redis URL/database is used. These changes make Sidekiq wait longer, retry when needed, and communicate more reliably with Redis, preventing the timeout errors we were seeing.




## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.




Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured timeout settings for background job processing and Redis caching services to improve system reliability and prevent connection issues during peak operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->