### PR TITLE
Fix N+1 query issue in ProjectsController#index by eager loading asso…

### DIFF
--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -204,38 +204,60 @@ class Api::V1::ProjectsController < Api::V1::BaseController
     end
 
     def load_index_projects
-      @projects = if current_user.nil?
+      base_projects = if current_user.nil?
         Project.open
       else
         Project.open.or(Project.by(current_user.id))
       end
+
+      @projects = base_projects.includes(
+        :author,
+        :commontator_thread,
+        :circuit_preview_attachment,
+        :tags
+      )
     end
 
     def load_user_projects
-      # if user is not authenticated or authenticated as some other user
-      # return only user's public projects else all
-      @projects = if current_user.nil? || current_user.id != params[:id].to_i
+      base_projects = if current_user.nil? || current_user.id != params[:id].to_i
         Project.open.by(params[:id])
       else
         current_user.projects
       end
+
+      @projects = base_projects.includes(
+        :author,
+        :commontator_thread,
+        :circuit_preview_attachment,
+        :tags
+      )
     end
 
     def load_user_favourites
-      @projects = Project.joins(:stars)
-                         .where(stars: { user_id: params[:id].to_i })
+      base_projects = Project.joins(:stars)
+                             .where(stars: { user_id: params[:id].to_i })
 
-      # if user is not authenticated or authenticated as some other user
-      # return only user's public favourites else all
-      @projects = if current_user.nil? || current_user.id != params[:id].to_i
-        @projects.open
+      base_projects = if current_user.nil? || current_user.id != params[:id].to_i
+        base_projects.open
       else
-        @projects
+        base_projects
       end
+
+      @projects = base_projects.includes(
+        :author,
+        :commontator_thread,
+        :circuit_preview_attachment,
+        :tags
+      )
     end
 
     def load_featured_circuits
-      @projects = Project.joins(:featured_circuit).all
+      @projects = Project.joins(:featured_circuit).includes(
+        :author,
+        :commontator_thread,
+        :circuit_preview_attachment,
+        :tags
+      )
     end
 
     def search_projects


### PR DESCRIPTION
…ciations

Fixes #6303 



#### Describe the changes you have made in this PR -
fixed the N+1 query in ProjectsController#index by eager loading associated records (author, tags, commontator_thread, circuit_preview_attachment) so that rendering projects no longer triggers extra queries for each project.










<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized backend project data loading to reduce API response times and improve performance across project list endpoints, user projects, favorites, and featured projects views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->