### PR TITLE
Fix CookieOverflow issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem "rails", "~> 8.0.0"
 gem "puma", "~> 6.4"
 # Use SCSS for stylesheets
 gem "sass-rails", "~> 6.0"
+gem 'redis-session-store'
 gem "terser"
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby
@@ -159,7 +160,7 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem "rails-erd"
   gem "rubocop"
-  
+
   gem "bundler-audit", "~> 0.9.1"
   gem 'database_consistency', require: false
   gem "lookbook", ">= 2.2.0"

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,6 @@
+Rails.application.config.session_store :redis_session_store,
+  key: '_circuitverse_session',
+  redis: {
+    url: ENV.fetch("REDIS_URL") { "redis://localhost:6379/" },
+    expire_after: 90.minutes
+  }


### PR DESCRIPTION
Fixes #6102 

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -
CircuitVerse was getting CookieOverflow errors because session data exceeded the browser's limiy so we switched from storing sessions in cookies (CookieStore) to storing them in Redis (RedisSessionStore) by adding the redis-session-store gem and creating config/initializers/session_store.rb .
### Screenshots  (If any) -

<img width="811" height="216" alt="image" src="https://github.com/user-attachments/assets/e7ca14b5-11c4-41a3-ba38-4a86f9477c0c" />


<!-- Do not add code diff here -->


## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.




Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Session storage now uses Redis backend
  * Sessions automatically expire after 90 minutes of inactivity
  * Redis connection URL is configurable via environment variable with sensible defaults

<!-- end of auto-generated comment: release notes by coderabbit.ai -->