### PR TITLE
fix: resolve TypeError in ForkNotification params access

### DIFF
--- a/app/notifications/fork_notification.rb
+++ b/app/notifications/fork_notification.rb
@@ -4,9 +4,13 @@ class ForkNotification < Noticed::Base
   deliver_by :database, association: :noticed_notifications
 
   def message
-    user = params[:user]
-    project = params[:project]
-    t("users.notifications.fork_notification", user: user&.name, project: project&.name)
+    user = record.params.with_indifferent_access[:user]
+    project = record.params.with_indifferent_access[:project]
+    t(
+      "users.notifications.fork_notification",
+      user: user&.name,
+      project: project&.name
+    )
   end
 
   def icon


### PR DESCRIPTION
Fixes #6310 

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -
Fixed TypeError in ForkNotification by changing params[:user] to record.params.with_indifferent_access[:user]. The notification was trying to access params incorrectly, causing crashes on the notifications page. Now it properly retrieves user and project data from the notification record.


## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.


cc-@tachons 

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of notification parameters to maintain consistent functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->