### PR TITLE
fix: Prevent duplicate user creation during OAuth authentication

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,23 +70,23 @@ class User < ApplicationRecord
     user = User.where(email: data["email"]).first
     name = data["name"] || data["nickname"]
     # Uncomment the section below if you want users to be created if they don't exist
-    user ||= User.create(name: name,
-                         email: data["email"],
-                         password: Devise.friendly_token[0, 20],
-                         provider: access_token.provider,
-                         confirmed_at: Time.zone.now,
-                         uid: access_token.uid)
+    user ||= User.find_or_create_by(email: data["email"]) do |u|
+      u.name = name
+      u.password = Devise.friendly_token[0, 20]
+      u.provider = access_token.provider
+      u.confirmed_at = Time.zone.now
+      u.uid = access_token.uid
+    end
     user
   end
 
   def self.from_oauth(oauth_user, provider)
-    User.create(
-      name: oauth_user["name"],
-      email: oauth_user["email"],
-      password: Devise.friendly_token[0, 20],
-      provider: provider,
-      uid: oauth_user["id"] || oauth_user["sub"]
-    )
+    User.find_or_create_by(email: oauth_user["email"]) do |user|
+      user.name = oauth_user["name"]
+      user.password = Devise.friendly_token[0, 20]
+      user.provider = provider
+      user.uid = oauth_user["id"] || oauth_user["sub"]
+    end
   end
 
   def flipper_id


### PR DESCRIPTION
Fixes #6306 

#### Describe the changes you have made in this PR -
Before, both `User.from_omniauth` and `User.from_oauth` methods used `User.create`, which attempted inserting new record everytime, thereby crashing.
Replaced `User.create` with `User.find_or_create_by` in both oauth methods. This makes existing users retrieved instead of recreating also making sure its in single atomic db transaction

### Screenshots of the UI changes (If any) -
Tested this way: 
<img width="920" height="540" alt="image" src="https://github.com/user-attachments/assets/69948042-f3c6-49bf-b2fa-88846ff057d3" />

<img width="920" height="540" alt="image" src="https://github.com/user-attachments/assets/3eb9baca-6ac2-4a59-b826-38dc91838a18" />


## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for duplicate account creation attempts during signup with appropriate HTTP status responses
  * Enhanced validation error reporting in authentication flows for clearer feedback
  * Refined user account creation logic for OAuth authentication to ensure consistent data handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->