### PR TITLE
Fix ActionDispatch::RemoteIp::IpSpoofAttackError by configuring trusted proxy ranges

### DIFF
--- a/app/middleware/proxy_ip_sanitizer.rb
+++ b/app/middleware/proxy_ip_sanitizer.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+# Sanitizes incoming proxy-related IP headers and normalizes the client IP
+# when requests are routed through Cloudflare (or other trusted proxies).
+#
+# Why this exists
+# - Some upstreams forward a non-standard, spoofable `Client-IP` header which
+#   can conflict with the standard `X-Forwarded-For` chain and trigger
+#   ActionDispatch::RemoteIp::IpSpoofAttackError.
+# - When behind Cloudflare, the canonical client IP is provided via the
+#   `CF-Connecting-IP` header, but only when the request actually came through
+#   Cloudflare's edge network.
+#
+# What it does
+# - Always drop `HTTP_CLIENT_IP` from the Rack env (it's non-standard and
+#   frequently spoofed), preventing false-positive spoofing errors.
+# - If CF_PROXY_ENABLED is set and the immediate peer (REMOTE_ADDR) is a
+#   Cloudflare IP, replace REMOTE_ADDR and action_dispatch.remote_ip with
+#   CF-Connecting-IP. This ensures Rails resolves the correct client IP.
+#
+# This middleware is inserted before ActionDispatch::RemoteIp in the stack.
+
+require "ipaddr"
+
+class ProxyIpSanitizer
+  CLOUDFLARE_CIDRS = %w[
+    173.245.48.0/20
+    103.21.244.0/22
+    103.22.200.0/22
+    103.31.4.0/22
+    141.101.64.0/18
+    108.162.192.0/18
+    190.93.240.0/20
+    188.114.96.0/20
+    197.234.240.0/22
+    198.41.128.0/17
+    162.158.0.0/15
+    104.16.0.0/13
+    104.24.0.0/14
+    172.64.0.0/13
+    131.0.72.0/22
+    2400:cb00::/32
+    2606:4700::/32
+    2803:f800::/32
+    2405:b500::/32
+    2405:8100::/32
+    2a06:98c0::/29
+    2c0f:f248::/32
+  ].map { |cidr| IPAddr.new(cidr) }.freeze
+
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    # 1) Drop the non-standard, spoofable Client-IP header to avoid conflicts
+    env.delete("HTTP_CLIENT_IP")
+
+    # 2) If behind Cloudflare (opt-in via env flag), and the immediate peer
+    #    is a Cloudflare edge, trust CF-Connecting-IP as the true client IP.
+    if truthy_env?(ENV["CF_PROXY_ENABLED"]) && cloudflare_peer?(env["REMOTE_ADDR"])
+      cf_ip = env["HTTP_CF_CONNECTING_IP"]
+      if valid_ip?(cf_ip)
+        env["action_dispatch.remote_ip"] = cf_ip
+        env["REMOTE_ADDR"] = cf_ip
+      end
+    end
+
+    @app.call(env)
+  end
+
+  private
+
+  def cloudflare_peer?(addr)
+    ip = ipaddr_from(addr)
+    return false unless ip
+    CLOUDFLARE_CIDRS.any? { |range| range.include?(ip) }
+  end
+
+  def ipaddr_from(addr)
+    IPAddr.new(addr)
+  rescue ArgumentError, IPAddr::InvalidAddressError
+    nil
+  end
+
+  def valid_ip?(addr)
+    !!ipaddr_from(addr)
+  end
+
+  def truthy_env?(val)
+    return false if val.nil?
+    %w[1 true yes on].include?(val.to_s.strip.downcase)
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,39 +23,42 @@ module Logix
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
-   config.action_mailer.preview_paths << "#{Rails.root}/lib/mailer_previews"
+    config.action_mailer.preview_paths << "#{Rails.root}/lib/mailer_previews"
 
-        # config/application.rb
-        config.view_component.preview_paths = "#{Rails.root}/spec/components/previews"
-        config.view_component.default_preview_layout = "lookbook_preview"
+    # ViewComponent previews
+    config.view_component.preview_paths = "#{Rails.root}/spec/components/previews"
+    config.view_component.default_preview_layout = "lookbook_preview"
 
-        config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**", "*.{rb,yml}")]
-        config.i18n.available_locales = [:ar, :bn, :de, :en, :es, :fr, :hi, :ja, :ml, :mr, :ne]
-        config.i18n.default_locale = :en
-        config.i18n.fallbacks = true
+    # I18n
+    config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**", "*.{rb,yml}")]
+    config.i18n.available_locales = [:ar, :bn, :de, :en, :es, :fr, :hi, :ja, :ml, :mr, :ne]
+    config.i18n.default_locale = :en
+    config.i18n.fallbacks = true
 
-        # configuring middleware
-        config.middleware.use Rack::Attack
-        # configuring middleware
-           config.middleware.use Rack::Attack
+    # Middleware
+    # Ensure custom middleware is loaded
+    require_relative "../app/middleware/proxy_ip_sanitizer"
+    # Insert early to normalize IP headers before RemoteIp runs
+    config.middleware.insert_before ActionDispatch::RemoteIp, ProxyIpSanitizer
+    # Rack::Attack (load once)
+    config.middleware.use Rack::Attack
 
-           # configuring forum
-           overrides = "#{Rails.root}/app/overrides"
-           Rails.autoloaders.main.ignore(overrides)
+    # Forum overrides
+    overrides = "#{Rails.root}/app/overrides"
+    Rails.autoloaders.main.ignore(overrides)
+    config.to_prepare do
+      Dir.glob("#{overrides}/**/*_override.rb").each do |override|
+        load override
+      end
+    end
 
-           config.to_prepare do
-             Dir.glob("#{overrides}/**/*_override.rb").each do |override|
-               load override
-             end
-           end
-
-           # Site config
-           config.site_url = "https://circuitverse.org/"
-           config.site_name = "CircuitVerse"
-           config.site_category = "Digital Logic Circuits"
-           config.site_download_url = "https://circuitverse.org/simulator"
-           config.site_image = "https://circuitverse.org/img/circuitverse2.svg"
-           config.site_description = "Explore Digital circuits online with CircuitVerse. With our easy to use simulator interface, you will be building circuits in no time."
-           config.slack_url = "https://circuitverse.org/slack"
+    # Site config
+    config.site_url = "https://circuitverse.org/"
+    config.site_name = "CircuitVerse"
+    config.site_category = "Digital Logic Circuits"
+    config.site_download_url = "https://circuitverse.org/simulator"
+    config.site_image = "https://circuitverse.org/img/circuitverse2.svg"
+    config.site_description = "Explore Digital circuits online with CircuitVerse. With our easy to use simulator interface, you will be building circuits in no time."
+    config.slack_url = "https://circuitverse.org/slack"
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,8 +40,7 @@ module Logix
     require_relative "../app/middleware/proxy_ip_sanitizer"
     # Insert early to normalize IP headers before RemoteIp runs
     config.middleware.insert_before ActionDispatch::RemoteIp, ProxyIpSanitizer
-    # Rack::Attack (load once)
-    config.middleware.use Rack::Attack
+    # Rack::Attack is added via its Railtie/initializer; avoid adding twice
 
     # Forum overrides
     overrides = "#{Rails.root}/app/overrides"

--- a/config/initializers/trusted_proxies.rb
+++ b/config/initializers/trusted_proxies.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# Configure which proxy IP ranges Rails should trust when resolving the
+# originating client IP address. This avoids false-positive
+# ActionDispatch::RemoteIp::IpSpoofAttackError when requests traverse
+# multiple legitimate proxies (CDN, load balancer, ingress, etc.).
+#
+# You can append additional ranges via TRUSTED_PROXY_CIDRS env var, e.g.:
+#   TRUSTED_PROXY_CIDRS="203.0.113.0/24, 2001:db8::/32"
+#
+# If you run behind Cloudflare, set CF_PROXY_ENABLED=1 in the environment so
+# Cloudflare CIDRs are added here and the ProxyIpSanitizer middleware will
+# also normalize the client IP using CF-Connecting-IP.
+
+require "ipaddr"
+
+Rails.application.configure do
+  private_and_reserved = %w[
+    127.0.0.0/8
+    ::1
+    10.0.0.0/8
+    172.16.0.0/12
+    192.168.0.0/16
+    100.64.0.0/10
+    169.254.0.0/16
+    fc00::/7
+    fe80::/10
+  ].map { |cidr| IPAddr.new(cidr) }
+
+  cloudflare = []
+  if %w[1 true yes on].include?(ENV.fetch("CF_PROXY_ENABLED", "").to_s.downcase)
+    cloudflare = %w[
+      173.245.48.0/20
+      103.21.244.0/22
+      103.22.200.0/22
+      103.31.4.0/22
+      141.101.64.0/18
+      108.162.192.0/18
+      190.93.240.0/20
+      188.114.96.0/20
+      197.234.240.0/22
+      198.41.128.0/17
+      162.158.0.0/15
+      104.16.0.0/13
+      104.24.0.0/14
+      172.64.0.0/13
+      131.0.72.0/22
+      2400:cb00::/32
+      2606:4700::/32
+      2803:f800::/32
+      2405:b500::/32
+      2405:8100::/32
+      2a06:98c0::/29
+      2c0f:f248::/32
+    ].map { |cidr| IPAddr.new(cidr) }
+  end
+
+  extra = ENV.fetch("TRUSTED_PROXY_CIDRS", "").split(",").map(&:strip).reject(&:empty?).map { |cidr| IPAddr.new(cidr) }
+
+  Rails.logger.info("[trusted_proxies] Configured #{(private_and_reserved + cloudflare + extra).size} trusted proxy ranges") if Rails.logger
+
+  config.action_dispatch.trusted_proxies = private_and_reserved + cloudflare + extra
+
+  # Keep Rails' spoofing check enabled. We rely on ProxyIpSanitizer to drop
+  # the untrusted Client-IP header to avoid false positives.
+  config.action_dispatch.ip_spoofing_check = true
+end

--- a/config/initializers/trusted_proxies.rb
+++ b/config/initializers/trusted_proxies.rb
@@ -27,35 +27,18 @@ Rails.application.configure do
     fe80::/10
   ].map { |cidr| IPAddr.new(cidr) }
 
-  cloudflare = []
-  if %w[1 true yes on].include?(ENV.fetch("CF_PROXY_ENABLED", "").to_s.downcase)
-    cloudflare = %w[
-      173.245.48.0/20
-      103.21.244.0/22
-      103.22.200.0/22
-      103.31.4.0/22
-      141.101.64.0/18
-      108.162.192.0/18
-      190.93.240.0/20
-      188.114.96.0/20
-      197.234.240.0/22
-      198.41.128.0/17
-      162.158.0.0/15
-      104.16.0.0/13
-      104.24.0.0/14
-      172.64.0.0/13
-      131.0.72.0/22
-      2400:cb00::/32
-      2606:4700::/32
-      2803:f800::/32
-      2405:b500::/32
-      2405:8100::/32
-      2a06:98c0::/29
-      2c0f:f248::/32
-    ].map { |cidr| IPAddr.new(cidr) }
+  cloudflare = if %w[1 true yes on].include?(ENV.fetch("CF_PROXY_ENABLED", "").to_s.downcase)
+    ProxyIpSanitizer::CLOUDFLARE_CIDRS
+  else
+    []
   end
 
-  extra = ENV.fetch("TRUSTED_PROXY_CIDRS", "").split(",").map(&:strip).reject(&:empty?).map { |cidr| IPAddr.new(cidr) }
+  extra = ENV.fetch("TRUSTED_PROXY_CIDRS", "").split(",").map(&:strip).reject(&:empty?).filter_map do |cidr|
+    IPAddr.new(cidr)
+  rescue IPAddr::InvalidAddressError, ArgumentError => e
+    Rails.logger&.warn("[trusted_proxies] Skipping invalid CIDR '#{cidr}': #{e.message}")
+    nil
+  end
 
   Rails.logger.info("[trusted_proxies] Configured #{(private_and_reserved + cloudflare + extra).size} trusted proxy ranges") if Rails.logger
 

--- a/spec/initializers/trusted_proxies_spec.rb
+++ b/spec/initializers/trusted_proxies_spec.rb
@@ -1,0 +1,259 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe "trusted_proxies initializer" do
+  let(:initializer_path) { Rails.root.join("config/initializers/trusted_proxies.rb") }
+
+  before do
+    # Store original config values
+    @original_trusted_proxies = Rails.configuration.action_dispatch.trusted_proxies
+    @original_ip_spoofing_check = Rails.configuration.action_dispatch.ip_spoofing_check
+  end
+
+  after do
+    # Restore original config values
+    Rails.configuration.action_dispatch.trusted_proxies = @original_trusted_proxies
+    Rails.configuration.action_dispatch.ip_spoofing_check = @original_ip_spoofing_check
+  end
+
+  def reload_initializer
+    load initializer_path
+  end
+
+  describe "trusted proxy configuration" do
+    context "with default settings (no Cloudflare, no extra CIDRs)" do
+      before do
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with("CF_PROXY_ENABLED", "").and_return("")
+        allow(ENV).to receive(:fetch).with("TRUSTED_PROXY_CIDRS", "").and_return("")
+        reload_initializer
+      end
+
+      # rubocop:disable RSpec/MultipleExpectations
+      it "includes private and reserved IP ranges" do
+        trusted_proxies = Rails.configuration.action_dispatch.trusted_proxies
+
+        # Check for localhost
+        expect(trusted_proxies.any? { |range| range.include?(IPAddr.new("127.0.0.1")) }).to be true
+        expect(trusted_proxies.any? { |range| range.include?(IPAddr.new("::1")) }).to be true
+
+        # Check for private networks
+        expect(trusted_proxies.any? { |range| range.include?(IPAddr.new("10.0.0.1")) }).to be true
+        expect(trusted_proxies.any? { |range| range.include?(IPAddr.new("172.16.0.1")) }).to be true
+        expect(trusted_proxies.any? { |range| range.include?(IPAddr.new("192.168.1.1")) }).to be true
+
+        # Check for CGNAT
+        expect(trusted_proxies.any? { |range| range.include?(IPAddr.new("100.64.0.1")) }).to be true
+
+        # Check for link-local
+        expect(trusted_proxies.any? { |range| range.include?(IPAddr.new("169.254.0.1")) }).to be true
+      end
+      # rubocop:enable RSpec/MultipleExpectations
+
+      it "does not include Cloudflare CIDRs" do
+        trusted_proxies = Rails.configuration.action_dispatch.trusted_proxies
+        cloudflare_ip = IPAddr.new("162.158.86.173")
+
+        expect(trusted_proxies.any? { |range| range.include?(cloudflare_ip) }).to be false
+      end
+
+      it "has at least 8 trusted proxy ranges (private/reserved only)" do
+        trusted_proxies = Rails.configuration.action_dispatch.trusted_proxies
+        expect(trusted_proxies.size).to be >= 8
+      end
+    end
+
+    context "when CF_PROXY_ENABLED=1" do
+      before do
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with("CF_PROXY_ENABLED", "").and_return("1")
+        allow(ENV).to receive(:fetch).with("TRUSTED_PROXY_CIDRS", "").and_return("")
+        reload_initializer
+      end
+
+      it "includes Cloudflare CIDRs" do
+        trusted_proxies = Rails.configuration.action_dispatch.trusted_proxies
+
+        # Check for known Cloudflare IPs
+        expect(trusted_proxies.any? { |range| range.include?(IPAddr.new("162.158.86.173")) }).to be true
+        expect(trusted_proxies.any? { |range| range.include?(IPAddr.new("104.16.0.1")) }).to be true
+        expect(trusted_proxies.any? { |range| range.include?(IPAddr.new("172.64.0.1")) }).to be true
+
+        # Check for Cloudflare IPv6
+        expect(trusted_proxies.any? { |range| range.include?(IPAddr.new("2606:4700::1")) }).to be true
+      end
+
+      it "has more ranges than just private/reserved" do
+        trusted_proxies = Rails.configuration.action_dispatch.trusted_proxies
+        # Private/reserved (8) + Cloudflare CIDRs (17) = 25
+        expect(trusted_proxies.size).to be > 8
+      end
+    end
+
+    context "when CF_PROXY_ENABLED=true" do
+      before do
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with("CF_PROXY_ENABLED", "").and_return("true")
+        allow(ENV).to receive(:fetch).with("TRUSTED_PROXY_CIDRS", "").and_return("")
+        reload_initializer
+      end
+
+      it "includes Cloudflare CIDRs" do
+        trusted_proxies = Rails.configuration.action_dispatch.trusted_proxies
+        expect(trusted_proxies.any? { |range| range.include?(IPAddr.new("162.158.86.173")) }).to be true
+      end
+    end
+
+    context "when CF_PROXY_ENABLED=yes" do
+      before do
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with("CF_PROXY_ENABLED", "").and_return("yes")
+        allow(ENV).to receive(:fetch).with("TRUSTED_PROXY_CIDRS", "").and_return("")
+        reload_initializer
+      end
+
+      it "includes Cloudflare CIDRs" do
+        trusted_proxies = Rails.configuration.action_dispatch.trusted_proxies
+        expect(trusted_proxies.any? { |range| range.include?(IPAddr.new("162.158.86.173")) }).to be true
+      end
+    end
+
+    context "when CF_PROXY_ENABLED=on" do
+      before do
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with("CF_PROXY_ENABLED", "").and_return("on")
+        allow(ENV).to receive(:fetch).with("TRUSTED_PROXY_CIDRS", "").and_return("")
+        reload_initializer
+      end
+
+      it "includes Cloudflare CIDRs" do
+        trusted_proxies = Rails.configuration.action_dispatch.trusted_proxies
+        expect(trusted_proxies.any? { |range| range.include?(IPAddr.new("162.158.86.173")) }).to be true
+      end
+    end
+
+    context "when CF_PROXY_ENABLED=0" do
+      before do
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with("CF_PROXY_ENABLED", "").and_return("0")
+        allow(ENV).to receive(:fetch).with("TRUSTED_PROXY_CIDRS", "").and_return("")
+        reload_initializer
+      end
+
+      it "does not include Cloudflare CIDRs" do
+        trusted_proxies = Rails.configuration.action_dispatch.trusted_proxies
+        cloudflare_ip = IPAddr.new("162.158.86.173")
+
+        expect(trusted_proxies.any? { |range| range.include?(cloudflare_ip) }).to be false
+      end
+    end
+
+    context "when TRUSTED_PROXY_CIDRS contains valid CIDRs" do
+      before do
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with("CF_PROXY_ENABLED", "").and_return("")
+        allow(ENV).to receive(:fetch).with("TRUSTED_PROXY_CIDRS", "").and_return("203.0.113.0/24, 2001:db8::/32")
+        reload_initializer
+      end
+
+      it "includes the extra CIDRs" do
+        trusted_proxies = Rails.configuration.action_dispatch.trusted_proxies
+
+        expect(trusted_proxies.any? { |range| range.include?(IPAddr.new("203.0.113.1")) }).to be true
+        expect(trusted_proxies.any? { |range| range.include?(IPAddr.new("203.0.113.255")) }).to be true
+        expect(trusted_proxies.any? { |range| range.include?(IPAddr.new("2001:db8::1")) }).to be true
+      end
+    end
+
+    context "when TRUSTED_PROXY_CIDRS contains invalid CIDRs" do
+      before do
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with("CF_PROXY_ENABLED", "").and_return("")
+        allow(ENV).to receive(:fetch).with("TRUSTED_PROXY_CIDRS", "")
+                                     .and_return("203.0.113.0/24, invalid-cidr, 198.51.100.0/24")
+        allow(Rails.logger).to receive(:warn)
+        reload_initializer
+      end
+
+      it "includes valid CIDRs and skips invalid ones" do
+        trusted_proxies = Rails.configuration.action_dispatch.trusted_proxies
+
+        # Valid CIDRs should be included
+        expect(trusted_proxies.any? { |range| range.include?(IPAddr.new("203.0.113.1")) }).to be true
+        expect(trusted_proxies.any? { |range| range.include?(IPAddr.new("198.51.100.1")) }).to be true
+      end
+
+      it "logs a warning for invalid CIDRs" do
+        expect(Rails.logger).to have_received(:warn).with(/Skipping invalid CIDR 'invalid-cidr'/)
+      end
+    end
+
+    context "when TRUSTED_PROXY_CIDRS has empty entries" do
+      before do
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with("CF_PROXY_ENABLED", "").and_return("")
+        allow(ENV).to receive(:fetch).with("TRUSTED_PROXY_CIDRS", "").and_return("203.0.113.0/24, , 198.51.100.0/24")
+        reload_initializer
+      end
+
+      it "skips empty entries and includes valid ones" do
+        trusted_proxies = Rails.configuration.action_dispatch.trusted_proxies
+
+        expect(trusted_proxies.any? { |range| range.include?(IPAddr.new("203.0.113.1")) }).to be true
+        expect(trusted_proxies.any? { |range| range.include?(IPAddr.new("198.51.100.1")) }).to be true
+      end
+    end
+
+    context "with CF_PROXY_ENABLED and TRUSTED_PROXY_CIDRS both set" do
+      before do
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with("CF_PROXY_ENABLED", "").and_return("1")
+        allow(ENV).to receive(:fetch).with("TRUSTED_PROXY_CIDRS", "").and_return("203.0.113.0/24")
+        reload_initializer
+      end
+
+      it "includes private, Cloudflare, and extra CIDRs" do
+        trusted_proxies = Rails.configuration.action_dispatch.trusted_proxies
+
+        # Private
+        expect(trusted_proxies.any? { |range| range.include?(IPAddr.new("10.0.0.1")) }).to be true
+
+        # Cloudflare
+        expect(trusted_proxies.any? { |range| range.include?(IPAddr.new("162.158.86.173")) }).to be true
+
+        # Extra
+        expect(trusted_proxies.any? { |range| range.include?(IPAddr.new("203.0.113.1")) }).to be true
+      end
+    end
+  end
+
+  describe "ip_spoofing_check configuration" do
+    before do
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with("CF_PROXY_ENABLED", "").and_return("")
+      allow(ENV).to receive(:fetch).with("TRUSTED_PROXY_CIDRS", "").and_return("")
+      reload_initializer
+    end
+
+    it "keeps ip_spoofing_check enabled" do
+      expect(Rails.configuration.action_dispatch.ip_spoofing_check).to be true
+    end
+  end
+
+  describe "logging" do
+    before do
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with("CF_PROXY_ENABLED", "").and_return("1")
+      allow(ENV).to receive(:fetch).with("TRUSTED_PROXY_CIDRS", "").and_return("")
+      allow(Rails.logger).to receive(:info)
+    end
+
+    it "logs the number of configured trusted proxy ranges" do
+      reload_initializer
+      expect(Rails.logger).to have_received(:info).with(/Configured \d+ trusted proxy ranges/)
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/middleware/proxy_ip_sanitizer_spec.rb
+++ b/spec/middleware/proxy_ip_sanitizer_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe ProxyIpSanitizer do
 
     context "when CF_PROXY_ENABLED is set" do
       before do
-        allow(ENV).to receive(:[]).and_call_original
-        allow(ENV).to receive(:[]).with("CF_PROXY_ENABLED").and_return(cf_proxy_value)
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with("CF_PROXY_ENABLED", nil).and_return(cf_proxy_value)
       end
 
       context "with truthy value (1)" do
@@ -184,8 +184,8 @@ RSpec.describe ProxyIpSanitizer do
 
     context "when CF_PROXY_ENABLED is not set" do
       before do
-        allow(ENV).to receive(:[]).and_call_original
-        allow(ENV).to receive(:[]).with("CF_PROXY_ENABLED").and_return(nil)
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with("CF_PROXY_ENABLED", nil).and_return(nil)
       end
 
       it "does not replace REMOTE_ADDR even when peer is Cloudflare" do

--- a/spec/middleware/proxy_ip_sanitizer_spec.rb
+++ b/spec/middleware/proxy_ip_sanitizer_spec.rb
@@ -1,0 +1,346 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ProxyIpSanitizer do
+  let(:app) { ->(env) { [200, env, "app"] } }
+  let(:middleware) { described_class.new(app) }
+
+  describe "#call" do
+    context "when HTTP_CLIENT_IP is present" do
+      it "removes HTTP_CLIENT_IP header" do
+        env = {
+          "HTTP_CLIENT_IP" => "233.43.24.6",
+          "REMOTE_ADDR" => "10.0.0.1"
+        }
+
+        middleware.call(env)
+
+        expect(env).not_to have_key("HTTP_CLIENT_IP")
+      end
+
+      it "prevents IP spoofing attack error by dropping conflicting Client-IP" do
+        env = {
+          "HTTP_CLIENT_IP" => "233.43.24.6",
+          "HTTP_X_FORWARDED_FOR" => "146.12.125.53,194.195.87.55,162.158.86.173",
+          "REMOTE_ADDR" => "162.158.86.173"
+        }
+
+        middleware.call(env)
+
+        expect(env).not_to have_key("HTTP_CLIENT_IP")
+      end
+    end
+
+    context "when CF_PROXY_ENABLED is set" do
+      before do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with("CF_PROXY_ENABLED").and_return(cf_proxy_value)
+      end
+
+      context "with truthy value (1)" do
+        let(:cf_proxy_value) { "1" }
+
+        it "replaces REMOTE_ADDR with CF-Connecting-IP when peer is Cloudflare" do
+          env = {
+            "REMOTE_ADDR" => "162.158.86.173", # Cloudflare IP
+            "HTTP_CF_CONNECTING_IP" => "146.12.125.53"
+          }
+
+          middleware.call(env)
+
+          expect(env["REMOTE_ADDR"]).to eq("146.12.125.53")
+          expect(env["action_dispatch.remote_ip"]).to eq("146.12.125.53")
+        end
+
+        it "replaces REMOTE_ADDR with CF-Connecting-IP for IPv6 Cloudflare IP" do
+          env = {
+            "REMOTE_ADDR" => "2606:4700:10::6816:123", # Cloudflare IPv6
+            "HTTP_CF_CONNECTING_IP" => "2001:db8::1"
+          }
+
+          middleware.call(env)
+
+          expect(env["REMOTE_ADDR"]).to eq("2001:db8::1")
+          expect(env["action_dispatch.remote_ip"]).to eq("2001:db8::1")
+        end
+
+        it "does not replace REMOTE_ADDR when peer is not Cloudflare IP" do
+          env = {
+            "REMOTE_ADDR" => "203.0.113.1", # Non-Cloudflare IP
+            "HTTP_CF_CONNECTING_IP" => "146.12.125.53"
+          }
+
+          middleware.call(env)
+
+          expect(env["REMOTE_ADDR"]).to eq("203.0.113.1")
+          expect(env["action_dispatch.remote_ip"]).to be_nil
+        end
+
+        it "does not replace REMOTE_ADDR when CF-Connecting-IP is invalid" do
+          env = {
+            "REMOTE_ADDR" => "162.158.86.173", # Cloudflare IP
+            "HTTP_CF_CONNECTING_IP" => "not-an-ip"
+          }
+
+          middleware.call(env)
+
+          expect(env["REMOTE_ADDR"]).to eq("162.158.86.173")
+          expect(env["action_dispatch.remote_ip"]).to be_nil
+        end
+
+        it "does not replace REMOTE_ADDR when CF-Connecting-IP is missing" do
+          env = {
+            "REMOTE_ADDR" => "162.158.86.173" # Cloudflare IP
+          }
+
+          middleware.call(env)
+
+          expect(env["REMOTE_ADDR"]).to eq("162.158.86.173")
+          expect(env["action_dispatch.remote_ip"]).to be_nil
+        end
+      end
+
+      context "with truthy value (true)" do
+        let(:cf_proxy_value) { "true" }
+
+        it "replaces REMOTE_ADDR with CF-Connecting-IP when peer is Cloudflare" do
+          env = {
+            "REMOTE_ADDR" => "104.16.0.1", # Cloudflare IP
+            "HTTP_CF_CONNECTING_IP" => "192.0.2.1"
+          }
+
+          middleware.call(env)
+
+          expect(env["REMOTE_ADDR"]).to eq("192.0.2.1")
+          expect(env["action_dispatch.remote_ip"]).to eq("192.0.2.1")
+        end
+      end
+
+      context "with truthy value (yes)" do
+        let(:cf_proxy_value) { "yes" }
+
+        it "replaces REMOTE_ADDR with CF-Connecting-IP when peer is Cloudflare" do
+          env = {
+            "REMOTE_ADDR" => "104.24.0.1", # Cloudflare IP
+            "HTTP_CF_CONNECTING_IP" => "198.51.100.1"
+          }
+
+          middleware.call(env)
+
+          expect(env["REMOTE_ADDR"]).to eq("198.51.100.1")
+          expect(env["action_dispatch.remote_ip"]).to eq("198.51.100.1")
+        end
+      end
+
+      context "with truthy value (on)" do
+        let(:cf_proxy_value) { "on" }
+
+        it "replaces REMOTE_ADDR with CF-Connecting-IP when peer is Cloudflare" do
+          env = {
+            "REMOTE_ADDR" => "172.64.0.1", # Cloudflare IP
+            "HTTP_CF_CONNECTING_IP" => "203.0.113.1"
+          }
+
+          middleware.call(env)
+
+          expect(env["REMOTE_ADDR"]).to eq("203.0.113.1")
+          expect(env["action_dispatch.remote_ip"]).to eq("203.0.113.1")
+        end
+      end
+
+      context "with falsy value (0)" do
+        let(:cf_proxy_value) { "0" }
+
+        it "does not replace REMOTE_ADDR even when peer is Cloudflare" do
+          env = {
+            "REMOTE_ADDR" => "162.158.86.173", # Cloudflare IP
+            "HTTP_CF_CONNECTING_IP" => "146.12.125.53"
+          }
+
+          middleware.call(env)
+
+          expect(env["REMOTE_ADDR"]).to eq("162.158.86.173")
+          expect(env["action_dispatch.remote_ip"]).to be_nil
+        end
+      end
+
+      context "with falsy value (false)" do
+        let(:cf_proxy_value) { "false" }
+
+        it "does not replace REMOTE_ADDR even when peer is Cloudflare" do
+          env = {
+            "REMOTE_ADDR" => "162.158.86.173", # Cloudflare IP
+            "HTTP_CF_CONNECTING_IP" => "146.12.125.53"
+          }
+
+          middleware.call(env)
+
+          expect(env["REMOTE_ADDR"]).to eq("162.158.86.173")
+          expect(env["action_dispatch.remote_ip"]).to be_nil
+        end
+      end
+    end
+
+    context "when CF_PROXY_ENABLED is not set" do
+      before do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with("CF_PROXY_ENABLED").and_return(nil)
+      end
+
+      it "does not replace REMOTE_ADDR even when peer is Cloudflare" do
+        env = {
+          "REMOTE_ADDR" => "162.158.86.173", # Cloudflare IP
+          "HTTP_CF_CONNECTING_IP" => "146.12.125.53"
+        }
+
+        middleware.call(env)
+
+        expect(env["REMOTE_ADDR"]).to eq("162.158.86.173")
+        expect(env["action_dispatch.remote_ip"]).to be_nil
+      end
+    end
+
+    it "calls the next middleware in the stack" do
+      env = { "REMOTE_ADDR" => "10.0.0.1" }
+      app_double = double("app") # rubocop:disable RSpec/VerifiedDoubles
+      middleware = described_class.new(app_double)
+
+      allow(app_double).to receive(:call).with(env)
+      middleware.call(env)
+      expect(app_double).to have_received(:call).with(env)
+    end
+  end
+
+  describe "#cloudflare_peer?" do
+    let(:middleware_instance) { middleware }
+
+    it "returns true for IPv4 Cloudflare CIDR" do
+      expect(middleware_instance.send(:cloudflare_peer?, "162.158.86.173")).to be true
+      expect(middleware_instance.send(:cloudflare_peer?, "104.16.0.1")).to be true
+      expect(middleware_instance.send(:cloudflare_peer?, "172.64.0.1")).to be true
+    end
+
+    it "returns true for IPv6 Cloudflare CIDR" do
+      expect(middleware_instance.send(:cloudflare_peer?, "2606:4700::1")).to be true
+      expect(middleware_instance.send(:cloudflare_peer?, "2400:cb00::1")).to be true
+    end
+
+    it "returns false for non-Cloudflare IPs" do
+      expect(middleware_instance.send(:cloudflare_peer?, "203.0.113.1")).to be false
+      expect(middleware_instance.send(:cloudflare_peer?, "192.0.2.1")).to be false
+      expect(middleware_instance.send(:cloudflare_peer?, "2001:db8::1")).to be false
+    end
+
+    it "returns false for invalid IP addresses" do
+      expect(middleware_instance.send(:cloudflare_peer?, "not-an-ip")).to be false
+      expect(middleware_instance.send(:cloudflare_peer?, "999.999.999.999")).to be false
+      expect(middleware_instance.send(:cloudflare_peer?, nil)).to be false
+    end
+  end
+
+  describe "#valid_ip?" do
+    let(:middleware_instance) { middleware }
+
+    it "returns true for valid IPv4 addresses" do
+      expect(middleware_instance.send(:valid_ip?, "192.0.2.1")).to be true
+      expect(middleware_instance.send(:valid_ip?, "10.0.0.1")).to be true
+    end
+
+    it "returns true for valid IPv6 addresses" do
+      expect(middleware_instance.send(:valid_ip?, "2001:db8::1")).to be true
+      expect(middleware_instance.send(:valid_ip?, "::1")).to be true
+    end
+
+    it "returns false for invalid IP addresses" do
+      expect(middleware_instance.send(:valid_ip?, "not-an-ip")).to be false
+      expect(middleware_instance.send(:valid_ip?, "999.999.999.999")).to be false
+      expect(middleware_instance.send(:valid_ip?, "")).to be false
+      expect(middleware_instance.send(:valid_ip?, nil)).to be false
+    end
+  end
+
+  describe "#truthy_env?" do
+    let(:middleware_instance) { middleware }
+
+    it "returns true for '1'" do
+      expect(middleware_instance.send(:truthy_env?, "1")).to be true
+    end
+
+    it "returns true for 'true'" do
+      expect(middleware_instance.send(:truthy_env?, "true")).to be true
+    end
+
+    it "returns true for 'yes'" do
+      expect(middleware_instance.send(:truthy_env?, "yes")).to be true
+    end
+
+    it "returns true for 'on'" do
+      expect(middleware_instance.send(:truthy_env?, "on")).to be true
+    end
+
+    it "returns true for uppercase variants" do
+      expect(middleware_instance.send(:truthy_env?, "TRUE")).to be true
+      expect(middleware_instance.send(:truthy_env?, "YES")).to be true
+      expect(middleware_instance.send(:truthy_env?, "ON")).to be true
+    end
+
+    it "returns true for values with whitespace" do
+      expect(middleware_instance.send(:truthy_env?, " 1 ")).to be true
+      expect(middleware_instance.send(:truthy_env?, " true ")).to be true
+    end
+
+    it "returns false for '0'" do
+      expect(middleware_instance.send(:truthy_env?, "0")).to be false
+    end
+
+    it "returns false for 'false'" do
+      expect(middleware_instance.send(:truthy_env?, "false")).to be false
+    end
+
+    it "returns false for 'no'" do
+      expect(middleware_instance.send(:truthy_env?, "no")).to be false
+    end
+
+    it "returns false for nil" do
+      expect(middleware_instance.send(:truthy_env?, nil)).to be false
+    end
+
+    it "returns false for empty string" do
+      expect(middleware_instance.send(:truthy_env?, "")).to be false
+    end
+
+    it "returns false for random strings" do
+      expect(middleware_instance.send(:truthy_env?, "random")).to be false
+    end
+  end
+
+  describe "CLOUDFLARE_CIDRS" do
+    it "is frozen" do
+      expect(described_class::CLOUDFLARE_CIDRS).to be_frozen
+    end
+
+    it "contains IPAddr objects" do
+      expect(described_class::CLOUDFLARE_CIDRS).to all(be_a(IPAddr))
+    end
+
+    it "includes known Cloudflare IPv4 ranges" do
+      ipv4_cidrs = described_class::CLOUDFLARE_CIDRS.select(&:ipv4?)
+      expect(ipv4_cidrs).not_to be_empty
+
+      # Check that specific IPs fall within the expected ranges
+      expect(ipv4_cidrs.any? { |range| range.include?(IPAddr.new("173.245.48.1")) }).to be true
+      expect(ipv4_cidrs.any? { |range| range.include?(IPAddr.new("162.158.0.1")) }).to be true
+      expect(ipv4_cidrs.any? { |range| range.include?(IPAddr.new("104.16.0.1")) }).to be true
+    end
+
+    it "includes known Cloudflare IPv6 ranges" do
+      ipv6_cidrs = described_class::CLOUDFLARE_CIDRS.select(&:ipv6?)
+      expect(ipv6_cidrs).not_to be_empty
+
+      # Check that specific IPs fall within the expected ranges
+      expect(ipv6_cidrs.any? { |range| range.include?(IPAddr.new("2400:cb00::1")) }).to be true
+      expect(ipv6_cidrs.any? { |range| range.include?(IPAddr.new("2606:4700::1")) }).to be true
+    end
+  end
+end

--- a/spec/requests/ip_spoofing_bug_fix_spec.rb
+++ b/spec/requests/ip_spoofing_bug_fix_spec.rb
@@ -55,8 +55,8 @@ RSpec.describe "IP Spoofing Bug Fix", type: :request do
   describe "Bug Fix: Cloudflare proxy IP resolution" do
     context "when CF_PROXY_ENABLED=1 and request is from Cloudflare" do
       before do
-        allow(ENV).to receive(:[]).and_call_original
-        allow(ENV).to receive(:[]).with("CF_PROXY_ENABLED").and_return("1")
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with("CF_PROXY_ENABLED", nil).and_return("1")
       end
 
       it "correctly resolves client IP from CF-Connecting-IP header" do
@@ -83,8 +83,8 @@ RSpec.describe "IP Spoofing Bug Fix", type: :request do
 
     context "when CF_PROXY_ENABLED is not set" do
       before do
-        allow(ENV).to receive(:[]).and_call_original
-        allow(ENV).to receive(:[]).with("CF_PROXY_ENABLED").and_return(nil)
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with("CF_PROXY_ENABLED", nil).and_return(nil)
       end
 
       it "does not raise IpSpoofAttackError even without CF feature enabled" do

--- a/spec/requests/ip_spoofing_bug_fix_spec.rb
+++ b/spec/requests/ip_spoofing_bug_fix_spec.rb
@@ -1,0 +1,194 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "IP Spoofing Bug Fix", type: :request do
+  before do
+    allow(Geocoder).to receive(:search).and_return([])
+  end
+
+  describe "Bug Fix: IpSpoofAttackError with conflicting HTTP_CLIENT_IP and X-Forwarded-For" do
+    context "when HTTP_CLIENT_IP conflicts with X-Forwarded-For (Issue #6101)" do
+      it "does not raise IpSpoofAttackError because Client-IP is dropped" do
+        expect do
+          get "/", headers: {
+            "HTTP_CLIENT_IP" => "233.43.24.6",
+            "HTTP_X_FORWARDED_FOR" => "146.12.125.53,194.195.87.55,162.158.86.173",
+            "REMOTE_ADDR" => "162.158.86.173"
+          }
+        end.not_to raise_error
+      end
+
+      it "resolves the client IP from X-Forwarded-For chain when Client-IP is dropped" do
+        get "/", headers: {
+          "HTTP_CLIENT_IP" => "233.43.24.6",
+          "HTTP_X_FORWARDED_FOR" => "146.12.125.53,194.195.87.55,162.158.86.173",
+          "REMOTE_ADDR" => "162.158.86.173"
+        }
+
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    context "when multiple proxy headers are present" do
+      it "does not raise IpSpoofAttackError with load balancer headers" do
+        expect do
+          get "/", headers: {
+            "HTTP_CLIENT_IP" => "192.0.2.1",
+            "HTTP_X_FORWARDED_FOR" => "198.51.100.1,203.0.113.1",
+            "REMOTE_ADDR" => "10.0.0.1"
+          }
+        end.not_to raise_error
+      end
+
+      it "handles requests without Client-IP normally" do
+        expect do
+          get "/", headers: {
+            "HTTP_X_FORWARDED_FOR" => "146.12.125.53,194.195.87.55",
+            "REMOTE_ADDR" => "172.16.0.1"
+          }
+        end.not_to raise_error
+      end
+    end
+  end
+
+  describe "Bug Fix: Cloudflare proxy IP resolution" do
+    context "when CF_PROXY_ENABLED=1 and request is from Cloudflare" do
+      before do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with("CF_PROXY_ENABLED").and_return("1")
+      end
+
+      it "correctly resolves client IP from CF-Connecting-IP header" do
+        get "/", headers: {
+          "HTTP_CF_CONNECTING_IP" => "203.0.113.1",
+          "HTTP_X_FORWARDED_FOR" => "203.0.113.1,162.158.86.173",
+          "REMOTE_ADDR" => "162.158.86.173"
+        }
+
+        expect(response).to have_http_status(:success)
+      end
+
+      it "does not raise IpSpoofAttackError with Cloudflare headers" do
+        expect do
+          get "/", headers: {
+            "HTTP_CLIENT_IP" => "233.43.24.6",
+            "HTTP_CF_CONNECTING_IP" => "146.12.125.53",
+            "HTTP_X_FORWARDED_FOR" => "146.12.125.53,162.158.86.173",
+            "REMOTE_ADDR" => "162.158.86.173"
+          }
+        end.not_to raise_error
+      end
+    end
+
+    context "when CF_PROXY_ENABLED is not set" do
+      before do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with("CF_PROXY_ENABLED").and_return(nil)
+      end
+
+      it "does not raise IpSpoofAttackError even without CF feature enabled" do
+        expect do
+          get "/", headers: {
+            "HTTP_CLIENT_IP" => "233.43.24.6",
+            "HTTP_X_FORWARDED_FOR" => "146.12.125.53,162.158.86.173",
+            "REMOTE_ADDR" => "162.158.86.173"
+          }
+        end.not_to raise_error
+      end
+    end
+  end
+
+  describe "Bug Fix: Trusted proxy configuration prevents false positives" do
+    it "does not raise IpSpoofAttackError for requests through private network proxies" do
+      expect do
+        get "/", headers: {
+          "HTTP_X_FORWARDED_FOR" => "198.51.100.1,10.0.0.1",
+          "REMOTE_ADDR" => "10.0.0.1"
+        }
+      end.not_to raise_error
+    end
+
+    it "does not raise IpSpoofAttackError for requests through localhost" do
+      expect do
+        get "/", headers: {
+          "HTTP_X_FORWARDED_FOR" => "198.51.100.1,127.0.0.1",
+          "REMOTE_ADDR" => "127.0.0.1"
+        }
+      end.not_to raise_error
+    end
+
+    it "handles IPv6 requests correctly" do
+      expect do
+        get "/", headers: {
+          "HTTP_X_FORWARDED_FOR" => "2001:db8::1,::1",
+          "REMOTE_ADDR" => "::1"
+        }
+      end.not_to raise_error
+    end
+  end
+
+  describe "Bug Fix: Maintains security while fixing false positives" do
+    it "still validates IPs when ip_spoofing_check is enabled" do
+      expect(Rails.configuration.action_dispatch.ip_spoofing_check).to be true
+    end
+
+    it "processes requests normally without spoofable headers" do
+      get "/", headers: {
+        "HTTP_X_FORWARDED_FOR" => "203.0.113.1",
+        "REMOTE_ADDR" => "10.0.0.1"
+      }
+
+      expect(response).to have_http_status(:success)
+    end
+
+    it "handles direct requests without proxy headers" do
+      get "/", headers: {
+        "REMOTE_ADDR" => "203.0.113.1"
+      }
+
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "Bug Fix: Edge cases that previously caused errors" do
+    it "handles malformed Client-IP without raising errors" do
+      expect do
+        get "/", headers: {
+          "HTTP_CLIENT_IP" => "not-an-ip",
+          "HTTP_X_FORWARDED_FOR" => "198.51.100.1",
+          "REMOTE_ADDR" => "10.0.0.1"
+        }
+      end.not_to raise_error
+    end
+
+    it "handles empty Client-IP header" do
+      expect do
+        get "/", headers: {
+          "HTTP_CLIENT_IP" => "",
+          "HTTP_X_FORWARDED_FOR" => "198.51.100.1",
+          "REMOTE_ADDR" => "10.0.0.1"
+        }
+      end.not_to raise_error
+    end
+
+    it "handles multiple IPs in X-Forwarded-For with spaces" do
+      expect do
+        get "/", headers: {
+          "HTTP_CLIENT_IP" => "233.43.24.6",
+          "HTTP_X_FORWARDED_FOR" => "146.12.125.53, 194.195.87.55, 162.158.86.173",
+          "REMOTE_ADDR" => "162.158.86.173"
+        }
+      end.not_to raise_error
+    end
+
+    it "handles requests with only Client-IP (no X-Forwarded-For)" do
+      expect do
+        get "/", headers: {
+          "HTTP_CLIENT_IP" => "233.43.24.6",
+          "REMOTE_ADDR" => "10.0.0.1"
+        }
+      end.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
# Summary
Requests behind CDN/load balancers were raising `ActionDispatch::RemoteIp::IpSpoofAttackError` due to conflicting `HTTP_CLIENT_IP` vs `X-Forwarded-For`.  
This PR normalizes IP headers and configures trusted proxies so Rails resolves the correct client IP while keeping spoofing protections enabled.



### Changes

- Add `ProxyIpSanitizer` middleware **before** `ActionDispatch::RemoteIp` to:
  - Drop spoofable `Client-IP`.
  - When `CF_PROXY_ENABLED=1` and the peer is a Cloudflare edge, use `CF-Connecting-IP`.
- Configure `action_dispatch.trusted_proxies` with:
  - Private/reserved IP ranges.
  - Optional Cloudflare CIDRs.
  - Extra ranges via `TRUSTED_PROXY_CIDRS`.
- Deduplicate `Rack::Attack` loading:
  - Explicitly require the middleware.
  - Clean up indentation in `application.rb`.


### Notes

- `ip_spoofing_check` remains `true` (**no security downgrade**).
- No change for non-proxied setups; fixes false positives behind Cloudflare or load balancers.
- **Environment variables:**
  - `CF_PROXY_ENABLED=1` — enable Cloudflare handling.
  - `TRUSTED_PROXY_CIDRS="203.0.113.0/24,2001:db8::/32"` — add extra trusted proxy CIDRs.


### Verification

- Middleware order confirmed: `ProxyIpSanitizer` → `RemoteIp`.
- `Rack::Attack` is loaded once.
- Proxied requests no longer raise `IpSpoofAttackError`.
- `request.remote_ip` resolves to the correct end-user IP.


**Closes #6101.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IP header handling: drop non-standard Client-IP headers and, when enabled, prefer validated CF-Connecting-IP for Cloudflare peers to reduce spoofing risk.

* **Chores**
  * Added proxy-sanitization middleware and centralized trusted-proxy configuration with optional provider CIDRs and admin-configurable ranges; ensured early normalization of IP headers.

* **Tests**
  * Added comprehensive tests covering middleware, trusted-proxy initializer, and request scenarios for IP validation and env-var variants.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->