### PR TITLE
Fix NameError: uninitialized constant CustomAuthError in AssignmentPolicy…

### DIFF
--- a/app/policies/assignment_policy.rb
+++ b/app/policies/assignment_policy.rb
@@ -33,7 +33,7 @@ class AssignmentPolicy < ApplicationPolicy
   end
 
   def reopen?
-    raise CustomAuthError, "Project is already open" if assignment.status == "open"
+    raise CustomAuthException, "Assignment is already open" if assignment.status == "open"
 
     true
   end


### PR DESCRIPTION
Fix NameError: uninitialized constant CustomAuthError in AssignmentPolicy

- Replace undefined CustomAuthError with CustomAuthException
- Update error message from 'Project' to 'Assignment' for clarity
- Fixes #6097

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messaging when attempting to reopen assignments that are already open, providing clearer and more accurate feedback to users about the operation status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->