### PR TITLE
Fix ActionView::MissingTemplate for simulator endpoints

### DIFF
--- a/app/controllers/simulator_controller.rb
+++ b/app/controllers/simulator_controller.rb
@@ -21,33 +21,55 @@ class SimulatorController < ApplicationController
   end
 
   def show
-    @logix_project_id = params[:id]
-    @external_embed = false
-    render "embed"
+    respond_to do |format|
+      format.html do
+        @logix_project_id = params[:id]
+        @external_embed = false
+        render "embed"
+      end
+      format.any { head :not_acceptable }
+    end
   end
 
   def new
-    @logix_project_id = 0
-    @projectName = ""
-    render "edit"
+    respond_to do |format|
+      format.html do
+        @logix_project_id = 0
+        @projectName = ""
+        render "edit"
+      end
+      format.any { head :not_acceptable }
+    end
   end
 
   def edit
-    @logix_project_id = params[:id]
-    @projectName = @project.name
+    respond_to do |format|
+      format.html do
+        @logix_project_id = params[:id]
+        @projectName = @project.name
+      end
+      format.any { head :not_acceptable }
+    end
   end
 
   def embed
     authorize @project
-    @logix_project_id = params[:id]
-    @project = Project.friendly.find(params[:id])
-    @author = @project.author_id
-    @external_embed = true
-    render "embed"
+    respond_to do |format|
+      format.html do
+        @logix_project_id = params[:id]
+        @author = @project.author_id
+        @external_embed = true
+        render "embed"
+      end
+      format.any { head :not_acceptable }
+    end
   end
 
   def get_data
-    render json: ProjectDatum.find_by(project: @project)&.data
+    respond_to do |format|
+      format.json { render json: ProjectDatum.find_by(project: @project)&.data }
+      format.any { head :not_acceptable }
+    end
   end
 
   def create


### PR DESCRIPTION
Fixes #6058 — resolves ActionView::MissingTemplate errors for simulator endpoints receiving JSON requests.

## Summary

The simulator controller raised MissingTemplate exceptions when new or edit actions were accessed with JSON format. These endpoints are meant for HTML responses only.

## Fix

Added respond_to blocks to explicitly handle formats:

HTML only for show, new, edit, and embed actions (returns 406 for unsupported formats)

JSON handling for get_data action

Removed redundant @project lookup in embed

## Outcome

- No more MissingTemplate or UnknownFormat errors

- Returns proper 406 for invalid formats

- Cleaner, more consistent controller behavior

## Testing

Verified via curl for both HTML and JSON requests — correct 406 or 200 responses returned as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Consolidated request-format handling across simulator endpoints (viewing, embedding, editing, creating, data retrieval) so HTML behavior is unchanged while unsupported formats return proper "Not Acceptable" (406) responses.
  * Data retrieval endpoint now explicitly provides JSON responses and rejects other formats for clearer, consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->