### PR TITLE
Fix race condition causing PG::UniqueViolation in star toggle

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -45,17 +45,9 @@ class ProjectsController < ApplicationController
   def edit; end
 
   def change_stars
-    star = Star.find_by(user_id: current_user.id, project_id: @project.id)
-    if star.nil?
-      @star = Star.new
-      @star.user_id = current_user.id
-      @star.project_id = @project.id
-      @star.save
-      render js: "2"
-    else
-      star.destroy
-      render js: "1"
-    end
+    # toggle_star returns true if starred, false if unstarred
+    starred = @project.toggle_star(current_user)
+    render js: starred ? "2" : "1"
   end
 
   def create_fork


### PR DESCRIPTION
## Description
Fixes race condition causing `PG::UniqueViolation` errors when users rapidly star/unstar projects.

Closes #6032

## Problem
The original code had a race condition in both the web controller and API:
```ruby
# Time-of-check to time-of-use gap
star = Star.find_by(user_id: user.id, project_id: id)
if star.nil?
  Star.create!(...)  # Can crash if another request created star meanwhile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the project star toggle feature to handle concurrent operations from multiple users more robustly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->