### PR TITLE
Fix ActionView::Template::Error by removing data attribute from project JSON

### DIFF
--- a/app/views/projects/_project.json.jbuilder
+++ b/app/views/projects/_project.json.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-json.extract! project, :id, :name, :author_id, :forked_project_id, :project_access_type, :data,
+json.extract! project, :id, :name, :author_id, :forked_project_id, :project_access_type,
               :created_at, :updated_at
 json.url project_url(project, format: :json)


### PR DESCRIPTION
## Description
Fixes #6035 

This PR resolves the `ActionView::Template::Error: undefined method 'data' for an instance of Project` error that was occurring when accessing project JSON views.

## Problem
The `_project.json.jbuilder` partial was attempting to extract a `:data` attribute directly from the `Project` model, but this column has been migrated to the `project_datum` table and is now listed in the Project model's `ignored_columns` (see line 9 of `app/models/project.rb`).

## Solution
Removed `:data` from the `json.extract!` call in `app/views/projects/_project.json.jbuilder` since it's no longer a valid attribute on the Project instance.

## Changes
- Removed `:data` from `json.extract!` in `app/views/projects/_project.json.jbuilder`

## Testing
- [ ] Verified that project JSON views no longer throw `NoMethodError`
- [ ] Confirmed that all other attributes are still properly serialized

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project API responses no longer include the data field, streamlining the output while maintaining all other project information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->