### PR TITLE
Fix: Handle JSON::ParserError in sim_version to prevent crashes

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -128,8 +128,21 @@ class Project < ApplicationRecord
 
   def sim_version
     raw_data = project_datum&.data
-    parsed_data = raw_data.present? ? JSON.parse(raw_data) : {}
-    parsed_data["simulatorVersion"] || "legacy"
+    return "legacy" if raw_data.blank?
+
+    begin
+      parsed_data = JSON.parse(raw_data)
+      parsed_data["simulatorVersion"] || "legacy"
+    rescue JSON::ParserError => e
+      # Log the error for monitoring
+      Rails.logger.error("JSON parsing failed for project #{id}: #{e.message}")
+      
+      # Report to Sentry if available
+      Sentry.capture_exception(e, extra: { project_id: id, data_size: raw_data.bytesize }) if defined?(Sentry)
+      
+      # Fallback to legacy version to prevent crashes
+      "legacy"
+    end
   end
 
   def uses_vue_simulator?

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -136,10 +136,8 @@ class Project < ApplicationRecord
     rescue JSON::ParserError => e
       # Log the error for monitoring
       Rails.logger.error("JSON parsing failed for project #{id}: #{e.message}")
-      
       # Report to Sentry if available
       Sentry.capture_exception(e, extra: { project_id: id, data_size: raw_data.bytesize }) if defined?(Sentry)
-      
       # Fallback to legacy version to prevent crashes
       "legacy"
     end

--- a/app/models/project_datum.rb
+++ b/app/models/project_datum.rb
@@ -2,40 +2,40 @@
 
 class ProjectDatum < ApplicationRecord
   belongs_to :project
-  
+
   # Maximum recommended data size (adjust based on your server configuration)
   # Set conservatively below your web server limit to account for HTTP overhead
   MAX_DATA_SIZE = 10.megabytes
-  
+
   validate :check_data_size
-  
+
   private
-  
-  def check_data_size
-    return if data.blank?
-    
-    data_size = data.bytesize
-    
-    if data_size > MAX_DATA_SIZE
-      errors.add(
-        :data,
-        "Circuit data is too large (#{format_bytes(data_size)}). " \
-        "Maximum size is #{format_bytes(MAX_DATA_SIZE)}. " \
-        "Please simplify your circuit or remove unused components."
-      )
-    elsif data_size > (MAX_DATA_SIZE * 0.8)
-      # Warning threshold at 80%
-      Rails.logger.warn("Project #{project_id} approaching size limit: #{format_bytes(data_size)}")
+
+    def check_data_size
+      return if data.blank?
+
+      data_size = data.bytesize
+
+      if data_size > MAX_DATA_SIZE
+        errors.add(
+          :data,
+          "Circuit data is too large (#{format_bytes(data_size)}). " \
+          "Maximum size is #{format_bytes(MAX_DATA_SIZE)}. " \
+          "Please simplify your circuit or remove unused components."
+        )
+      elsif data_size > (MAX_DATA_SIZE * 0.8)
+        # Warning threshold at 80%
+        Rails.logger.warn("Project #{project_id} approaching size limit: #{format_bytes(data_size)}")
+      end
     end
-  end
-  
-  def format_bytes(bytes)
-    if bytes < 1024
-      "#{bytes} B"
-    elsif bytes < 1024 * 1024
-      "#{(bytes / 1024.0).round(2)} KB"
-    else
-      "#{(bytes / (1024.0 * 1024)).round(2)} MB"
+
+    def format_bytes(bytes)
+      if bytes < 1024
+        "#{bytes} B"
+      elsif bytes < 1024 * 1024
+        "#{(bytes / 1024.0).round(2)} KB"
+      else
+        "#{(bytes / (1024.0 * 1024)).round(2)} MB"
+      end
     end
-  end
 end

--- a/app/models/project_datum.rb
+++ b/app/models/project_datum.rb
@@ -2,4 +2,40 @@
 
 class ProjectDatum < ApplicationRecord
   belongs_to :project
+  
+  # Maximum recommended data size (adjust based on your server configuration)
+  # Set conservatively below your web server limit to account for HTTP overhead
+  MAX_DATA_SIZE = 10.megabytes
+  
+  validate :check_data_size
+  
+  private
+  
+  def check_data_size
+    return if data.blank?
+    
+    data_size = data.bytesize
+    
+    if data_size > MAX_DATA_SIZE
+      errors.add(
+        :data,
+        "Circuit data is too large (#{format_bytes(data_size)}). " \
+        "Maximum size is #{format_bytes(MAX_DATA_SIZE)}. " \
+        "Please simplify your circuit or remove unused components."
+      )
+    elsif data_size > (MAX_DATA_SIZE * 0.8)
+      # Warning threshold at 80%
+      Rails.logger.warn("Project #{project_id} approaching size limit: #{format_bytes(data_size)}")
+    end
+  end
+  
+  def format_bytes(bytes)
+    if bytes < 1024
+      "#{bytes} B"
+    elsif bytes < 1024 * 1024
+      "#{(bytes / 1024.0).round(2)} KB"
+    else
+      "#{(bytes / (1024.0 * 1024)).round(2)} MB"
+    end
+  end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -154,9 +154,10 @@ RSpec.describe Project, type: :model do
           project.build_project_datum
           project.project_datum.data = '{"invalid json'
           project.save!
-          
-          expect(Rails.logger).to receive(:error).with(/JSON parsing failed/)
+
+          allow(Rails.logger).to receive(:error)
           project.sim_version
+          expect(Rails.logger).to have_received(:error).with(/JSON parsing failed/)
         end
       end
     end
@@ -191,6 +192,5 @@ RSpec.describe Project, type: :model do
         expect(project.uses_vue_simulator?).to be false
       end
     end
-
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -104,5 +104,93 @@ RSpec.describe Project, type: :model do
         end.to change(FeaturedCircuit, :count).by(-1)
       end
     end
+
+    describe "#sim_version" do
+      context "with valid JSON data" do
+        it "returns the simulator version from JSON" do
+          project = FactoryBot.create(:project, author: @user)
+          project.build_project_datum
+          project.project_datum.data = '{"simulatorVersion":"v1","name":"test"}'
+          project.save!
+          expect(project.sim_version).to eq("v1")
+        end
+
+        it "returns 'legacy' when simulatorVersion is not present" do
+          project = FactoryBot.create(:project, author: @user)
+          project.build_project_datum
+          project.project_datum.data = '{"name":"test"}'
+          project.save!
+          expect(project.sim_version).to eq("legacy")
+        end
+      end
+
+      context "with no project data" do
+        it "returns 'legacy' when project_datum is nil" do
+          project = FactoryBot.create(:project, author: @user)
+          expect(project.sim_version).to eq("legacy")
+        end
+
+        it "returns 'legacy' when data is blank" do
+          project = FactoryBot.create(:project, author: @user)
+          project.build_project_datum
+          project.project_datum.data = ""
+          project.save!
+          expect(project.sim_version).to eq("legacy")
+        end
+      end
+
+      context "with corrupted JSON data" do
+        it "returns 'legacy' when JSON parsing fails" do
+          project = FactoryBot.create(:project, author: @user)
+          project.build_project_datum
+          # Simulate corrupted/truncated JSON
+          project.project_datum.data = '{"name":"test","data":{"invalid'
+          project.save!
+          expect(project.sim_version).to eq("legacy")
+        end
+
+        it "logs error when JSON parsing fails" do
+          project = FactoryBot.create(:project, author: @user)
+          project.build_project_datum
+          project.project_datum.data = '{"invalid json'
+          project.save!
+          
+          expect(Rails.logger).to receive(:error).with(/JSON parsing failed/)
+          project.sim_version
+        end
+      end
+    end
+
+    describe "#uses_vue_simulator?" do
+      it "returns true for v0 simulator" do
+        project = FactoryBot.create(:project, author: @user)
+        project.build_project_datum
+        project.project_datum.data = '{"simulatorVersion":"v0"}'
+        project.save!
+        expect(project.uses_vue_simulator?).to be true
+      end
+
+      it "returns true for v1 simulator" do
+        project = FactoryBot.create(:project, author: @user)
+        project.build_project_datum
+        project.project_datum.data = '{"simulatorVersion":"v1"}'
+        project.save!
+        expect(project.uses_vue_simulator?).to be true
+      end
+
+      it "returns false for legacy simulator" do
+        project = FactoryBot.create(:project, author: @user)
+        expect(project.uses_vue_simulator?).to be false
+      end
+
+      it "returns false when JSON is corrupted" do
+        project = FactoryBot.create(:project, author: @user)
+        project.build_project_datum
+        project.project_datum.data = '{"invalid json'
+        project.save!
+        expect(project.uses_vue_simulator?).to be false
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Fix: Handle JSON::ParserError in sim_version to prevent crashes (fixes #6411)

- Add rescue block in Project#sim_version to catch JSON::ParserError
- Gracefully fall back to 'legacy' simulator version when JSON is corrupted
- Log errors and report to Sentry for monitoring
- Add JSON parsing error handling in ProjectsController#set_name_project_datum
- Add data size validation in ProjectDatum to prevent oversized data
- Add comprehensive test coverage for corrupted JSON scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced 10MB max per project dataset with warnings when usage approaches 80%.

* **Bug Fixes**
  * Improved handling of corrupted/invalid project JSON: logs/reporting on parse errors and safely falls back to default values.
  * More robust determination of simulator version for legacy fallback.

* **Tests**
  * Added coverage for simulator version detection and related behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->