### PR TITLE
Fix undefined method 'project_url' error in JSON jbuilder

### DIFF
--- a/app/views/projects/_project.json.jbuilder
+++ b/app/views/projects/_project.json.jbuilder
@@ -2,4 +2,4 @@
 
 json.extract! project, :id, :name, :author_id, :forked_project_id, :project_access_type,
               :created_at, :updated_at
-json.url project_url(project, format: :json)
+json.url user_project_url(project.author, project, format: :json)


### PR DESCRIPTION

## Description
Fixes #6403

This PR fixes the `ActionView::Template::Error: undefined method 'project_url'` error that occurs when rendering the JSON project partial.

## Root Cause
In `config/routes.rb`, the `projects` resource is nested under `users`:

```ruby
resources :users do
  resources :projects, except: %i[index new]
end
````

This means Rails generates the URL helper `user_project_url(user, project)` instead of `project_url(project)`. The error occurred because the jbuilder partial was using the non-existent `project_url` helper.

## Changes Made

* **`app/views/projects/_project.json.jbuilder`**: Changed `project_url(project, format: :json)` to `user_project_url(project.author, project, format: :json)`

This follows the same pattern used throughout the codebase:

* `app/views/simulator/edit.html.erb`: `user_project_url(@project.author, @project)`
* `app/views/featured_circuits/index.html.erb`: `user_project_url(project.author, project)`
* `app/controllers/simulator_controller.rb`: `edit_user_project_url(current_user, @project)`

## Testing

* Verified the route exists via `bin/rails routes | grep user_project`
* The fix uses the correct nested route helper that matches existing usage patterns




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated API endpoint URL structure for project resources to be scoped under user context.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->