### PR TITLE
Fix: Navbar Features link not navigating to homepage section

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -16,7 +16,7 @@
             <a class="nav-link navbar-item navbar-text" href="/simulator"><%= t("layout.link_to_simulator") %></a>
           </li>
           <li class="nav-item">
-            <a class="nav-link navbar-item navbar-text" href="/#home-features-section"><%= t("layout.link_to_features") %></a>
+            <a class="nav-link navbar-item navbar-text" href="/#powerful-features"><%= t("layout.link_to_features") %></a>
           </li>
           <% if Flipper.enabled?(:circuit_explore_page, current_user) %>
             <li class="nav-item">


### PR DESCRIPTION
Fixes #6433

### Describe the changes you have made in this PR
The "Features" link in the navbar was incorrectly pointing to `/#home-features`.  
However, the homepage section uses the id `#powerful-features`, causing the link to not navigate to the intended section.

This PR updates the navbar link to use the correct id: `/#powerful-features`.

### Screenshots of the changes (If any)
N/A — UI layout unchanged. Only the link target was corrected.

---

### Code Understanding and AI Usage
- Located the navigation link inside `app/views/layouts/_header.html.erb`
- Identified mismatch between navbar href and homepage section id
- Updated only the required line to keep the diff minimal
- Ensured no formatting or unrelated changes were introduced

### Testing
- Ran the application locally
- Clicked the “Features” link in the navbar
- Confirmed it scrolls correctly to the "Powerful Features" section



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Features navigation link in the header to scroll to the correct section on the page.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->