### PR TITLE
Fix: Update favicon link to resolve display issue

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,7 @@
                           title: yield(:title).presence || "CircuitVerse - Digital Circuit Simulator" %>
     <meta name="keywords"
       content="Digital circuits, logisim, online, educational platform, karnaugh map, kmap, electronic devices and circuits,digital electronics basics,introduction to digital electronics, simple electronics projects for students,electric circuit analysis, logic circuits, logic simulation, digital logic circuits, boolean logic">
-    <%= favicon_link_tag "favicon.ico" %>
+    <%= favicon_link_tag '/favicon.ico' %>
 
     <%= stylesheet_link_tag "application", media: "all", "data-turbolinks-track": "reload" %>
     <link rel="preconnect" href="https://fonts.gstatic.com">


### PR DESCRIPTION
Closes #6435 

## Description
This PR fixes the missing favicon display issue by updating the favicon link tag in the application layout.

## Changes Made
- Updated `favicon_link_tag` in `app/views/layouts/application.html.erb` to use absolute path `/favicon.ico`
- This ensures the browser correctly loads the favicon from the public directory

## Testing
- ✅ Verified favicon displays correctly in browser tab on localhost:3000 via Docker setup
- ✅ Tested in Chrome browser (on Mac)
- ✅ No breaking changes

## Screenshots
The favicon now displays correctly on `localhost:3000`:
<img width="2446" height="354" alt="image" src="https://github.com/user-attachments/assets/d4018a2e-e451-4781-9297-d0f2104c7ad0" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed favicon loading by updating asset path resolution to ensure consistent display across all environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->