### PR TITLE
fix: update Brewfile for current homebrew versions

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-brew "node@20"
+brew "node@22"
 brew "redis"
 brew "imagemagick"
 brew "yarn"


### PR DESCRIPTION
Fixes #6292

### Changes
- Remove deprecated Homebrew taps from `Brewfile`.
- Upgrade `node@16` to `node@20` since `node@16` is disabled upstream.
- Keep the rest of the dependencies unchanged.

### Notes
- This should make `brew bundle` succeed again on macOS with a current Homebrew setup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Node.js runtime from version 16 to version 22
  * Removed several obsolete package sources from the development setup
  * Updated development environment configuration and package entries (no functional change to PostgreSQL)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->