### PR TITLE
docs: add Redis startup instructions for Linux and macOS

### DIFF
--- a/installation_docs/manual/linux.md
+++ b/installation_docs/manual/linux.md
@@ -38,6 +38,8 @@ cd CircuitVerse
      echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
      sudo apt-get update
      sudo apt-get install redis
+     sudo systemctl start redis-server
+     sudo systemctl enable redis-server
      ```
 - [ImageMagick](https://imagemagick.org/) - Image manipulation library
      ```bash

--- a/installation_docs/manual/mac.md
+++ b/installation_docs/manual/mac.md
@@ -43,6 +43,11 @@ cd CircuitVerse
      - [CMAKE](https://cmake.org/install/)
      - OpenSSL
      - [PostgreSQL](https://www.postgresql.org/download/macosx/) (`12`) - Database
+- **Start required services (if installed via Homebrew)**
+     ```bash
+     brew services start redis
+     brew services start postgresql
+     ```
 
 
 #### Setup


### PR DESCRIPTION
Fixes #6461  

#### Describe the changes you have made in this PR -
This pr adds redis startup instructions to the Linux and macOS setup documentation to make the installation steps complete and consistent across platforms.

- Updated `linux.md` to include Redis start and enable commands using `systemctl`.
- Updated `mac.md` to document starting Redis and PostgreSQL services when installed via Homebrew.
- No application code was changed; this is a documentation-only update.

### Screenshots of the UI changes (If any) -
N/A

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The setup documentation already required Redis to be running but did not include startup commands for Linux and macOS, which could lead to confusion during setup.  
I added minimal, platform-appropriate service start instructions using `systemctl` for Linux and Homebrew services for macOS, keeping the changes scoped to documentation only and aligned with existing conventions in the repository.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my changes
- [x] I can explain the purpose of every change I added
- [x] I understand why my changes work
- [ ] If it is a core feature, I have added thorough tests (not applicable)
- [x] My changes follow the project's style guidelines and conventions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated Linux installation guide with commands to start and enable Redis service after installation.
* Updated macOS installation guide with commands to start Redis and PostgreSQL services via Homebrew, ensuring services run immediately and on boot.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->