### PR TITLE
Fixed Search Query Timeout Issue 

### DIFF
--- a/app/lib/adapters/pg_adapter.rb
+++ b/app/lib/adapters/pg_adapter.rb
@@ -27,6 +27,11 @@ module Adapters
         type: :project,
         includes: %i[tags author]
       )
+    rescue ActiveRecord::QueryCanceled => e
+      # Log the error for monitoring
+      Rails.logger.error("Project search query timeout: #{e.message}")
+      # Return empty paginated result instead of crashing
+      Project.none.paginate(page: query_params[:page], per_page: MAX_RESULTS_PER_PAGE)
     end
 
     def search_user(relation, query_params)
@@ -35,6 +40,11 @@ module Adapters
         query_params: query_params,
         type: :user
       )
+    rescue ActiveRecord::QueryCanceled => e
+      # Log the error for monitoring
+      Rails.logger.error("User search query timeout: #{e.message}")
+      # Return empty paginated result instead of crashing
+      User.none.paginate(page: query_params[:page], per_page: MAX_RESULTS_PER_PAGE)
     end
 
     private

--- a/db/migrate/20251220221947_add_indexes_to_users_search_columns.rb
+++ b/db/migrate/20251220221947_add_indexes_to_users_search_columns.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class AddIndexesToUsersSearchColumns < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def up
+    # Add index on LOWER(country) for case-insensitive equality searches
+    execute <<-SQL.squish
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS index_users_on_lower_country
+      ON users (LOWER(country))
+    SQL
+
+    # Enable pg_trgm extension if not already enabled (for ILIKE searches)
+    execute "CREATE EXTENSION IF NOT EXISTS pg_trgm"
+
+    # Add GIN index on educational_institute for ILIKE pattern matching
+    execute <<-SQL.squish
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS index_users_on_educational_institute_trgm
+      ON users USING gin (educational_institute gin_trgm_ops)
+    SQL
+  end
+
+  def down
+    execute "DROP INDEX CONCURRENTLY IF EXISTS index_users_on_lower_country"
+    execute "DROP INDEX CONCURRENTLY IF EXISTS index_users_on_educational_institute_trgm"
+  end
+end


### PR DESCRIPTION
Fixes #6477

## Issue Summary
**Sentry**: CIRCUITVERSE-CORE-WB  
User search requests were timing out (`PG::QueryCanceled`) when filtering by
country or educational institute, resulting in 500 errors.

## Root Cause
- Filters were applied on `User.all` when no search term was present
- No indexes on `country` and `educational_institute`
- PostgreSQL performed full table scans on large datasets

## Solution
### Database
- Added functional index on `LOWER(country)` for case-insensitive equality
- Added GIN trigram index on `educational_institute` for `ILIKE` queries
- Used `CONCURRENTLY` to avoid table locks

### Application
- Added graceful handling for `ActiveRecord::QueryCanceled`
- Returns empty paginated results instead of crashing
- Logs timeout errors for monitoring

### Tests
- Added coverage for user and project search timeout scenarios

## Files Changed
- `app/lib/adapters/pg_adapter.rb`
- `spec/lib/adapters/pg_adapter_spec.rb`
- `db/migrate/20251220221947_add_indexes_to_users_search_columns.rb`

## How to Test
```bash
bundle exec rails db:migrate
bundle exec rspec spec/lib/adapters/pg_adapter_spec.rb
````

## Risk

Low. Changes are additive (indexes + error handling) and backward-compatible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search reliability by gracefully handling timeout errors. When searches exceed time limits, users now receive empty results instead of application crashes.

* **Performance Improvements**
  * Added database optimizations to accelerate search query performance for user profiles and projects.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->