### PR TITLE
Fix UI alignment for grading scale and restriction checkboxes

### DIFF
--- a/app/views/assignments/_form.html.erb
+++ b/app/views/assignments/_form.html.erb
@@ -57,10 +57,6 @@
     <label for="restrict-elements" class="primary-checkpoint-container d-flex align-items-center gap-2" id="label-restrict-elements"><h6><%= t("assignments.form.enable_element_restriction") %></h6>
       <%= check_box_tag "restrict-elements", checked: @assignment.elements_restricted? %>
       <div class="primary-checkpoint"></div>
-      <span class="ms-2">
-        <%= t("assignments.form.enable_element_restriction") %>
-      </span>
-
     </label>
     <div class="restricted-elements-list mt-2 ms-4"> <!-- Operated by script --> </div>
   </div>

--- a/app/views/assignments/_form.html.erb
+++ b/app/views/assignments/_form.html.erb
@@ -36,7 +36,7 @@
     <h6><label for="assignment_deadline"><%= t("assignments.deadline") %></label></h6> (<span id='remaining-time'><b><%= t("assignments.remaining_time_error") %></b></span>)
     <input id="assignment_deadline" name="assignment[deadline]" type="text" class="form-control form-input">
   </div>
-  <div id="grade-field" class="form-group projects-tag-mb-3">
+  <div id="grade-field" class="form-group projects-tag-mb-3 mt-3">
     <h6><%= form.label :grading_scale %></h6>
     <% if @assignment.new_record? %>
       <span><%= t("assignments.form.grade_scale_cant_change") %></span>
@@ -54,11 +54,15 @@
   </div>
 
   <div id="restrictions-field" class="field mb-3">
-    <label for="restrict-elements" class="primary-checkpoint-container" id="label-restrict-elements"><h6><%= t("assignments.form.enable_element_restriction") %></h6>
+    <label for="restrict-elements" class="primary-checkpoint-container d-flex align-items-center gap-2" id="label-restrict-elements"><h6><%= t("assignments.form.enable_element_restriction") %></h6>
       <%= check_box_tag "restrict-elements", checked: @assignment.elements_restricted? %>
       <div class="primary-checkpoint"></div>
+      <span class="ms-2">
+        <%= t("assignments.form.enable_element_restriction") %>
+      </span>
+
     </label>
-    <div class="restricted-elements-list"> <!-- Operated by script --> </div>
+    <div class="restricted-elements-list mt-2 ms-4"> <!-- Operated by script --> </div>
   </div>
 
   <div id="restrictions-field" class="field mb-3" data-controller="assignment">


### PR DESCRIPTION
Fixes #5541 

## What does this PR do?

This PR improves the UI alignment in the Assignment edit page by:
- Adding proper spacing between the grading scale and deadline fields
- Aligning restriction checkboxes and labels correctly
- Ensuring consistent row and column alignment for better readability

## Why is this needed?
The assignment edit page had misaligned UI elements, particularly around the grading scale and restriction checkboxes, which affected visual clarity and usability.

This change improves spacing and alignment , making the layout cleaner and more intuitive for users while editing assignments

## Screenshots

### Before
(UI was misaligned - grading scale and restriction checkboxes were not properly spaced and aligned)
<img width="1914" height="889" alt="image" src="https://github.com/user-attachments/assets/9b4680fc-e8c4-4247-8cae-164fd58b1a2a" />


### After
(UI elements are now properly aligned with consistent spacing for better readability)
<img width="1896" height="1082" alt="image" src="https://github.com/user-attachments/assets/ef089739-1c4f-47d0-ae77-80af6ba782f6" />
<img width="1859" height="1084" alt="image" src="https://github.com/user-attachments/assets/c1713dc0-f72c-447e-9081-0b707fb88e37" />



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved vertical spacing between fields in the assignments form for clearer layout.
  * Enhanced horizontal alignment and spacing of labels and controls for better readability and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->