### PR TITLE
fix: improve spacing between CAPTCHA and login button

### DIFF
--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -55,7 +55,9 @@
         <div class="field mb-3">
           <div class="input-group">
             <% if Flipper.enabled?(:recaptcha) %>
-              <%= recaptcha_tags %>
+              <div class="mb-3">
+                <%= recaptcha_tags %>
+              </div>
             <% end %>
             <%= f.submit t("login"), class: "btn primary-button users-login-primary-button" %>
             <div class="users-text-container">


### PR DESCRIPTION
This PR fixes the spacing issue between the CAPTCHA and the login button on the login page.
 Changes Made
- Added a wrapper `<div class="mb-3">` around `recaptcha_tags`
- Uses Bootstrap's margin-bottom utility class for consistent spacing
- Maintains visual consistency with other form elements
Testing
- Verified spacing improvement when recaptcha is enabled
- No changes to functionality, only visual spacing
- Uses existing Bootstrap utility classes

Fixes #5442

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing and layout of the reCAPTCHA element on the login page for enhanced visual presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->