### PR TITLE
docs: add workarounds for application.js and CRLF errors in troubleshooting guide

### DIFF
--- a/installation_docs/troubleshooting_guide.md
+++ b/installation_docs/troubleshooting_guide.md
@@ -3,6 +3,83 @@
 ---
 
 ### 1. Sprockets::Rails::Helper::AssetNotFound in CircuitVerse#index
+
 ![image](https://github.com/CircuitVerse/CircuitVerse/assets/57363826/5e707303-5147-4645-89e4-715c7b70a3f5)
 
-**Solution:** Wait for few seconds (upto 1 minute) and refresh the page.
+**What's happening?**
+
+This error occurs when Rails cannot find the `application.js` file in the asset pipeline. The file is compiled by esbuild from `app/javascript/` to `app/assets/builds/`. In Docker, if Rails starts before the asset compilation finishes (or if dependencies weren't installed properly), you'll see this error.
+
+---
+
+#### Solution A: Wait and Refresh (Recommended First)
+
+Simply wait for 30-60 seconds and refresh the page. The `asset_build` Docker service compiles assets in the background, and it may take a moment to complete.
+
+---
+
+#### Solution B: Manual Asset Precompilation (If Solution A Doesn't Work)
+
+If waiting doesn't resolve the issue, the Ruby dependencies may not have been installed properly. Follow these steps to manually install dependencies and precompile assets:
+
+**Step 1:** Start the Docker containers in detached mode (runs in background)
+```bash
+docker compose up -d
+```
+> This starts all services defined in `docker-compose.yml` without blocking your terminal.
+
+**Step 2:** Open a bash shell inside the `web` container
+```bash
+docker compose exec web bash
+```
+> You should now see a prompt like `root@a1b2c3d4:/circuitverse#` indicating you're inside the container.
+
+**Step 3:** Install Ruby gem dependencies
+```bash
+bundle install
+```
+> This installs all gems listed in `Gemfile`. Rails needs these dependencies to compile assets.
+
+**Step 4:** Precompile the assets manually
+```bash
+bundle exec rake assets:precompile
+```
+> This runs the Rails asset pipeline to compile `application.js` and other assets into the `public/assets/` folder.
+
+**Step 5:** Exit the container shell
+```bash
+exit
+```
+
+**Step 6:** Restart the Docker containers
+```bash
+docker compose down
+docker compose up
+```
+> This cleanly restarts all services with the newly compiled assets.
+
+Now refresh your browser - the error should be resolved!
+
+---
+
+### 2. `$'\r': command not found` Errors When Running `build.sh`
+
+**What's happening?**
+
+This error occurs because the `build.sh` script has Windows-style line endings (CRLF) instead of Unix-style line endings (LF). Docker containers run Linux, which doesn't recognize CRLF line endings.
+
+---
+
+#### Solution: Convert CRLF to LF in VS Code
+
+**Step 1:** Open `cv-frontend-vue/build.sh` in VS Code
+
+**Step 2:** Look at the bottom-right corner of VS Code - you'll see either `CRLF` or `LF`
+
+**Step 3:** Click on `CRLF` to open the line ending selector
+
+**Step 4:** Select `LF` from the dropdown menu
+
+**Step 5:** Save the file (`Ctrl+S` or `Cmd+S`)
+
+The script should now run without the `$'\r'` errors.


### PR DESCRIPTION
### Describe the changes you have made in this PR -
This PR expands the troubleshooting guide with detailed, beginner-friendly workarounds for common Docker setup issues:

**1. application.js Asset Not Found Error**
- Added an explanation of why this error occurs (race condition between Rails starting and asset compilation)
- **Solution A**: Wait and refresh (existing, kept as primary recommendation)
- **Solution B**: Manual asset precompilation with step-by-step commands:
  - `docker compose up -d`
  - `docker compose exec web bash`
  - `bundle install`
  - `bundle exec rake assets:precompile`
  - `exit` → `docker compose down` → `docker compose up`

**2. `$'\r': command not found` Errors**
- Added a new section explaining CRLF vs LF line ending issues on Windows
- Added a guide to convert `build.sh` from CRLF to LF using VS Code
### Screenshots of the UI changes (If any) -
N/A - Documentation only

---
## Code Understanding and AI Usage
**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)
**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The application.js not found error is a race condition in Docker where Rails may start before esbuild finishes compiling assets. The existing "wait and refresh" solution doesn't work sometimes. 

The manual precompilation workaround ensures:
1. All Ruby gems are installed (`bundle install`)
2. Assets are explicitly compiled (`rake assets:precompile`)
3. Services restart cleanly with proper assets

The CRLF issue is a common Windows problem. Docker runs Linux which doesn't recognize Windows line endings.

---
## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded troubleshooting guide with detailed explanations for AssetNotFound errors, providing two comprehensive solutions: automated (wait and refresh) and manual (step-by-step asset precompilation).
  * Added new troubleshooting section for CRLF vs LF line ending compatibility issues with environment-specific guidance and VS Code workflow instructions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->