### PR TITLE
Fix NoMethodError in search_projects when page params are nil

### DIFF
--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -239,7 +239,11 @@ class Api::V1::ProjectsController < Api::V1::BaseController
     end
 
     def search_projects
-      query_params = { q: params[:q], page: params.dig(:page, :number) || 1, per_page: params.dig(:page, :size) || 10 }
+      query_params = { 
+      q: params[:q], 
+      page: (params.dig(:page, :number) || 1).to_i,
+      per_page: (params.dig(:page, :size) || 10).to_i
+    }
       @projects = ProjectsQuery.new(query_params, Project.public_and_not_forked).results
     end
 

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -239,7 +239,7 @@ class Api::V1::ProjectsController < Api::V1::BaseController
     end
 
     def search_projects
-      query_params = { q: params[:q], page: params[:page][:number], per_page: params[:page][:size] }
+      query_params = { q: params[:q], page: params.dig(:page, :number) || 1, per_page: params.dig(:page, :size) || 10 }
       @projects = ProjectsQuery.new(query_params, Project.public_and_not_forked).results
     end
 


### PR DESCRIPTION
## Description
Fixes #6529 

This PR fixes a NoMethodError that occurs when `params[:page]` is nil or missing in the `search_projects` API endpoint.

## Changes Made
- Replaced direct hash access with `dig` method for safe navigation
- Added default values for pagination: `page: 1, per_page: 10`
- Prevents crash when page params are missing or nil

## Code Change
**Before:**
```ruby
query_params = { q: params[:q], page: params[:page][:number], per_page: params[:page][:size] }
```

**After:**
```ruby
query_params = { q: params[:q], page: params.dig(:page, :number) || 1, per_page: params.dig(:page, :size) || 10 }
```

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] This fix handles nil/missing page parameters gracefully
- [x] Includes reference to issue #6529

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search pagination now safely handles missing or malformed page data, defaulting to page 1 with 10 results per page and ensuring pagination values are treated as integers to prevent errors and improve stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->