### PR TITLE
Show 'Continue with' on signup social auth section

### DIFF
--- a/app/component/auth_components/social_login_component.html.erb
+++ b/app/component/auth_components/social_login_component.html.erb
@@ -1,6 +1,8 @@
 <div class="field mb-3 users-shared">
   <div class="text-center">
-    <h6 class="users-shared-row"><%= t("users.shared.login_with") %></h6>
+    <h6 class="users-shared-row">
+      <%= controller_name == "registrations" ? t("users.shared.continue_with") : t("users.shared.login_with") %>
+    </h6>
     <div class="text-center">
       <div class="d-flex flex-column flex-md-row align-items-center justify-content-center">
       <%= link_to user_google_oauth2_omniauth_authorize_path, method: :post, class: 'text-decoration-none oauth-button' do %>

--- a/app/component/auth_components/social_login_component.html.erb
+++ b/app/component/auth_components/social_login_component.html.erb
@@ -1,8 +1,6 @@
 <div class="field mb-3 users-shared">
   <div class="text-center">
-    <h6 class="users-shared-row">
-      <%= controller_name == "registrations" ? t("users.shared.continue_with") : t("users.shared.login_with") %>
-    </h6>
+    <h6 class="users-shared-row"><%= title %></h6>
     <div class="text-center">
       <div class="d-flex flex-column flex-md-row align-items-center justify-content-center">
       <%= link_to user_google_oauth2_omniauth_authorize_path, method: :post, class: 'text-decoration-none oauth-button' do %>

--- a/app/component/auth_components/social_login_component.rb
+++ b/app/component/auth_components/social_login_component.rb
@@ -4,10 +4,16 @@ module AuthComponents
   class SocialLoginComponent < ViewComponent::Base
     delegate :new_confirmation_path, to: :view_context
 
-    def initialize(devise_mapping:, resource_name:)
+    def initialize(devise_mapping:, resource_name:, controller_name:)
       super()
       @devise_mapping = devise_mapping
       @resource_name = resource_name
+      @controller_name = controller_name
+    end
+
+    def title
+      @controller_name == "registrations" ? t("users.shared.continue_with") : t("users.shared.login_with")
     end
   end
 end
+

--- a/app/views/users/confirmations/new.html.erb
+++ b/app/views/users/confirmations/new.html.erb
@@ -20,7 +20,7 @@
               <%= f.submit t("users.confirmations.resend_confirmation_instructions"), class:"btn primary-button users-primary-button" %>
             </div>
           </div>
-          <%= render(AuthComponents::SocialLoginComponent.new(devise_mapping: devise_mapping, resource_name: resource_name)) %>
+          <%= render(AuthComponents::SocialLoginComponent.new(devise_mapping: devise_mapping, resource_name: resource_name, controller_name: controller_name)) %>
         <% end %>
       </div>
     </div>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -53,7 +53,7 @@
               <%= link_to t("sign_up"), new_user_registration_path, class: "anchor-text" %>
             </div>
           </div>
-          <%= render(AuthComponents::SocialLoginComponent.new(devise_mapping: devise_mapping, resource_name: resource_name)) %>
+          <%= render(AuthComponents::SocialLoginComponent.new(devise_mapping: devise_mapping, resource_name: resource_name, controller_name: controller_name)) %>
         <% end %>
       </div>
     </div>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -30,7 +30,7 @@
               <%= link_to t("users.passwords.link_to_login_page"), new_user_session_path, class: "anchor-text mt-2" %>
             </div>
           </div>
-          <%= render(AuthComponents::SocialLoginComponent.new(devise_mapping: devise_mapping, resource_name: resource_name)) %>
+          <%= render(AuthComponents::SocialLoginComponent.new(devise_mapping: devise_mapping, resource_name: resource_name, controller_name: controller_name)) %>
         <% end %>
       </div>
     </div>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -54,7 +54,7 @@
               </div>
             </div>
           </div>
-          <%= render(AuthComponents::SocialLoginComponent.new(devise_mapping: devise_mapping, resource_name: resource_name)) %>
+          <%= render(AuthComponents::SocialLoginComponent.new(devise_mapping: devise_mapping, resource_name: resource_name, controller_name: controller_name)) %>
         <% end %>
       </div>
     </div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -66,7 +66,7 @@
             </div>
           </div>
         </div>
-        <%= render(AuthComponents::SocialLoginComponent.new(devise_mapping: devise_mapping, resource_name: resource_name)) %>
+        <%= render(AuthComponents::SocialLoginComponent.new(devise_mapping: devise_mapping, resource_name: resource_name, controller_name: controller_name)) %>
       </div>
       <% end %>
     </div>

--- a/app/views/users/unlocks/new.html.erb
+++ b/app/views/users/unlocks/new.html.erb
@@ -28,7 +28,7 @@
               <%= f.submit t("users.unlock.resend_unlock_instructions"), class: "btn primary-button users-primary-button" %>
             </div>
           </div>
-          <%= render(AuthComponents::SocialLoginComponent.new(devise_mapping: devise_mapping, resource_name: resource_name)) %>
+          <%= render(AuthComponents::SocialLoginComponent.new(devise_mapping: devise_mapping, resource_name: resource_name, controller_name: controller_name)) %>
         <% end %>
       </div>
     </div>

--- a/config/locales/views/users/en.yml
+++ b/config/locales/views/users/en.yml
@@ -81,6 +81,7 @@ en:
       remember_me: "Remember Me"
     shared:
       login_with: "Login With"
+      continue_with: "Continue with"
       login_with_sso: "Single Sign On"
       resend_email: "Didn't receive confirmation instructions?"
     unlocks:

--- a/spec/components/previews/social_login_component_preview.rb
+++ b/spec/components/previews/social_login_component_preview.rb
@@ -3,6 +3,6 @@
 class SocialLoginComponentPreview < ViewComponent::Preview
   def default
     fake_mapping = Struct.new(:confirmable?).new(true)
-    render(AuthComponents::SocialLoginComponent.new(devise_mapping: fake_mapping, resource_name: :user))
+    render(AuthComponents::SocialLoginComponent.new(devise_mapping: fake_mapping, resource_name: :user, controller_name: "registrations"))
   end
 end


### PR DESCRIPTION
Fixes #6545 

#### Describe the changes you have made in this PR -

On the signup page, the social authentication section currently shows the text “Login with” above the social buttons.
This can confuse new users because they are on the signup page, not the login page.

To fix this, I changed the text to “Continue with” on the signup page.
This makes it clear that the social buttons are part of the signup flow and helps avoid confusion, especially for new users.

### Screenshots of the UI changes (If any) -

<img width="1920" height="911" alt="Screenshot (90)" src="https://github.com/user-attachments/assets/c2be5084-ce6e-4660-a3bf-750328d4115a" />


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**

* [x] No, I wrote all the code myself
* [ ] Yes, I used AI assistance (continue below)

**Explain your implementation approach:**
This change improves clarity in the signup UI by adding a clear label above the social authentication buttons.
The update is limited to the relevant view component and locale text, without affecting existing authentication logic.

---

## Checklist before requesting a review

* [x] I have added a proper PR title and linked to the issue
* [x] I have performed a self-review of my code
* [x] **I can explain the purpose of every change I added**
* [x] I understand why my changes work and have tested them
* [x] My code follows the project's style guidelines and conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Social login header is now context-aware: displays "Continue with" during registration and "Login with" for sign-in flows.
  * Added a translation for the "Continue with" label to support localization.

* **Chores**
  * Updated views and previews to pass controller context so the social login header can adapt its wording.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->