### PR TITLE
Add error handling and timeout for HTTP requests in verilog_cv method

### DIFF
--- a/app/controllers/api/v1/simulator_controller.rb
+++ b/app/controllers/api/v1/simulator_controller.rb
@@ -31,7 +31,15 @@ class Api::V1::SimulatorController < Api::V1::BaseController
   # POST /api/v1/simulator/verilogcv
   def verilog_cv
     url = "#{ENV.fetch('YOSYS_PATH', 'http://127.0.0.1:3040')}/getJSON"
-    response = HTTP.post(url, json: { code: params[:code] })
-    render json: response.to_s, status: response.code
+    begin
+      response = HTTP.timeout(30).post(url, json: { code: params[:code] })
+      render json: response.to_s, status: response.code
+    rescue HTTP::TimeoutError, HTTP::ConnectionError => e
+      Rails.logger.error "Verilog synthesis service error: #{e.message}"
+      api_error(status: 503, errors: "Verilog synthesis service is currently unavailable. Please try again later.")
+    rescue StandardError => e
+      Rails.logger.error "Unexpected error in verilog_cv: #{e.class} - #{e.message}"
+      api_error(status: 500, errors: "An error occurred while processing your Verilog code. Please try again later.")
+    end
   end
 end

--- a/app/controllers/api/v1/simulator_controller.rb
+++ b/app/controllers/api/v1/simulator_controller.rb
@@ -29,6 +29,7 @@ class Api::V1::SimulatorController < Api::V1::BaseController
   # rubocop:enable Metrics/MethodLength
 
   # POST /api/v1/simulator/verilogcv
+  # rubocop:disable Metrics/MethodLength
   def verilog_cv
     return api_error(status: 400, errors: "Code parameter is required") if params[:code].blank?
 
@@ -49,4 +50,5 @@ class Api::V1::SimulatorController < Api::V1::BaseController
       api_error(status: 500, errors: "An error occurred while processing your Verilog code. Please try again later.")
     end
   end
+  # rubocop:enable Metrics/MethodLength
 end

--- a/app/controllers/api/v1/simulator_controller.rb
+++ b/app/controllers/api/v1/simulator_controller.rb
@@ -33,7 +33,7 @@ class Api::V1::SimulatorController < Api::V1::BaseController
     url = "#{ENV.fetch('YOSYS_PATH', 'http://127.0.0.1:3040')}/getJSON"
     begin
       response = HTTP.timeout(30).post(url, json: { code: params[:code] })
-      render json: response.to_s, status: response.code
+      render json: response.body.to_s, status: response.code
     rescue HTTP::TimeoutError, HTTP::ConnectionError => e
       Rails.logger.error "Verilog synthesis service error: #{e.message}"
       api_error(status: 503, errors: "Verilog synthesis service is currently unavailable. Please try again later.")

--- a/app/controllers/simulator_controller.rb
+++ b/app/controllers/simulator_controller.rb
@@ -118,7 +118,7 @@ class SimulatorController < ApplicationController
     url = "#{ENV.fetch('YOSYS_PATH', 'http://127.0.0.1:3040')}/getJSON"
     begin
       response = HTTP.timeout(30).post(url, json: { code: params[:code] })
-      render json: response.to_s, status: response.code
+      render json: response.body.to_s, status: response.code
     rescue HTTP::TimeoutError, HTTP::ConnectionError => e
       Rails.logger.error "Verilog synthesis service error: #{e.message}"
       render json: { error: "Verilog synthesis service is currently unavailable. Please try again later." },

--- a/app/controllers/simulator_controller.rb
+++ b/app/controllers/simulator_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/ClassLength
 class SimulatorController < ApplicationController
   include SimulatorHelper
   include ActionView::Helpers::SanitizeHelper
@@ -180,3 +181,4 @@ class SimulatorController < ApplicationController
       end
     end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/controllers/simulator_controller.rb
+++ b/app/controllers/simulator_controller.rb
@@ -115,6 +115,7 @@ class SimulatorController < ApplicationController
     head :ok, content_type: "text/html"
   end
 
+  # rubocop:disable Metrics/MethodLength
   def verilog_cv
     if params[:code].blank?
       render json: { error: "Code parameter is required" }, status: :bad_request
@@ -141,6 +142,7 @@ class SimulatorController < ApplicationController
              status: :internal_server_error
     end
   end
+  # rubocop:enable Metrics/MethodLength
 
   def allow_iframe_lti
     return unless session[:is_lti]

--- a/spec/requests/api/v1/simulator_controller/verilog_cv_spec.rb
+++ b/spec/requests/api/v1/simulator_controller/verilog_cv_spec.rb
@@ -8,13 +8,22 @@ RSpec.describe Api::V1::SimulatorController, type: :request do
     let(:yosys_url) { "#{ENV.fetch('YOSYS_PATH', 'http://127.0.0.1:3040')}/getJSON" }
     let(:yosys_response) { { "data" => "response_from_yosys" } }
 
+    context "when code parameter is missing" do
+      it "returns a bad request error" do
+        post "/api/v1/simulator/verilogcv", params: {}
+        expect(response.status).to eq(400)
+        expect(response.parsed_body["errors"]).to include("Code parameter is required")
+      end
+    end
+
     context "when YOSYS_PATH is valid and returns a successful response" do
       let(:body_string) { yosys_response.to_json }
-      let(:response_double) { instance_double(HTTP::Response, code: 200, body: body_string) }
+      let(:status_double) { instance_double(HTTP::Response::Status, success?: true) }
+      let(:response_double) { instance_double(HTTP::Response, code: 200, body: body_string, status: status_double) }
 
       before do
         allow(ENV).to receive(:fetch).with("YOSYS_PATH", "http://127.0.0.1:3040").and_return("http://127.0.0.1:3040")
-        allow(HTTP).to receive(:timeout).with(30).and_return(HTTP)
+        allow(HTTP).to receive(:timeout).with(connect: 30, read: 30, write: 30).and_return(HTTP)
         allow(HTTP).to receive(:post).and_return(response_double)
       end
 
@@ -26,17 +35,19 @@ RSpec.describe Api::V1::SimulatorController, type: :request do
     end
 
     context "when YOSYS_PATH is valid but returns a failed response" do
-      let(:response_double) { instance_double(HTTP::Response, code: 500, body: "") }
+      let(:status_double) { instance_double(HTTP::Response::Status, success?: false) }
+      let(:response_double) { instance_double(HTTP::Response, code: 500, body: "", status: status_double) }
 
       before do
         allow(ENV).to receive(:fetch).with("YOSYS_PATH", "http://127.0.0.1:3040").and_return("http://127.0.0.1:3040")
-        allow(HTTP).to receive(:timeout).with(30).and_return(HTTP)
+        allow(HTTP).to receive(:timeout).with(connect: 30, read: 30, write: 30).and_return(HTTP)
         allow(HTTP).to receive(:post).and_return(response_double)
       end
 
-      it "returns the failed status code" do
+      it "returns service unavailable error" do
         post "/api/v1/simulator/verilogcv", params: { code: code }
-        expect(response.status).to eq(500)
+        expect(response.status).to eq(503)
+        expect(response.parsed_body["errors"]).to include("Verilog synthesis service returned an error")
       end
     end
   end

--- a/spec/requests/api/v1/simulator_controller/verilog_cv_spec.rb
+++ b/spec/requests/api/v1/simulator_controller/verilog_cv_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Api::V1::SimulatorController, type: :request do
       it "returns a bad request error" do
         post "/api/v1/simulator/verilogcv", params: {}
         expect(response.status).to eq(400)
-        expect(response.parsed_body["errors"]).to include("Code parameter is required")
+        expect(response.parsed_body).to have_jsonapi_error("Code parameter is required")
       end
     end
 
@@ -47,7 +47,7 @@ RSpec.describe Api::V1::SimulatorController, type: :request do
       it "returns service unavailable error" do
         post "/api/v1/simulator/verilogcv", params: { code: code }
         expect(response.status).to eq(503)
-        expect(response.parsed_body["errors"]).to include("Verilog synthesis service returned an error")
+        expect(response.parsed_body).to have_jsonapi_error("Verilog synthesis service returned an error")
       end
     end
   end

--- a/spec/requests/api/v1/simulator_controller/verilog_cv_spec.rb
+++ b/spec/requests/api/v1/simulator_controller/verilog_cv_spec.rb
@@ -9,10 +9,12 @@ RSpec.describe Api::V1::SimulatorController, type: :request do
     let(:yosys_response) { { "data" => "response_from_yosys" } }
 
     context "when YOSYS_PATH is valid and returns a successful response" do
-      let(:response_double) { instance_double(HTTP::Response, code: 200, to_s: yosys_response.to_json) }
+      let(:body_string) { yosys_response.to_json }
+      let(:response_double) { instance_double(HTTP::Response, code: 200, body: body_string) }
 
       before do
         allow(ENV).to receive(:fetch).with("YOSYS_PATH", "http://127.0.0.1:3040").and_return("http://127.0.0.1:3040")
+        allow(HTTP).to receive(:timeout).with(30).and_return(HTTP)
         allow(HTTP).to receive(:post).and_return(response_double)
       end
 
@@ -24,10 +26,11 @@ RSpec.describe Api::V1::SimulatorController, type: :request do
     end
 
     context "when YOSYS_PATH is valid but returns a failed response" do
-      let(:response_double) { instance_double(HTTP::Response, code: 500, to_s: "") }
+      let(:response_double) { instance_double(HTTP::Response, code: 500, body: "") }
 
       before do
         allow(ENV).to receive(:fetch).with("YOSYS_PATH", "http://127.0.0.1:3040").and_return("http://127.0.0.1:3040")
+        allow(HTTP).to receive(:timeout).with(30).and_return(HTTP)
         allow(HTTP).to receive(:post).and_return(response_double)
       end
 


### PR DESCRIPTION
## Fixes #6546

#### Changes I have made in this PR -

This PR adds comprehensive error handling and timeout configuration for HTTP requests to the yosys service in the `verilog_cv` method. The changes include:

- Added 30 second timeout for HTTP requests to yosys service to prevent indefinite hanging
- Handle HTTP::TimeoutError and HTTP::ConnectionError gracefully with appropriate error responses
- Return user-friendly error messages instead of crashing the application
- Log errors for debugging purposes using Rails.logger
- Applied fixes to both web interface (`SimulatorController`) and API (`Api::V1::SimulatorController`)

**Files Modified:**
- `app/controllers/simulator_controller.rb` - Added error handling to `verilog_cv` method
- `app/controllers/api/v1/simulator_controller.rb` - Added error handling to API `verilog_cv` method

### Screenshots of the UI changes (If any) -
N/A - This is a backend error handling improvement. Users will now see proper error messages instead of application crashes when the yosys service is unavailable.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself

**Explain your implementation approach:**

**Problem solved:**
The `verilog_cv` method was making HTTP requests to the yosys service without any error handling. When the service was unavailable, timed out, or encountered network errors, the application would crash with unhandled exceptions, providing a poor user experience.

**Alternative approaches considered:**
1. Using background jobs - Rejected as this would require significant refactoring and the synchronous nature is needed for immediate feedback
2. Only handling specific exceptions - Rejected as we need comprehensive error handling for all network-related failures
3. Different timeout values - Chose 30 seconds as a balance between user experience and service response time

**Why this implementation:**
- Follows existing patterns in the codebase (similar to how `OauthApiHandler` handles HTTP errors)
- Uses `HTTP.timeout(30)` which is a standard approach in the HTTP gem
- Catches specific exceptions (`HTTP::TimeoutError`, `HTTP::ConnectionError`) first, then has a catch-all for unexpected errors
- Returns appropriate HTTP status codes (503 for service unavailable, 500 for internal errors)
- Logs errors for debugging while providing user-friendly messages

**Key functions/components:**
- `HTTP.timeout(30).post()` - Sets a 30-second timeout on the HTTP request to prevent indefinite hanging
- `rescue HTTP::TimeoutError, HTTP::ConnectionError` - Handles network-related errors specifically, catching cases where the service is unreachable or takes too long
- `rescue StandardError` - Catches any unexpected errors as a safety net to prevent application crashes
- `Rails.logger.error` - Logs errors with context for debugging and monitoring in production
- `api_error()` method (in API controller) - Uses the existing API error handling pattern from `Api::V1::BaseController` for consistency
- `render json: { error: ... }, status: :service_unavailable` - Returns proper HTTP responses with user-friendly error messages

**Edge cases handled:**
- Service completely down (connection refused) - Caught by `HTTP::ConnectionError`
- Service timeout (takes too long to respond) - Caught by `HTTP::TimeoutError` after 30 seconds
- Service returns error status codes - Handled by checking response status
- Unexpected exceptions during request processing - Caught by `StandardError` rescue block
- Network interruptions - Handled by connection error rescue

**Testing approach:**
- Reviewed existing error handling patterns in the codebase (OauthApiHandler, post_issue method)
- Ensured consistency with API error response format using `api_error()` method
- Verified that error messages are user-friendly and don't expose internal details
- Confirmed proper HTTP status codes are returned (503 for service unavailable, 500 for internal errors)

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added 30s timeout protection for simulator service calls to prevent hangs.
  * Validates required input and returns 400 when missing.
  * Distinguishes success vs non-200 remote responses (returns remote body on success; reports service unavailable for remote failures/timeouts; returns 500 for unexpected errors).
  * Improved logging for diagnosis.

* **Tests**
  * Added/updated tests covering missing-parameter, success, failure and timeout behaviors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->