### PR TITLE
Fixes : #6552 [UX/Enhancement]: Improve Project Name input: add maxlength and update label

### DIFF
--- a/simulator/src/ux.js
+++ b/simulator/src/ux.js
@@ -331,7 +331,7 @@ export function showProperties(obj) {
     else if (simulationArea.lastSelected === undefined || ['Wire', 'CircuitElement', 'Node'].indexOf(simulationArea.lastSelected.objectType) !== -1) {
         $('#moduleProperty').show();
         $(moduleProperty.modulePropertyInner).append("<div class='moduleProperty-header'>" + 'Project Properties' + '</div>');
-        $(moduleProperty.modulePropertyInner).append(`<p><span>Project:</span> <input id='projname' class='objectPropertyAttribute' type='text' autocomplete='off' name='setProjectName'  value='${getProjectName() || 'Untitled'}' aria-label='project'></p>`);
+        $(moduleProperty.modulePropertyInner).append(`<p><span>Project Name:</span> <input id='projname' class='objectPropertyAttribute' type='text' maxlength="50" autocomplete='off' name='setProjectName'  value='${getProjectName() || 'Untitled'}' aria-label='project'></p>`);
         $(moduleProperty.modulePropertyInner).append(`<p><span>Circuit:</span> <input id='circname' class='objectPropertyAttribute' type='text' autocomplete='off' name='changeCircuitName'  value='${globalScope.name || 'Untitled'}' aria-label='circuit'></p>`);
         $(moduleProperty.modulePropertyInner).append(`<p><span>Clock Time (ms):</span> <input class='objectPropertyAttribute' min='50' type='number' style='width:100px' step='10' name='changeClockTime'  value='${simulationArea.timePeriod}' aria-label='clock time'></p>`);
         $(moduleProperty.modulePropertyInner).append(`<p><span>Clock Enabled:</span> <label class='switch'> <input type='checkbox' ${['', 'checked'][simulationArea.clockEnabled + 0]} class='objectPropertyAttributeChecked' name='changeClockEnable' aria-label='clock enabled'> <span class='slider'></span></label></p>`);

--- a/simulator/src/ux.js
+++ b/simulator/src/ux.js
@@ -3,7 +3,7 @@
 /* eslint-disable no-restricted-syntax */
 /* eslint-disable no-restricted-syntax */
 /* eslint-disable guard-for-in */
-
+import { showMessage } from './utils';
 import { layoutModeGet } from './layoutMode';
 import {
     scheduleUpdate, wireToBeCheckedSet, updateCanvasSet, update, updateSimulationSet,
@@ -411,22 +411,30 @@ export function showProperties(obj) {
     }
 
     $('.objectPropertyAttribute').on('change keyup paste click', function () {
-        checkValidBitWidth();
-        scheduleUpdate();
-        updateCanvasSet(true);
-        wireToBeCheckedSet(1);
-        let { value } = this;
-        if (this.type === 'number') {
-            value = parseFloat(value);
-        }
-        if (simulationArea.lastSelected && simulationArea.lastSelected[this.name]) {
-            simulationArea.lastSelected[this.name](value);
-            // Commented out due to property menu refresh bug
-            // prevPropertyObjSet(simulationArea.lastSelected[this.name](this.value)) || prevPropertyObjGet();
+    checkValidBitWidth();
+    scheduleUpdate();
+    updateCanvasSet(true);
+    wireToBeCheckedSet(1);
+    if (this.id === 'projname') {
+        if (this.value.length >= 50) {
+            // Standard simulator message for character limit
+            showMessage("Character limit reached (50 characters max)");
+            $(this).css('border-color', 'red'); 
         } else {
-            circuitProperty[this.name](value);
+            $(this).css('border-color', ''); 
         }
-    });
+    }
+
+    let { value } = this;
+    if (this.type === 'number') {
+        value = parseFloat(value);
+    }
+    if (simulationArea.lastSelected && simulationArea.lastSelected[this.name]) {
+        simulationArea.lastSelected[this.name](value);
+    } else {
+        circuitProperty[this.name](value);
+    }
+});
 
     $('.objectPropertyAttributeChecked').on('change keyup paste click', function () {
         if(this.name === "toggleLabelInLayoutMode") return; // Hack to prevent toggleLabelInLayoutMode from toggling twice


### PR DESCRIPTION
Fixes CircuitVerse/cv-frontend-vue#712



#### Describe the changes you have made in this PR -
just changed the module property.modulepropertyInner from Project ---> Project Name: and add a attribute for input of maxlenght = "50"

### Screenshots of the UI changes (If any) -
before and after :
<img width="1710" height="1044" alt="image" src="https://github.com/user-attachments/assets/c60ab3fd-8d0f-4996-b1ad-deeb468d3bd1" />
<img width="1708" height="1041" alt="531635928-67990e6b-e132-40e6-8c15-42fb217cb63d" src="https://github.com/user-attachments/assets/4d85e638-1f14-4a65-843c-b2ffc94dcf20" />


---


**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- initially there was no upper limit for a project title . i changed that to 50 char and the label for project was just Project changed that to Project Name.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified project property label as "Project Name."
  * Limited project name input to 50 characters maximum.
  * Added inline validation with an error message and red border when input exceeds the limit.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->