### PR TITLE
Add Hardik Sachdeva to core team on About page

### DIFF
--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -30,7 +30,9 @@ class AboutController < ApplicationController
       { name: "Harsh Bhadu",
         img: "https://avatars.githubusercontent.com/u/102225113?v=4", link: "https://github.com/senbo1" },
       { name: "Aman Asrani",
-        img: "https://avatars.githubusercontent.com/u/96644946?v=4", link: "https://github.com/Asrani-Aman" }
+        img: "https://avatars.githubusercontent.com/u/96644946?v=4", link: "https://github.com/Asrani-Aman" },
+      { name: "Hardik Sachdeva",
+        img: "https://avatars.githubusercontent.com/u/85028179?v=4", link: "https://github.com/hardik17771" }
     ]
 
     @mentors = []


### PR DESCRIPTION
## Description
Adds Hardik Sachdeva (hardik17771) to the core team section on the About page.

## Changes Made
- Added Hardik Sachdeva's entry to the `@cores` array in [app/controllers/about_controller.rb](cci:7://file:///Users/hmshuu/Desktop/CircuitVerse/app/controllers/about_controller.rb:0:0-0:0)
- Includes name, GitHub avatar, and profile link following existing format

## Screenshots
The new team member now appears in the Core Team section on [/about](cci:7://file:///Users/hmshuu/Desktop/CircuitVerse/app/views/about:0:0-0:0) page.
<img width="521" height="327" alt="image" src="https://github.com/user-attachments/assets/b9310f8b-ccbf-488f-b143-f3e783249506" />


Fixes #6558

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new core mentor to the team roster with associated profile avatar and GitHub link information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->