### PR TITLE
fix(mailer): patch aws-actionmailer-ses to wrap recipients in array

### DIFF
--- a/config/initializers/aws_actionmailer_ses_patch.rb
+++ b/config/initializers/aws_actionmailer_ses_patch.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Monkey patch for aws-actionmailer-ses v1.0.0 to fix ArgumentError
+# The gem passes single string emails to the AWS SDK, which strictly requires arrays.
+# This patch ensures to_addresses, cc_addresses, and bcc_addresses always return arrays.
+# Remove this patch once a fixed version of aws-actionmailer-ses is released and installed.
+
+require 'aws/action_mailer/ses_v2/mailer'
+
+module Aws
+  module ActionMailer
+    module SESV2
+      class Mailer
+        private
+
+        # Original method returns message.to or message.smtp_envelope_to directly.
+        # ActionMailer can return a String or Array. AWS SDK requires Array.
+        def to_addresses(message)
+          Array(message.instance_variable_get(:@smtp_envelope_to) || message.to)
+        end
+
+        def cc_addresses(message)
+          Array(message.cc)
+        end
+
+        def bcc_addresses(message)
+          Array(message.bcc)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #6568 

### Describe the changes you have made in this PR -

This PR fixes a critical `ArgumentError` in the AWS SES email delivery flow caused by a bug in the `aws-actionmailer-ses` gem (v1.0.0).

**The Issue:**

The `aws-actionmailer-ses` gem passes the [to](cci:1://file:///d:/VsCode/CircuitVerse/config/initializers/aws_actionmailer_ses_patch.rb:15:8-19:11) address as a `String` directly to the AWS SDK when only a single recipient is present. However, the AWS SES v2 SDK (`Aws::SESV2::Client#send_email`) *strictly* requires [to_addresses](cci:1://file:///d:/VsCode/CircuitVerse/config/initializers/aws_actionmailer_ses_patch.rb:15:8-19:11) (inside the `destination` hash) to be an `Array` of strings. This mismatch causes the following error:
`ArgumentError: expected params[:destination][:to_addresses] to be an Array, got class String instead.`

**The Fix:**

I have added an initializer [config/initializers/aws_actionmailer_ses_patch.rb](cci:7://file:///d:/VsCode/CircuitVerse/config/initializers/aws_actionmailer_ses_patch.rb:0:0-0:0) that monkey-patches `Aws::ActionMailer::SESV2::Mailer`. This patch overrides the [to_addresses](cci:1://file:///d:/VsCode/CircuitVerse/config/initializers/aws_actionmailer_ses_patch.rb:15:8-19:11), [cc_addresses](cci:1://file:///d:/VsCode/CircuitVerse/config/initializers/aws_actionmailer_ses_patch.rb:21:8-23:11), and [bcc_addresses](cci:1://file:///d:/VsCode/CircuitVerse/config/initializers/aws_actionmailer_ses_patch.rb:25:8-27:11) methods to ensure they **always** wrap their output in an `Array()`. This satisfies the AWS SDK contract while allowing us to keep the required `aws-actionmailer-ses` gem (which is mandatory for `aws-sdk-rails` v5).

**References:**
1.  **AWS SDK Requirement:** The `Aws::SESV2::Client` documentation confirms [to_addresses](cci:1://file:///d:/VsCode/CircuitVerse/config/initializers/aws_actionmailer_ses_patch.rb:15:8-19:11) must be an array.
    *   *Reference:* [AWS SDK for Ruby V3 Docs - SESV2 Client](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SESV2/Client.html#send_email-instance_method)
2.  **Bug Source:** The `aws-actionmailer-ses` source code shows direct assignment without array wrapping.
    *   *Source:* [aws-actionmailer-ses/lib/aws/action_mailer/ses_v2/mailer.rb (Line 18)](https://github.com/aws/aws-actionmailer-ses-ruby/blob/v1.0.0/lib/aws/action_mailer/ses_v2/mailer.rb#L18)
    *   *Snippet:* `to_addresses: to_addresses(message)` where [to_addresses](cci:1://file:///d:/VsCode/CircuitVerse/config/initializers/aws_actionmailer_ses_patch.rb:15:8-19:11) returns `message.to` (which can be a String).
   
### Screenshots of the UI changes (If any) -

N/A

---
## Code Understanding and AI Usage
**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)
**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I chose a monkey-patch approach because removing the `aws-actionmailer-ses` gem is not an option; it is the official component for SES integration with `aws-sdk-rails` v5. Since the gem itself is buggy (version 1.0.0), patching the specific methods to force array conversion is the cleanest way to resolve the crash without forking the entire gem or waiting for an upstream release.

---
## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an error that occurred when sending emails with recipient address fields, ensuring proper handling of To, Cc, and Bcc addresses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->