### PR TITLE
Remove FIXME comments and temporary workarounds

### DIFF
--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -182,9 +182,8 @@ class Api::V1::ProjectsController < Api::V1::BaseController
 
     # Update circuit data Related methods
 
-    # FIXME: remove this logic after fixing production data
     def set_user_project
-      @project = current_user.projects.friendly.find_by(id: params[:id]) || Project.friendly.find(params[:id])
+      @project = current_user.projects.friendly.find(params[:id])
     end
 
     def build_project_datum

--- a/app/controllers/simulator_controller.rb
+++ b/app/controllers/simulator_controller.rb
@@ -136,9 +136,8 @@ class SimulatorController < ApplicationController
       @project = Project.friendly.find(params[:id])
     end
 
-    # FIXME: remove this logic after fixing production data
     def set_user_project
-      @project = current_user.projects.friendly.find_by(id: params[:id]) || Project.friendly.find(params[:id])
+      @project = current_user.projects.friendly.find(params[:id])
     end
 
     def check_edit_access

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -161,8 +161,7 @@ class Project < ApplicationRecord
     end
 
     def should_generate_new_friendly_id?
-      # FIXME: Remove extra query once production data is resolved
-      name_changed? || Project.where(slug: slug).many?
+      name_changed?
     end
 
     def purge_circuit_preview


### PR DESCRIPTION
- Remove fallback logic in set_user_project methods
- Simplify should_generate_new_friendly_id? method
- Clean up production data workarounds

---

## Describe the changes you have made in this PR

This PR addresses several FIXME comments and cleanup items related to legacy fallback logic and unnecessary workarounds:

- Removed fallback logic from `set_user_project` in both `simulator_controller.rb` and `api/v1/projects_controller.rb`.  
  The fallback paths were originally added to handle inconsistent production data, but they obscure the expected behavior and make the control flow harder to reason about. The updated logic now relies on the correct, explicit associations.

- Simplified `should_generate_new_friendly_id?` in `project.rb` by removing an extra database query.  
  The method now relies on existing state instead of re-checking conditions that are already guaranteed, improving clarity and avoiding redundant work.

- Cleaned up production data workarounds that are no longer required, making the code easier to understand and maintain.

Overall, these changes aim to reduce complexity, remove hidden behavior, and make the intent of the code more explicit.

---

## Screenshots of the UI changes (If any)

N/A — no UI changes were made.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**

- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**

- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added or modified
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The main goal was to remove temporary or defensive logic that had outlived its original purpose.

Before making changes, I reviewed how `set_user_project` is used across controllers and how projects and users are expected to be associated. This made it clear that the fallback behavior was masking data issues rather than solving them.

For `should_generate_new_friendly_id?`, I examined how `friendly_id` is configured and when this method is called. The additional query was unnecessary given the guarantees already provided by the model lifecycle, so the logic was simplified to be more direct and efficient.

Alternative approaches included keeping the fallback logic with additional comments or guards, but removing it entirely resulted in clearer, more maintainable code that better reflects the intended domain behavior.

---

## Checklist before requesting a review

- [x] I have added a proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I modified
- [x] I understand why my changes work and have tested them
- [x] I have considered potential edge cases
- [x] My code follows the project's style guidelines and conventions

---

**Note:** *Allow edits from maintainers* is enabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened security by enforcing stricter access controls on project resources, ensuring users can only access projects they own.
  * Improved system performance by eliminating unnecessary database queries during project slug generation and validation processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->