### PR TITLE
fix: prevent crash when search query contains null byte (#6612)

### DIFF
--- a/app/lib/adapters/pg_adapter.rb
+++ b/app/lib/adapters/pg_adapter.rb
@@ -49,12 +49,24 @@ module Adapters
       end
 
       def base_project_results(relation, query_params)
-        query_params[:q].present? ? relation.text_search(query_params[:q]) : Project.public_and_not_forked
+       q = query_params[:q]
+
+       return Project.public_and_not_forked if q.blank?
+       return Project.none if q.include?("\0")
+
+        relation.text_search(q)
       end
 
+
       def base_user_results(relation, query_params)
-        query_params[:q].present? ? relation.text_search(query_params[:q]) : User.all
-      end
+       q = query_params[:q]
+
+       return User.all if q.blank?
+       return User.none if q.include?("\0")
+
+       relation.text_search(q)
+     end
+
 
       def apply_sorting(relation, query_params, type)
         sort_field = sanitize_sort_field(query_params[:sort_by], type)

--- a/app/lib/adapters/pg_adapter.rb
+++ b/app/lib/adapters/pg_adapter.rb
@@ -57,16 +57,14 @@ module Adapters
         relation.text_search(q)
       end
 
-
-      def base_user_results(relation, query_params)
+     def base_user_results(relation, query_params)
        q = query_params[:q]
 
-       return User.all if q.blank?
+       return relation if q.blank?
        return User.none if q.include?("\0")
-
+  
        relation.text_search(q)
      end
-
 
       def apply_sorting(relation, query_params, type)
         sort_field = sanitize_sort_field(query_params[:sort_by], type)


### PR DESCRIPTION
Fixes #6612

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -
This PR fixes a crash in user and project search that occurred when the search
query contained a null byte (`\0`). The search logic now safely handles such
invalid input by returning an empty result set instead of raising an error.

### Screenshots of the UI changes (If any) -
No UI changes

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The issue occurred because PostgreSQL does not support escaping strings that
contain null bytes (`\0`). When a search query with a null byte was passed
to `text_search`, ActiveRecord raised an `ArgumentError`, causing the search
endpoint to crash.

To fix this, I added a defensive check in the PostgreSQL adapter methods
`base_user_results` and `base_project_results`. Before calling `text_search`,
the code now verifies whether the query is blank or contains a null byte.

If the query is blank, the existing behavior is preserved to avoid any
regressions. If the query contains a null byte, the method safely returns
an empty ActiveRecord relation instead of executing a database query.

I considered sanitizing or removing the null byte from the input, but chose
this approach because null bytes have no meaningful use in search queries
and should be treated as invalid input. This solution prevents the error
at the earliest point, keeps the fix minimal, and avoids altering valid
search behavior.

I verified the fix using the Rails console by testing both valid queries
and queries containing null bytes.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search behavior for projects and users: empty queries now return the expected default result sets, queries containing null/special characters return no results, and normal queries perform full-text search as expected.



<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->