### PR TITLE
Fix : vuesim request specs to assert rendered SPA instead of redirects

### DIFF
--- a/spec/controllers/simulator_controller_spec.rb
+++ b/spec/controllers/simulator_controller_spec.rb
@@ -145,20 +145,21 @@ describe SimulatorController, type: :request do
           get simulator_new_path
         end
 
-        it "redirects to default simulatorvue path if path is root" do
-          expect(response).to redirect_to("/simulatorvue")
+        it "renders the vue simulator" do
+          expect(response.status).to eq(200)
+          expect(response.body).to include("simulator-v0.js")
         end
       end
 
       context "when vuesim is enabled for user and user tries to edit a circuit" do
         before do
           allow(Flipper).to receive(:enabled?).with(:vuesim, @user).and_return(true)
-          get simulator_path(@project)
+          get simulator_edit_path(@project)
         end
 
-        it "redirects to the simulatorvue path with the given path" do
-          get simulator_edit_path(@project)
-          expect(response).to redirect_to("/simulatorvue/edit/#{@project.name.parameterize}")
+        it "renders the vue simulator" do
+          expect(response.status).to eq(200)
+          expect(response.body).to include("simulator-v0.js")
         end
       end
 
@@ -168,8 +169,8 @@ describe SimulatorController, type: :request do
           get simulator_path(@project)
         end
 
-        it "does not redirect to simulatorvue" do
-          expect(response).not_to("/simulatorvue")
+        it "does not render the vue simulator" do
+          expect(response.body).not_to include("simulator-v0.js")
         end
       end
     end


### PR DESCRIPTION
#### Describe the changes you have made in this PR -
This PR updates the vuesim-related request specs to align with the current simulator behavior.

The Vue-based simulator renders a Single Page Application (SPA) with a `200 OK` response instead of performing HTTP redirects. Existing specs were asserting redirects to `/simulatorvue`, which no longer reflect the actual behavior and caused test failures.

The specs have been updated to assert that the SPA is rendered successfully rather than expecting redirects.

### Screenshots of the UI changes (If any) -
<img width="1395" height="728" alt="Screenshot 2026-01-13 142605" src="https://github.com/user-attachments/assets/69638e3b-5a4c-41f9-9399-232302edcea5" />
<img width="1903" height="1075" alt="image" src="https://github.com/user-attachments/assets/1456593b-9835-4fc7-9110-f6aee6235375" />

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x]  No, I wrote all the code myself

**Explain your implementation approach:**
The problem was that vuesim request specs were asserting redirect responses, while the simulator controller now renders the Vue SPA directly with a successful response.

I reviewed the controller behavior and verified that the correct and intended response is an HTML SPA render with status `200`. Based on this, I updated the request specs to assert rendered content instead of redirects.

No production code was changed. Only test expectations were updated to accurately reflect existing behavior. This approach was chosen to keep the fix minimal, avoid unnecessary refactors, and ensure the specs validate real application behavior.

---

## Checklist before requesting a review
- [x]  I have added proper PR title and linked to the issue
- [x]  I have performed a self-review of my code
- [x]  **I can explain the purpose of every function, class, and logic block I added**
- [x]  I understand why my changes work and have tested them thoroughly
- [x]  My code follows the project's style guidelines and conventions
---

**CI Notes**
Ruby CI / coverage failures are pre-existing on the base branch and are unrelated to this change.

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated simulator controller tests to verify direct rendering of the Vue simulator instead of redirect-based behavior.
  * Adjusted test cases for simulator initialization and circuit editing workflows to confirm proper rendering response handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->