### PR TITLE
Fix ArgumentError from malformed page parameter in ContestsController

### DIFF
--- a/app/controllers/admin/contests_controller.rb
+++ b/app/controllers/admin/contests_controller.rb
@@ -6,7 +6,7 @@ class Admin::ContestsController < ApplicationController
   before_action :authorize_admin
 
   def index
-    @contests = Contest.order(id: :desc).paginate(page: params[:page]).limit(Contest.per_page)
+    @contests = Contest.order(id: :desc).paginate(page: sanitize_page).limit(Contest.per_page)
   end
 
   def create
@@ -21,7 +21,7 @@ class Admin::ContestsController < ApplicationController
       ContestScheduler.call(@contest)
       redirect_to contest_path(@contest), notice: t(".success")
     else
-      @contests = Contest.order(id: :desc).paginate(page: params[:page]).limit(Contest.per_page)
+      @contests = Contest.order(id: :desc).paginate(page: sanitize_page).limit(Contest.per_page)
       render :index, status: :unprocessable_content
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -77,4 +77,11 @@ class ApplicationController < ActionController::Base
         "tag" => params[:tag]
       }
     end
+
+    # Sanitizes the page parameter to prevent ArgumentError from non-numeric values
+    # Returns a valid page number (minimum 1)
+    def sanitize_page
+      page = params[:page].to_i
+      [page, 1].max
+    end
 end

--- a/app/controllers/contests_controller.rb
+++ b/app/controllers/contests_controller.rb
@@ -8,7 +8,7 @@ class ContestsController < ApplicationController
 
   def index
     @contests = Contest.order(id: :desc)
-                       .paginate(page: params[:page])
+                       .paginate(page: sanitize_page)
                        .limit(Contest.per_page)
 
     respond_to do |format|
@@ -22,7 +22,7 @@ class ContestsController < ApplicationController
     @user_submission = @contest.submissions.where(user_id: current_user&.id)
     @submissions     = @contest.submissions
                                .where.not(user_id: current_user&.id)
-                               .paginate(page: params[:page])
+                               .paginate(page: sanitize_page)
                                .limit(6)
 
     return unless @contest.completed? && Submission.exists?(contest_id: @contest.id)


### PR DESCRIPTION
## Description
Fixes #6583

This PR adds a defensive fix to prevent `ArgumentError: invalid value for Integer()` when non-numeric page parameters (e.g., `"JJJ2QQQ"`) are passed to the contests pagination.

## Changes
- Added `sanitize_page` helper method in `ApplicationController` that safely converts `params[:page]` to a valid integer, defaulting to page 1 for invalid values
- Updated `ContestsController#index` and `#show` to use `sanitize_page`
- Updated `Admin::ContestsController#index` and `#create` to use `sanitize_page`

## How it works
- `"JJJ2QQQ".to_i` returns `0` (Ruby's safe string-to-integer conversion)
- `[0, 1].max` returns `1` (falls back to page 1)
- Valid page numbers like `"5"` continue to work normally

## Verification
- [x] RuboCop passes with no offenses
- [x] Fix verified locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced pagination validation across contest listings and submissions to ensure page parameters are properly validated. This prevents invalid page values from causing display errors on both user-facing and administrative sections.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->