### PR TITLE
Fix broken localhost Markdown link in .otel/README.md

### DIFF
--- a/.otel/README.md
+++ b/.otel/README.md
@@ -16,7 +16,8 @@ cd .otel
 docker compose up -d
 ```
 
-Navigate to [http://localhost:16686/](http://localhost:16686/) to view the Jaeger UI dashboard and view the traces.
+Navigate to http://localhost:16686/ to view the Jaeger UI dashboard and view the traces.
+
 
 ## New Relic OpenTelemetry
 


### PR DESCRIPTION
This PR fixes a duplicated and incorrectly formatted Markdown link for `http://localhost:16686/` in `.otel/README.md`.

✔ Removed redundant duplicate Markdown wrapper  
✔ Cleaned up link formatting  
✔ Improves documentation readability  
✔ No code changes and no effect on tests

A small but useful documentation cleanup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated URL formatting in OpenTelemetry documentation for improved readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->