### PR TITLE
perf: fix N+1 query on user profile page (#6637)

### DIFF
--- a/app/controllers/users/circuitverse_controller.rb
+++ b/app/controllers/users/circuitverse_controller.rb
@@ -11,9 +11,9 @@ class Users::CircuitverseController < ApplicationController
 
   def index
     @profile = ProfileDecorator.new(@user)
-    @projects = @user.rated_projects.with_attached_circuit_preview
-    @user_projects = @user.projects.with_attached_circuit_preview
-    @collaborated_projects = @user.collaborated_projects.with_attached_circuit_preview
+    @projects = @user.rated_projects.with_attached_circuit_preview.includes(:collaborations)
+    @user_projects = @user.projects.with_attached_circuit_preview.includes(:collaborations)
+    @collaborated_projects = @user.collaborated_projects.with_attached_circuit_preview.includes(:collaborations)
   end
 
   def edit; end

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -31,61 +31,61 @@ class ProjectPolicy < ApplicationPolicy
       author_access? ||
       mentor_access? ||
       collaborator_access? ||
-      (user.present? && user.admin)
+      (user.present? && user.admin?)
   end
 
   def check_direct_view_access?
     project.project_access_type == "Public" ||
       (project.project_submission == false && author_access?) ||
       collaborator_access? ||
-      (user.present? && user.admin)
+      (user.present? && user.admin?)
   end
 
   private
 
-  def mentor_access?
-    return false if user.nil? || project.assignment_id.nil?
+    def mentor_access?
+      return false if user.nil? || project.assignment_id.nil?
 
-    group = project.assignment.group
-    group.primary_mentor_id == user.id ||
-      group.group_members.exists?(user_id: user.id, mentor: true)
-  end
+      group = project.assignment.group
+      group.primary_mentor_id == user.id ||
+        group.group_members.exists?(user_id: user.id, mentor: true)
+    end
 
-  def collaborator_access?
-    return false if user.nil?
+    def collaborator_access?
+      return false if user.nil?
 
-    project.collaborations.any? { |c| c.user_id == user.id }
-  end
+      project.collaborations.any? { |c| c.user_id == user.id }
+    end
 
-  def edit_access?
-    raise @simulator_exception unless user_access?
+    def edit_access?
+      raise @simulator_exception unless user_access?
 
-    true
-  end
+      true
+    end
 
-  def view_access?
-    raise @simulator_exception unless check_view_access?
+    def view_access?
+      raise @simulator_exception unless check_view_access?
 
-    true
-  end
+      true
+    end
 
-  def direct_view_access?
-    raise @simulator_exception unless check_direct_view_access?
+    def direct_view_access?
+      raise @simulator_exception unless check_direct_view_access?
 
-    true
-  end
+      true
+    end
 
-  def embed?
-    raise @simulator_exception unless project.project_access_type != "Private"
+    def embed?
+      raise @simulator_exception unless project.project_access_type != "Private"
 
-    true
-  end
+      true
+    end
 
-  def create_fork?
-    project.assignment_id.nil?
-  end
+    def create_fork?
+      project.assignment_id.nil?
+    end
 
-  def author_access?
-    (user.present? && user.admin?) || project.author_id == (user.present? && user.id)
-  end
+    def author_access?
+      (user.present? && user.admin?) || project.author_id == (user.present? && user.id)
+    end
 end

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -23,7 +23,7 @@ class ProjectPolicy < ApplicationPolicy
     return false if user.nil? || project.project_submission
 
     project.author_id == user.id ||
-      Collaboration.exists?(project_id: project.id, user_id: user.id)
+      project.collaborations.any? { |c| c.user_id == user.id }
   end
 
   def check_view_access?
@@ -32,14 +32,14 @@ class ProjectPolicy < ApplicationPolicy
       (!user.nil? && !project.assignment_id.nil? &&
       ((project.assignment.group.primary_mentor_id == user.id) ||
       project.assignment.group.group_members.exists?(user_id: user.id, mentor: true))) ||
-      (!user.nil? && Collaboration.exists?(project_id: project.id, user_id: user.id)) ||
+      (!user.nil? && project.collaborations.any? { |c| c.user_id == user.id }) ||
       (!user.nil? && user.admin)
   end
 
   def check_direct_view_access?
     project.project_access_type == "Public" ||
       (project.project_submission == false && !user.nil? && project.author_id == user.id) ||
-      (!user.nil? && Collaboration.exists?(project_id: project.id, user_id: user.id)) ||
+      (!user.nil? && project.collaborations.any? { |c| c.user_id == user.id }) ||
       (!user.nil? && user.admin)
   end
 

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -23,24 +23,38 @@ class ProjectPolicy < ApplicationPolicy
     return false if user.nil? || project.project_submission
 
     project.author_id == user.id ||
-      project.collaborations.any? { |c| c.user_id == user.id }
+      collaborator_access?
   end
 
   def check_view_access?
     project.project_access_type != "Private" ||
-      (!user.nil? && project.author_id == user.id) ||
-      (!user.nil? && !project.assignment_id.nil? &&
-      ((project.assignment.group.primary_mentor_id == user.id) ||
-      project.assignment.group.group_members.exists?(user_id: user.id, mentor: true))) ||
-      (!user.nil? && project.collaborations.any? { |c| c.user_id == user.id }) ||
-      (!user.nil? && user.admin)
+      author_access? ||
+      mentor_access? ||
+      collaborator_access? ||
+      (user.present? && user.admin)
   end
 
   def check_direct_view_access?
     project.project_access_type == "Public" ||
-      (project.project_submission == false && !user.nil? && project.author_id == user.id) ||
-      (!user.nil? && project.collaborations.any? { |c| c.user_id == user.id }) ||
-      (!user.nil? && user.admin)
+      (project.project_submission == false && author_access?) ||
+      collaborator_access? ||
+      (user.present? && user.admin)
+  end
+
+  private
+
+  def mentor_access?
+    return false if user.nil? || project.assignment_id.nil?
+
+    group = project.assignment.group
+    group.primary_mentor_id == user.id ||
+      group.group_members.exists?(user_id: user.id, mentor: true)
+  end
+
+  def collaborator_access?
+    return false if user.nil?
+
+    project.collaborations.any? { |c| c.user_id == user.id }
   end
 
   def edit_access?

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -29,9 +29,7 @@ class ProjectPolicy < ApplicationPolicy
   def check_view_access?
     project.project_access_type != "Private" ||
       (!user.nil? && project.author_id == user.id) ||
-      (!user.nil? && !project.assignment_id.nil? &&
-      ((project.assignment.group.primary_mentor_id == user.id) ||
-      project.assignment.group.group_members.exists?(user_id: user.id, mentor: true))) ||
+      mentor_access? ||
       (!user.nil? && project.collaborations.any? { |c| c.user_id == user.id }) ||
       (!user.nil? && user.admin)
   end
@@ -74,4 +72,12 @@ class ProjectPolicy < ApplicationPolicy
   def author_access?
     (user.present? && user.admin?) || project.author_id == (user.present? && user.id)
   end
+
+  private
+
+    def mentor_access?
+      !user.nil? && !project.assignment_id.nil? &&
+        ((project.assignment.group.primary_mentor_id == user.id) ||
+        project.assignment.group.group_members.exists?(user_id: user.id, mentor: true))
+    end
 end


### PR DESCRIPTION
Fixes #6637

#### Describe the changes you have made in this PR -

This PR fixes an N+1 query issue on the user profile page.
Previously, for each project displayed on the profile page (User Projects, Rated Projects, Collaborated Projects), the `ProjectPolicy` was triggering a separate database query (`SELECT 1 FROM collaborations ...`) to check for access permissions.

Changes implemented:
1.  **Eager Loading**: Modified `Users::CircuitverseController#index` to eager-load the `collaborations` association for `@projects`, `@user_projects`, and `@collaborated_projects`.
2.  **In-Memory Check**: Updated `ProjectPolicy` (`check_edit_access?`, `check_view_access?`, `check_direct_view_access?`) to use the loaded `collaborations` association (`project.collaborations.any? { |c| c.user_id == user.id }`) instead of querying the database directly (`Collaboration.exists?`).
3.  **Refactoring**: Extracted complex logic for mentor access into a private method `mentor_access?` in `ProjectPolicy` to improve code readability and satisfy complexity metrics.

This ensures that collaboration data is fetched in a single query per project list, significantly reducing the number of database queries and improving page load performance.

### Screenshots of the UI changes (If any) -
<!-- Do not add code diff here -->
No UI changes. Performance improvement only.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->
The problem was that the `ProjectPolicy` was performing a database query to check for collaborations for every project in the list view. By eager loading `collaborations` in the controller and switching to `any?` on the association in the policy, we utilize Rails' eager loading mechanism to fetch all necessary data upfront. This is the standard "Rails way" to solve N+1 queries. I considered just eager loading, but without changing the policy to use the association, Rails might still have triggered queries if `exists?` was called on the relation directly. Using `any?` on the association ensures we use the loaded data.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Faster loading of project lists and previews, especially for shared and collaborated projects.

* **Bug Fixes / Access Controls**
  * More consistent and reliable view/edit permissions for authors, mentors, collaborators, and admins, reducing incorrect access or unexpected restrictions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->