### PR TITLE
Add database indexes to improve search performance

### DIFF
--- a/db/migrate/20260115164742_add_search_performance_indexes.rb
+++ b/db/migrate/20260115164742_add_search_performance_indexes.rb
@@ -1,0 +1,17 @@
+class AddSearchPerformanceIndexes < ActiveRecord::Migration[7.0]
+  def change
+    add_index :projects, :view
+    add_index :projects, :stars_count
+    add_index :projects, :created_at
+
+    add_index :users, :projects_count
+    add_index :users, :created_at
+
+    add_index :users, "LOWER(country)", name: "index_users_on_lower_country"
+
+    enable_extension "pg_trgm" unless extension_enabled?("pg_trgm")
+    add_index :users, :educational_institute,
+              using: :gin,
+              opclass: :gin_trgm_ops
+  end
+end

--- a/db/migrate/20260115164742_add_search_performance_indexes.rb
+++ b/db/migrate/20260115164742_add_search_performance_indexes.rb
@@ -1,17 +1,42 @@
+# frozen_string_literal: true
+
 class AddSearchPerformanceIndexes < ActiveRecord::Migration[7.0]
-  def change
-    add_index :projects, :view
-    add_index :projects, :stars_count
-    add_index :projects, :created_at
+  disable_ddl_transaction!
 
-    add_index :users, :projects_count
-    add_index :users, :created_at
+  def up
+    add_index :projects, :view,
+              algorithm: :concurrently, if_not_exists: true
+    add_index :projects, :stars_count,
+              algorithm: :concurrently, if_not_exists: true
+    add_index :projects, :created_at,
+              algorithm: :concurrently, if_not_exists: true
 
-    add_index :users, "LOWER(country)", name: "index_users_on_lower_country"
+    add_index :users, :projects_count,
+              algorithm: :concurrently, if_not_exists: true
+    add_index :users, :created_at,
+              algorithm: :concurrently, if_not_exists: true
 
-    enable_extension "pg_trgm" unless extension_enabled?("pg_trgm")
+    add_index :users, "LOWER(country)",
+              name: "index_users_on_lower_country",
+              algorithm: :concurrently,
+              if_not_exists: true
+
+    enable_extension "pg_trgm"
+
     add_index :users, :educational_institute,
               using: :gin,
-              opclass: :gin_trgm_ops
+              opclass: :gin_trgm_ops,
+              algorithm: :concurrently,
+              if_not_exists: true
+  end
+
+  def down
+    remove_index :users, :educational_institute, if_exists: true
+    remove_index :users, name: "index_users_on_lower_country", if_exists: true
+    remove_index :users, :created_at, if_exists: true
+    remove_index :users, :projects_count, if_exists: true
+    remove_index :projects, :created_at, if_exists: true
+    remove_index :projects, :stars_count, if_exists: true
+    remove_index :projects, :view, if_exists: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_31_010356) do
+ActiveRecord::Schema[8.0].define(version: 2026_01_15_164742) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 


### PR DESCRIPTION
Fixes : #6632 

### Context
Sentry reports `PG::QueryCanceled: canceling statement due to statement timeout`
during search in production.

### Root cause
Search queries use filtering and sorting on columns without indexes, causing
full-table scans and expensive sorts on large datasets.

### Fix
Adds missing database indexes used by existing search filters and sorting.
This improves query performance and prevents Postgres statement timeouts.

### Notes
- No logic or UI changes
- Migration-only fix
- Search behavior remains unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved database indexing and search behavior: faster project listings, filters, and user profile lookups; enhanced fuzzy matching for educational institute and country searches; safer, non-blocking index updates to reduce deployment impact.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->