### PR TITLE
Fix N+1 query in search by eager loading circuit_preview

### DIFF
--- a/app/lib/adapters/pg_adapter.rb
+++ b/app/lib/adapters/pg_adapter.rb
@@ -25,7 +25,7 @@ module Adapters
         base_results: base_project_results(relation, query_params),
         query_params: query_params,
         type: :project,
-        includes: %i[tags author]
+        includes: [:tags, :author, { circuit_preview_attachment: :blob }]
       )
     end
 

--- a/spec/lib/adapters/pg_adapter_spec.rb
+++ b/spec/lib/adapters/pg_adapter_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe Adapters::PgAdapter do
 
       it "performs text search and returns paginated results" do
         allow(project_relation).to receive(:text_search).with("test").and_return(mock_results)
-        allow(mock_results).to receive(:includes).with(:tags, :author).and_return(mock_results)
+        allow(mock_results).to receive(:includes)
+          .with(:tags, :author, { circuit_preview_attachment: :blob }).and_return(mock_results)
         allow(mock_results).to receive(:paginate).with(page: 1, per_page: 9).and_return(paginated_results)
 
         result = adapter.search_project(project_relation, query_params)
@@ -39,7 +40,8 @@ RSpec.describe Adapters::PgAdapter do
 
       it "returns public projects and applies pagination" do
         allow(Project).to receive(:public_and_not_forked).and_return(mock_results)
-        allow(mock_results).to receive(:includes).with(:tags, :author).and_return(mock_results)
+        allow(mock_results).to receive(:includes)
+          .with(:tags, :author, { circuit_preview_attachment: :blob }).and_return(mock_results)
         allow(mock_results).to receive(:paginate).with(page: 1, per_page: 9).and_return(paginated_results)
 
         result = adapter.search_project(project_relation, query_params)


### PR DESCRIPTION
Add circuit_preview_attachment with its blob to the includes array in PgAdapter#search_project to prevent N+1 queries when rendering ProjectCardComponent which accesses project.circuit_preview.attached?

Fixes Sentry issue CIRCUITVERSE-CORE-X0

Fixes #6605 
Fixes #6694 
Fixes #6697 

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -

This PR fixes an N+1 query issue reported by Sentry in the project search functionality. 

**Problem:** When searching for projects, each project card checks `project.circuit_preview.attached?` which triggers a separate database query to `active_storage_attachments` for each project in the results.

**Solution:** Added `{ circuit_preview_attachment: :blob }` to the `includes` array in `PgAdapter#search_project` to eager load Active Storage attachments in a single query.

**Files changed:**
- [app/lib/adapters/pg_adapter.rb](cci:7://file:///Users/hmshuu/Desktop/CircuitVerse/app/lib/adapters/pg_adapter.rb:0:0-0:0) - Added eager loading for circuit_preview attachment
- [spec/lib/adapters/pg_adapter_spec.rb](cci:7://file:///Users/hmshuu/Desktop/CircuitVerse/spec/lib/adapters/pg_adapter_spec.rb:0:0-0:0) - Updated test expectations

### Screenshots of the UI changes (If any) -
N/A - This is a backend performance fix with no UI changes.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

- **Problem:** Sentry reported repeated queries to `active_storage_attachments` during project search - a classic N+1 query pattern.
- **Root cause:** `PgAdapter#search_project` only eager-loaded `[:tags, :author]`, but [ProjectCardComponent](cci:2://file:///Users/hmshuu/Desktop/CircuitVerse/app/components/project/project_card_component.rb:2:0-15:3) accesses `project.circuit_preview.attached?` for each project.
- **Alternative considered:** Could have used `with_attached_circuit_preview` scope, but directly adding to `includes` is cleaner and consistent with existing code patterns.
- **Solution:** Added `{ circuit_preview_attachment: :blob }` to the includes - this is the standard Rails pattern for eager loading Active Storage attachments with their associated blobs in a single query.
- **Verification:** Confirmed `circuit_preview` is the only attachment used in search cards by searching for other patterns (`thumbnail`, `cover`, `image`) and checking the Project model.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Search now preloads additional related preview data to reduce latency and improve result loading consistency.
* **Tests**
  * Test suite updated to reflect the expanded data preloading for search, ensuring stable behavior and expectations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->