### PR TITLE
docs: add Humans of CircuitVerse page

### DIFF
--- a/docs/HUMANS_OF_CIRCUITVERSE.md
+++ b/docs/HUMANS_OF_CIRCUITVERSE.md
@@ -16,7 +16,7 @@ This page highlights the people behind the code, documentation, design, and comm
 ## 🧑‍💻 Contributors
 
 ### Example Contributor
-- **GitHub**: https://github.com/example
+- **GitHub**: [https://github.com/example](https://github.com/example)
 - **Areas**: Documentation
 - **About**: Helped improve documentation clarity.
 


### PR DESCRIPTION
This PR adds a new documentation page: `HUMANS_OF_CIRCUITVERSE.md`.

The goal of this page is to highlight and appreciate contributors behind
CircuitVerse, including documentation, design, and community contributors.

### What this PR includes
- A clear purpose for contributor recognition
- A simple, markdown-based structure
- Instructions for contributors to add themselves easily

This helps improve community visibility and encourages new contributors.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Humans of CircuitVerse" documentation page showcasing community contributors, including an example contributor entry and step-by-step instructions for adding yourself, enabling easier sharing of member stories and involvement with the project.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->