### PR TITLE
Fix: Center align navbar logo in API docs (Fixes #6620)

### DIFF
--- a/apidoc/v1/index.html
+++ b/apidoc/v1/index.html
@@ -208,7 +208,7 @@
         <img src="images/navbar-cad8cdcb.png" alt="Navbar" />
       </span>
     </a>
-    <div class="toc-wrapper">
+    <div class="toc-wrapper style="text-align: center;">
       <img src="images/logo-1229a552.png" class="logo" alt="Logo" />
         <div class="lang-selector">
               <a href="#" data-language-name="http">http</a>

--- a/apidoc/v1/index.html
+++ b/apidoc/v1/index.html
@@ -208,7 +208,7 @@
         <img src="images/navbar-cad8cdcb.png" alt="Navbar" />
       </span>
     </a>
-    <div class="toc-wrapper style="text-align: center;">
+    <div class="toc-wrapper" style="text-align: center;">
       <img src="images/logo-1229a552.png" class="logo" alt="Logo" />
         <div class="lang-selector">
               <a href="#" data-language-name="http">http</a>


### PR DESCRIPTION
Fixes #6620

### Description
The navbar logo in the API documentation (`apidoc/v1/index.html`) was left-aligned, which looked inconsistent with the design.

### Changes Proposed
- Added `text-align: center;` to the `.toc-wrapper` div.
- This centers the logo and sidebar header content without breaking the page layout (unlike previous attempts with flexbox).

### Screenshots
<img width="1917" height="971" alt="Screenshot 2026-01-21 015814" src="https://github.com/user-attachments/assets/27cc0c46-e240-41f0-881c-9bc2de1837b8" />

### Checklist
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have tested the changes in the browser

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Centered the table-of-contents area in the API documentation to improve layout and visual balance. No functional or API behavior changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->