### PR TITLE
fix: prevent Regexp::TimeoutError in auto_link  

### DIFF
--- a/app/helpers/safe_auto_link_helper.rb
+++ b/app/helpers/safe_auto_link_helper.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module SafeAutoLinkHelper
+  # Maximum number of characters to process with auto_link to prevent ReDoS attacks
+  # Note: This refers to character count, not byte length
+  MAX_AUTO_LINK_LENGTH = 10_000
+
+  # Timeout in seconds for auto_link processing
+  AUTO_LINK_TIMEOUT = 2
+
+  # Safely converts URLs in text to clickable links with timeout and length protection
+  # to prevent Regexp::TimeoutError (ReDoS attacks)
+  #
+  # @param text [String] the text to process
+  # @param options [Hash] options to pass to auto_link
+  # @return [String] the text with URLs converted to links, or sanitized original text on failure
+  def safe_auto_link(text, options = {})
+    return "" if text.blank?
+    return sanitized_truncated_text(text) if text.length > MAX_AUTO_LINK_LENGTH
+
+    Timeout.timeout(AUTO_LINK_TIMEOUT) { auto_link(text, options) }
+  rescue Timeout::Error, Regexp::TimeoutError => e
+    Rails.logger.warn("SafeAutoLinkHelper: Timeout while processing auto_link - #{e.class}")
+    sanitized_truncated_text(text)
+  rescue StandardError => e
+    Rails.logger.error("SafeAutoLinkHelper: Unexpected error - #{e.class}\n#{Array(e.backtrace).first(5).join("\n")}")
+    sanitized_truncated_text(text)
+  end
+
+  private
+
+    def sanitized_truncated_text(text)
+      h(text.truncate(MAX_AUTO_LINK_LENGTH, omission: "... [content truncated]"))
+    end
+end

--- a/app/views/commontator/comments/_body.html.erb
+++ b/app/views/commontator/comments/_body.html.erb
@@ -3,4 +3,4 @@
   comment
 %>
 
-<%= auto_link(comment.body) %>
+<%= safe_auto_link(comment.body) %>

--- a/spec/helpers/safe_auto_link_helper_spec.rb
+++ b/spec/helpers/safe_auto_link_helper_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SafeAutoLinkHelper, type: :helper do
+  describe "#safe_auto_link" do
+    context "with normal text containing URLs" do
+      it "converts URLs to links" do
+        text = "Check out https://circuitverse.org for more info"
+        result = helper.safe_auto_link(text)
+
+        expect(result).to include('href="https://circuitverse.org"')
+        expect(result).to include("Check out")
+      end
+
+      it "converts multiple URLs to links" do
+        text = "Visit https://example.com and https://test.com"
+        result = helper.safe_auto_link(text)
+
+        expect(result).to include('href="https://example.com"')
+        expect(result).to include('href="https://test.com"')
+      end
+
+      it "forwards options to auto_link" do
+        text = "Visit https://example.com"
+        result = helper.safe_auto_link(text, html: { target: "_blank", rel: "noopener" })
+
+        expect(result).to include('target="_blank"')
+        expect(result).to include('rel="noopener"')
+      end
+    end
+
+    context "with plain text without URLs" do
+      it "returns the text as-is" do
+        text = "This is plain text without any URLs"
+        result = helper.safe_auto_link(text)
+
+        expect(result).to eq(text)
+      end
+    end
+
+    context "with blank or nil input" do
+      it "returns empty string for nil" do
+        expect(helper.safe_auto_link(nil)).to eq("")
+      end
+
+      it "returns empty string for empty string" do
+        expect(helper.safe_auto_link("")).to eq("")
+      end
+
+      it "returns empty string for whitespace only" do
+        expect(helper.safe_auto_link("   ")).to eq("")
+      end
+    end
+
+    context "with very long text" do
+      it "truncates text exceeding MAX_AUTO_LINK_LENGTH" do
+        long_text = "a" * 15_000
+        result = helper.safe_auto_link(long_text)
+
+        expect(result.length).to eq(SafeAutoLinkHelper::MAX_AUTO_LINK_LENGTH)
+        expect(result).to include("[content truncated]")
+      end
+
+      it "processes text exactly at MAX_AUTO_LINK_LENGTH without truncation" do
+        exact_length_text = "a" * SafeAutoLinkHelper::MAX_AUTO_LINK_LENGTH
+        result = helper.safe_auto_link(exact_length_text)
+
+        expect(result).not_to include("[content truncated]")
+        expect(result.length).to eq(SafeAutoLinkHelper::MAX_AUTO_LINK_LENGTH)
+      end
+    end
+
+    context "when timeout occurs" do
+      before do
+        allow(Timeout).to receive(:timeout).and_raise(Timeout::Error)
+      end
+
+      it "returns sanitized text on timeout" do
+        text = "<script>alert('xss')</script> with https://example.com"
+        result = helper.safe_auto_link(text)
+
+        # Should return escaped text, not raise error
+        expect(result).to be_present
+        expect(result).not_to include("<script>")
+        expect(result).to include("&lt;script&gt;")
+      end
+
+      it "logs a warning on timeout" do
+        allow(Rails.logger).to receive(:warn)
+
+        helper.safe_auto_link("test text")
+
+        expect(Rails.logger).to have_received(:warn).with(/Timeout while processing auto_link/)
+      end
+    end
+
+    context "when Regexp::TimeoutError occurs" do
+      # Regexp::TimeoutError is raised directly by regex operations inside
+      # auto_link, not by Timeout.timeout itself. We mock it via
+      # Timeout.timeout here only as a convenient injection point.
+      before do
+        allow(Timeout).to receive(:timeout).and_raise(Regexp::TimeoutError)
+      end
+
+      it "returns sanitized text on regexp timeout" do
+        text = "Some text"
+        result = helper.safe_auto_link(text)
+
+        expect(result).to be_present
+      end
+    end
+
+    context "with potentially malicious input" do
+      it "escapes HTML in fallback" do
+        allow(Timeout).to receive(:timeout).and_raise(Timeout::Error)
+
+        text = "<script>alert('xss')</script>"
+        result = helper.safe_auto_link(text)
+
+        expect(result).not_to include("<script>")
+        expect(result).to include("&lt;script&gt;")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add safe_auto_link wrapper with timeout and length limits

Fixes #6693

#### Describe the changes you have made in this PR -

### Summary
The existing `auto_link` call was triggering `Regexp::TimeoutError` for certain comment bodies, which resulted in **500 errors** (Sentry: **CIRCUITVERSE-CORE-XR**).  
This PR introduces a safe wrapper to prevent crashes and ensure comments still render safely.

### Changes
- Added **`SafeAutoLinkHelper`** with a new method: `safe_auto_link(text)`
  - **Timeout protection:** 2 seconds
  - **Length limit:** 10,000 characters
  - **Graceful fallback:** returns sanitized plain text if auto-linking fails
  - **Error logging:** logs failures for monitoring/debugging
- Updated `/_body.html.erb` to use `safe_auto_link` instead of directly calling `auto_link`
- Added **11 tests** to cover edge cases and ensure safe behavior

### Screenshots of the UI changes (If any) -
N/A — No UI changes, this is a backend safety fix.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

---

## Testing
- `11 examples, 0 failures`

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Comments now use a safer URL-to-link conversion that sanitizes output, truncates excessively long content with a notice, and falls back gracefully on processing timeouts or errors to avoid disruption.

* **Tests**
  * Added comprehensive tests for the safe linking behavior covering normal cases, multiple URLs, long inputs, timeouts, error fallbacks, and security (HTML-escaping).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->