### PR TITLE
fix: typeahead query timeout

### DIFF
--- a/spec/controllers/users_circuitverse_controller_spec.rb
+++ b/spec/controllers/users_circuitverse_controller_spec.rb
@@ -19,6 +19,46 @@ describe Users::CircuitverseController, type: :request do
     expect(response.status).to eq(301)
   end
 
+  describe "#typeahead_educational_institute" do
+    before do
+      @user_mit = FactoryBot.create(:user, educational_institute: "Massachusetts Institute of Technology")
+      @user_stanford = FactoryBot.create(:user, educational_institute: "Stanford University")
+      @user_nil = FactoryBot.create(:user, educational_institute: nil)
+    end
+
+    it "returns matching educational institutes" do
+      get "/educational_institute/typeahead/Massachusetts"
+      expect(response.status).to eq(200)
+      json_response = response.parsed_body
+      expect(json_response).to be_an(Array)
+    end
+
+    it "returns empty array for short queries" do
+      get "/educational_institute/typeahead/M"
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq([])
+    end
+
+    it "returns empty array for blank queries" do
+      get "/educational_institute/typeahead/%20"
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq([])
+    end
+
+    it "handles special characters safely" do
+      get "/educational_institute/typeahead/test%27%22%3B"
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to be_an(Array)
+    end
+
+    it "does not return nil educational institutes" do
+      get "/educational_institute/typeahead/University"
+      json_response = response.parsed_body
+      names = json_response.pluck("name")
+      expect(names).not_to include(nil)
+    end
+  end
+
   describe "#groups" do
     before do
       sign_out @user


### PR DESCRIPTION
Fixes #6712

#### Describe the changes you have made in this PR -
This PR fixes frequent `PG::QueryCanceled` timeouts in the `typeahead_educational_institute` endpoint by optimizing the search query and adding safeguards to prevent expensive requests from reaching the database.

The previous implementation used `LIKE '%query%'`, which caused full table scans and resulted in slow queries under load. This PR switches the endpoint to use the existing GIN-indexed full-text search column, adds input validation + caching, and gracefully handles query timeouts.

### Screenshots of the UI changes (If any) -
N/A (No UI changes)

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**Explain your implementation approach:**
This PR solves the timeout issue in the institute typeahead by replacing an expensive wildcard `LIKE` search with indexed full-text search.

**Alternative approaches considered:**
- Adding/optimizing indexes for `LIKE` queries (not effective with leading `%`)
- Increasing DB statement timeout (does not solve the root cause)
- Only limiting result size (query would still remain costly)

**Why this implementation was chosen:**
The project already maintains a GIN-indexed searchable `tsvector` column. Using full-text search allows Postgres to leverage the index properly, making the endpoint fast and stable.

**Key changes included:**
- Updated query logic to use the existing full-text searchable `tsvector` column
- Added input validation (minimum 2 characters + sanitization) to avoid unnecessary heavy queries
- Added 5-minute caching to reduce repeated DB hits for common searches
- Added safe handling for canceled/timeout queries by returning an empty array
- Filtered out nil/blank educational institute values before returning results

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Typeahead now trims input, enforces a 2-character minimum, safely handles special characters, excludes empty/null names, and returns empty results for invalid queries or timeouts.

* **Performance**
  * Search results are cached (short expiry) and result sets are limited to improve response times.

* **Tests**
  * Added tests covering matching, short/blank queries, special characters, and exclusion of nil institute names.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->