### PR TITLE
fix: project destroy timeout

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -106,15 +106,16 @@ class ProjectsController < ApplicationController
   # DELETE /projects/1
   # DELETE /projects/1.json
   def destroy
+    author = @project.author
     author_id = @project.author_id
     @project.destroy!
     respond_destroy_success(author_id)
   rescue ActiveRecord::RecordNotDestroyed => e
     Rails.logger.error("Project destroy failed: #{e.message}")
-    respond_destroy_failure
+    respond_destroy_failure(author, @project)
   rescue ActiveRecord::QueryCanceled => e
     Rails.logger.error("Project destroy timeout: #{e.message}")
-    respond_destroy_timeout
+    respond_destroy_timeout(author, @project)
   end
 
   private
@@ -126,20 +127,20 @@ class ProjectsController < ApplicationController
       end
     end
 
-    def respond_destroy_failure
+    def respond_destroy_failure(author, project)
       respond_to do |format|
         format.html do
-          redirect_to user_project_path(@project.author, @project),
+          redirect_to user_project_path(author, project),
                       alert: "Project could not be deleted."
         end
         format.json { render json: { error: "Deletion failed" }, status: :unprocessable_entity }
       end
     end
 
-    def respond_destroy_timeout
+    def respond_destroy_timeout(author, project)
       respond_to do |format|
         format.html do
-          redirect_to user_project_path(@project.author, @project),
+          redirect_to user_project_path(author, project),
                       alert: "Project deletion timed out. Please try again."
         end
         format.json { render json: { error: "Deletion timed out" }, status: :request_timeout }

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -106,16 +106,45 @@ class ProjectsController < ApplicationController
   # DELETE /projects/1
   # DELETE /projects/1.json
   def destroy
-    @project.destroy
-    respond_to do |format|
-      format.html do
-        redirect_to user_path(@project.author_id), notice: "Project was successfully destroyed."
-      end
-      format.json { head :no_content }
-    end
+    author_id = @project.author_id
+    @project.destroy!
+    respond_destroy_success(author_id)
+  rescue ActiveRecord::RecordNotDestroyed => e
+    Rails.logger.error("Project destroy failed: #{e.message}")
+    respond_destroy_failure
+  rescue ActiveRecord::QueryCanceled => e
+    Rails.logger.error("Project destroy timeout: #{e.message}")
+    respond_destroy_timeout
   end
 
   private
+
+    def respond_destroy_success(author_id)
+      respond_to do |format|
+        format.html { redirect_to user_path(author_id), notice: "Project was successfully destroyed." }
+        format.json { head :no_content }
+      end
+    end
+
+    def respond_destroy_failure
+      respond_to do |format|
+        format.html do
+          redirect_to user_project_path(@project.author, @project),
+                      alert: "Project could not be deleted."
+        end
+        format.json { render json: { error: "Deletion failed" }, status: :unprocessable_entity }
+      end
+    end
+
+    def respond_destroy_timeout
+      respond_to do |format|
+        format.html do
+          redirect_to user_project_path(@project.author, @project),
+                      alert: "Project deletion timed out. Please try again."
+        end
+        format.json { render json: { error: "Deletion timed out" }, status: :request_timeout }
+      end
+    end
 
     # Use callbacks to share common setup or constraints between actions.
     def set_project

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -20,9 +20,9 @@ class Project < ApplicationRecord
 
   has_noticed_notifications model_name: "NoticedNotification"
   has_many :noticed_notifications, through: :author
-  has_many :collaborations, dependent: :destroy
+  has_many :collaborations, dependent: :delete_all
   has_many :collaborators, source: "user", through: :collaborations
-  has_many :taggings, dependent: :destroy
+  has_many :taggings, dependent: :delete_all
   has_many :tags, -> { where.not(name: "") }, through: :taggings
   mount_uploader :image_preview, ImagePreviewUploader
   has_one_attached :circuit_preview


### PR DESCRIPTION
Fixes #6715  

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -
This PR fixes the `PG::QueryCanceled` timeout issue on the project destroy endpoint.

**Problem**
- Project deletion was timing out due to slow cascading deletes from multiple `dependent: :destroy` associations.
- No proper handling existed for DB timeouts or failed destroy operations.

**Solution**
- Updated `collaborations` and `taggings` to `dependent: :delete_all` for faster bulk deletion (no callbacks needed).
- Switched to `destroy!` to properly detect and raise deletion failures.
- Added controller-level rescue handling for:
  - `ActiveRecord::QueryCanceled` (timeout)
  - `ActiveRecord::RecordNotDestroyed` (destroy failure)
- Added user-friendly flash messages for both failure cases.

**Files changed**
- `projects_controller.rb` → Added error handling + response helpers
- `project.rb` → Optimized association deletion strategy

**Testing**
- Successful delete redirects to user profile
- Timeout shows "Please try again" message
- Failed delete shows appropriate error message

### Screenshots of the UI changes (If any) -
N/A (no UI changes)

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**Explain your implementation approach:**
Project deletion was slow because `dependent: :destroy` triggered callbacks and individual deletes for associated records, leading to request timeouts. Since `collaborations` and `taggings` don’t require callbacks, I switched them to `dependent: :delete_all` to speed up deletion. I also used `destroy!` to ensure failures raise exceptions and added controller rescue blocks to handle timeouts and destroy failures gracefully with proper user feedback.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Project deletion now uses guarded flows with explicit handling for failures and timeouts, giving clearer success/error messages and more reliable behavior for both web and API responses.

* **Performance**
  * Improved cleanup of associated project data during deletion to reduce overhead and speed up the delete operation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->