### PR TITLE
Fix issue 6672 - Footer FAQ link redirects to incorrect documentation…

### DIFF
--- a/app/component/footer_links_component.rb
+++ b/app/component/footer_links_component.rb
@@ -27,7 +27,7 @@ class FooterLinksComponent < ViewComponent::Base
       { url: "/teachers", text: "layout.link_to_teachers" },
       { url: "/about", text: "layout.link_to_about" },
       { url: "https://api.circuitverse.org", text: "API", target: "_blank" },
-      { url: "https://docs.circuitverse.org/#/chapter8/2cvfaq", text: "layout.link_to_faq" }
+      { url: "https://docs.circuitverse.org/chapter8/chapter8-cvfaq", text: "layout.link_to_faq" }
     ]
   end
 

--- a/spec/components/footer_links_component_spec.rb
+++ b/spec/components/footer_links_component_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe FooterLinksComponent, type: :component do
 
     expect(page).to have_link(I18n.t("layout.link_to_simulator"), href: "/simulator")
     expect(page).to have_link(I18n.t("layout.link_to_learn_more"), href: "/learn")
+    expect(page).to have_link(I18n.t("layout.link_to_faq"),
+                              href: "https://docs.circuitverse.org/chapter8/chapter8-cvfaq")
     expect(page).to have_link(I18n.t("login"), href: "/users/sign_in")
     expect(page).not_to have_link(I18n.t("layout.footer.my_circuits"))
   end


### PR DESCRIPTION
… page

Fixes #

Fixed ISSUE 6672 [https://github.com/CircuitVerse/CircuitVerse/issues/6672](url)

#### changes done in this PR 
Updated the footer FAQ URL to the correct docs path in app/component/footer_links_component.rb.
Added a regression check in spec/components/footer_links_component_spec.rb to ensure the footer renders the correct FAQ link. (Correct link as per issue details is https://docs.circuitverse.org/chapter8/chapter8-cvfaq)

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [X] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)


**implementation approach:**
- Searched for footer snippet and further for FAQ link. Surely, the FAQ link was set to the wrong url. So replaced it with right url (as per [https://github.com/CircuitVerse/CircuitVerse/issues/6672](url)
- problem that my code solves - Issue 6672. Misdirecting footer FAQ link to incorrect link has been corrected and now leads to the correct link
- It was just simple replacing of link from "https://docs.circuitverse.org/#/chapter8/2cvfaq" TO "https://docs.circuitverse.org/chapter8/chapter8-cvfaq"

---

## Checklist before requesting a review
- [ X] I have added proper PR title and linked to the issue
- [ X] I have performed a self-review of my code
- [ X] **I can explain the purpose of every function, class, and logic block I added**
- [ X] I understand why my changes work and have tested them thoroughly
- [ X] I have considered potential edge cases and how my code handles them
- [ X] If it is a core feature, I have added thorough tests
- [ X] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the FAQ link in the footer to direct to the correct documentation page.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->