### PR TITLE
Fixes issue#6716

### DIFF
--- a/app/controllers/simulator_controller.rb
+++ b/app/controllers/simulator_controller.rb
@@ -89,7 +89,7 @@ class SimulatorController < ApplicationController
     @project.build_project_datum unless ProjectDatum.exists?(project_id: @project.id)
     @project.project_datum.data = sanitize_data(@project, params[:data])
     # ActiveStorage
-    @project.circuit_preview.purge if @project.circuit_preview.attached?
+    @project.circuit_preview.purge_later if @project.circuit_preview.attached?
     io_image_file = parse_image_data_url(params[:image])
     attach_circuit_preview(io_image_file)
     # CarrierWave


### PR DESCRIPTION
Fixes #6716 

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -

Change made:

Before: @project.circuit_preview.purge if @project.circuit_preview.attached?
After: @project.circuit_preview.purge_later if @project.circuit_preview.attached?

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**

- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The application was experiencing database query timeouts when users updated projects with circuit preview images. Specifically, when the update action tried to delete the old circuit preview attachment using the synchronous purge method, it would block the entire request. If the file was large or the storage system was slow, the database connection would time out before the deletion completed, causing the entire update operation to fail.

This created a poor user experience: users would get an error when trying to save their circuit designs, even though the core update logic had completed successfully.

---
**Alternative Approaches Considered:**

- Increase database timeout – This would be a band-aid solution that doesn't address the root cause. The timeout exists for a reason (to prevent runaway queries), and simply increasing it could mask other performance issues.

- Delete in a separate background thread – Could work, but less elegant and harder to track/manage than using the existing job queue infrastructure.

- Make the deletion optional during update – Skip deletion entirely and rely on manual cleanup. But this wastes storage and isn't user-friendly.

- Use a transaction with custom timeout settings – Complex and doesn't follow Rails conventions; the framework already provides the right tool for this.

- Implement custom async deletion logic – Reinventing the wheel when Rails already has built-in support for this pattern.

---

**Why This Implementation**
I chose [purge_later] because it:

- Follows Rails conventions – ActiveStorage provides this method specifically for this use case (asynchronous deletion of attachments)
- Leverages existing infrastructure – The app already has Sidekiq set up for background jobs, so this integrates seamlessly
- Maintains atomicity of the important operation – The circuit design update completes immediately and reliably
- Defers non-critical work – File deletion is important but not urgent; it doesn't need to happen during the user's request
- Is production-tested – This is the recommended pattern used across thousands of Rails applications

How It Works (Request Flow):
              User clicks "Save" 
                  ↓
              Controller receives update request
                  ↓
              Update circuit data
                  ↓
              queue purge_later job (returns immediately) ← KEY CHANGE
                  ↓
              Attach a new preview image
                  ↓
              Return response to user (fast!)
                  ↓
              [Meanwhile in the background]
              Sidekiq worker processes a job
                  ↓
              Deletes old file from storage

Before: User waits for file deletion → timeout → error
After: User gets response immediately → file deleted in background → no timeout
---
## Checklist before requesting a review
- [x] I have added a proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
