### PR TITLE
Fix: Favicon not displaying in browser tab

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,10 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400&display=swap" rel="stylesheet">
     <%= csrf_meta_tags %>
 
+    <link rel="icon" href="/favicon.ico" type="image/x-icon">
+<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+
+
     <%= javascript_include_tag "application_sprockets", "data-turbolinks-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbolinks-track": "reload", defer: true %>
 


### PR DESCRIPTION
### Problem
The website favicon was not visible in the browser tab due to missing HTML link tags in the layout file.

### Solution
Added correct <link rel="icon"> and <link rel="shortcut icon"> tags in `app/views/layouts/application.html.erb`.

### Result
Favicon now displays correctly in browser tabs.

Closes #<6751>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved favicon support across browsers with enhanced rendering declarations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->