### PR TITLE
Fix slow DB query in project search

### DIFF
--- a/app/lib/adapters/pg_adapter.rb
+++ b/app/lib/adapters/pg_adapter.rb
@@ -25,7 +25,7 @@ module Adapters
         base_results: base_project_results(relation, query_params),
         query_params: query_params,
         type: :project,
-        includes: %i[tags author]
+        includes: [:tags, :author, { circuit_preview_attachment: :blob }]
       )
     end
 

--- a/db/migrate/20260127000000_add_compound_index_to_projects.rb
+++ b/db/migrate/20260127000000_add_compound_index_to_projects.rb
@@ -1,0 +1,7 @@
+class AddCompoundIndexToProjects < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :projects, [:project_access_type, :forked_project_id], algorithm: :concurrently
+  end
+end


### PR DESCRIPTION
Fixes #6723

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -

- **Database Optimization**: Added a composite index on the `projects` table for columns `[:project_access_type, :forked_project_id]`. This significantly eliminates the bottleneck when filtering for public, non-forked projects (the default search scope). The migration uses `algorithm: :concurrently` to prevent locking the table during the operation.
- **N+1 Query Fix**: Updated `PgAdapter#search_project` to eager load `circuit_preview_attachment` and its associated `blob`. Previously, rendering project cards caused separate database queries for every project's preview image.

### Screenshots of the UI changes (If any) -
<!-- Do not add code diff here -->
N/A - Backend performance optimization.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

**Problem**: The search page was experiencing slow load times. Logs indicated two main issues: a slow SQL query when filtering projects by access type and fork status, and a high number of queries (N+1) fetching ActiveStorage attachments for project cards.

**Implementation**:
1.  **Composite Index**: I chose to add a composite index on `project_access_type` and `forked_project_id` because these two columns are frequently queried together in the `Project.public_and_not_forked` scope. A standard index might not have been sufficient given the cardinality of the data.
2.  **Eager Loading**: In `app/lib/adapters/pg_adapter.rb`, I modified the `includes` array. By adding `{ circuit_preview_attachment: :blob }`, Rails fetches the attachment metadata in the initial query. This prevents the view from triggering a separate SQL query for every project card to check if a preview image exists.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved project search functionality with faster result retrieval and enhanced responsiveness, providing a smoother experience when browsing and accessing project details
  * Optimized database performance for project operations, including faster query execution and reduced system latency for improved overall application performance

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->