### PR TITLE
fix: resolve N+1 queries in Groups and API controllers (Ref #6722)

### DIFF
--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -204,9 +204,9 @@ class Api::V1::ProjectsController < Api::V1::BaseController
 
     def load_index_projects
       @projects = if current_user.nil?
-        Project.open
+        Project.open.with_attached_circuit_preview
       else
-        Project.open.or(Project.by(current_user.id))
+        Project.open.or(Project.by(current_user.id)).with_attached_circuit_preview
       end
     end
 
@@ -214,15 +214,16 @@ class Api::V1::ProjectsController < Api::V1::BaseController
       # if user is not authenticated or authenticated as some other user
       # return only user's public projects else all
       @projects = if current_user.nil? || current_user.id != params[:id].to_i
-        Project.open.by(params[:id])
+        Project.open.by(params[:id]).with_attached_circuit_preview
       else
-        current_user.projects
+        current_user.projects.with_attached_circuit_preview
       end
     end
 
     def load_user_favourites
       @projects = Project.joins(:stars)
                          .where(stars: { user_id: params[:id].to_i })
+                         .with_attached_circuit_preview
 
       # if user is not authenticated or authenticated as some other user
       # return only user's public favourites else all
@@ -234,12 +235,12 @@ class Api::V1::ProjectsController < Api::V1::BaseController
     end
 
     def load_featured_circuits
-      @projects = Project.joins(:featured_circuit).all
+      @projects = Project.joins(:featured_circuit).with_attached_circuit_preview.all
     end
 
     def search_projects
       query_params = { q: params[:q], page: params[:page][:number], per_page: params[:page][:size] }
-      @projects = ProjectsQuery.new(query_params, Project.public_and_not_forked).results
+      @projects = ProjectsQuery.new(query_params, Project.public_and_not_forked.with_attached_circuit_preview).results
     end
 
     # include=author

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::UsersController < Api::V1::BaseController
 
   # GET api/v1/users
   def index
-    @users = paginate(User.all)
+    @users = paginate(User.all.with_attached_profile_picture)
     @options = { params: { only_name: true } }
     @options[:links] = link_attrs(@users, api_v1_users_url)
     render json: Api::V1::UserSerializer.new(@users, @options)

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -10,6 +10,8 @@ class GroupsController < ApplicationController
   # GET /groups/1.json
   def show
     @group_member = @group.group_members.new
+    @mentors = @group.group_members.mentor.includes(user: { profile_picture_attachment: :blob })
+    @members = @group.group_members.member.includes(user: { profile_picture_attachment: :blob })
     @group.assignments.each do |assignment|
       if (assignment.status == "reopening") && (assignment.deadline < Time.zone.now)
         assignment.status = "closed"

--- a/app/views/groups/_group_members.html.erb
+++ b/app/views/groups/_group_members.html.erb
@@ -1,4 +1,4 @@
-<% group.group_members.member.each do |member| %>
+<% members.each do |member| %>
   <div class="<%= membersCardViewerContainer(group) %>">
     <div class="<%= membersCardViewer(group) %>">
       <div class="row">

--- a/app/views/groups/_group_mentors.html.erb
+++ b/app/views/groups/_group_mentors.html.erb
@@ -1,4 +1,4 @@
-<% group.group_members.mentor.each do |member| %>
+<% mentors.each do |member| %>
   <div class="<%= membersCardViewerContainer(group) %>">
     <div class="<%= membersCardViewer(group) %>">
       <div class="row">

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -42,11 +42,11 @@
   <% end %>
 </div>
 <hr>
-<% if @group.group_members.mentor.blank? %>
+<% if @mentors.blank? %>
   <span class="null-text"><%= t("groups.show.no_mentors_html") %></span>
 <% end %>
 <div class="row">
-  <%= render partial: "group_mentors", locals: { group: @group } %>
+  <%= render partial: "group_mentors", locals: { mentors: @mentors, group: @group } %>
 </div>
 
 <!-- Members Section -->
@@ -62,11 +62,11 @@
   <% end %>
 </div>
 <hr>
-<% if @group.group_members.member.blank? %>
+<% if @members.blank? %>
   <span class="null-text"><%= t("groups.show.no_members_html") %></span>
 <% end %>
 <div class="row">
-  <%= render partial: "group_members", locals: { group: @group } %>
+  <%= render partial: "group_members", locals: { members: @members, group: @group } %>
 </div>
 
 <!-- Assignments Section -->


### PR DESCRIPTION
Fixes #6722

#### Describe the changes you have made in this PR -
This PR addresses the N+1 query performance issue identified in Sentry (Issue 6722). 

The problem was that `active_storage_attachments` (like user profile pictures and project circuit previews) were being loaded individually for each record in a collection, causing a significant number of database queries in [GroupsController](cci:2://file:///home/h30s/Project/CircuitVerse/app/controllers/api/v1/groups_controller.rb:2:0-87:3), `Api::V1::ProjectsController`, and `Api::V1::UsersController`.

I fixed this by adding explicit eager loading (`.includes` or `.with_attached_*`) to the relevant controller queries. I also updated the [groups/show.html.erb](cci:7://file:///home/h30s/Project/CircuitVerse/app/views/groups/show.html.erb:0:0-0:0) views and partials to correctly use these preloaded variables instead of invoking the association directly on each iteration.

Key changes:
- `GroupsController#show`: Eager loads mentors and members with their profile pictures.
- `Api::V1::ProjectsController`: Added `.with_attached_circuit_preview` to project listing endpoints.
- `Api::V1::UsersController`: Added `.with_attached_profile_picture` to the index endpoint.


### Screenshots of the UI changes (If any) -
No visual changes. This is purely a backend performance optimization.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
I tackled this by identifying where collections of records were being fetched without their associated attachments. For the [GroupsController](cci:2://file:///home/h30s/Project/CircuitVerse/app/controllers/api/v1/groups_controller.rb:2:0-87:3), I used Rails' `.includes` method to preload the [user](cci:1://file:///home/h30s/Project/CircuitVerse/app/controllers/api/v1/users_controller.rb:39:4-41:7) and `profile_picture_attachment` associations. I also had to slightly refactor the view partials to accept the preloaded collection as a local variable, rather than re-querying the association from the parent group object, which would have triggered the N+1 again. For the API controllers, I utilized the Rails ActiveStorage scope helpers like `with_attached_circuit_preview` which is the standard Rails way to optimize attachment loading.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Circuit preview images now display consistently across all project views, including user projects, favorites, featured circuits, and search results.
  * User profile pictures now display throughout the application in user listings.
  * Group pages now display profile pictures for all mentors and members.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->