### PR TITLE
fix: replace invalid jQuery ajax 'failure' callback with 'error'

### DIFF
--- a/public/js/data.js
+++ b/public/js/data.js
@@ -508,7 +508,7 @@ function save() {
                 $('.loadingIcon').fadeOut();
                 localStorage.removeItem("recover");
             },
-            failure: function(err) {
+            error: function(err) {
                 showMessage("There was an error, we couldn't save to our servers")
                 $('.loadingIcon').fadeOut();
             }
@@ -1016,8 +1016,8 @@ async function postUserIssue(message) {
         success: function(response) {
             $('#result').html("<i class='fa fa-check' style='color:green'></i> You've successfully submitted the issue. Thanks for improving our platform.");
         },
-        failure: function(err) {
-            $('#result').html("<i class='fa fa-check' style='color:red'></i> There seems to be a network issue. Please reach out to us at support@ciruitverse.org");
+        error: function(err) {
+            $('#result').html("<i class='fa fa-check' style='color:red'></i> There seems to be a network issue. Please reach out to us at support@circuitverse.org");
         }
     });
 }

--- a/simulator/src/Verilog2CV.js
+++ b/simulator/src/Verilog2CV.js
@@ -193,9 +193,6 @@ export default function generateVerilogCircuit(verilogCode, scope = globalScope)
                 $('#verilogOutput').html(errorMessage.message);
             }
         },
-        failure: function(err) {
-
-        }
     });
 }
 

--- a/simulator/src/ux.js
+++ b/simulator/src/ux.js
@@ -693,8 +693,8 @@ async function postUserIssue(message) {
         success: function(response) {
             $('#result').html("<i class='fa fa-check' style='color:green'></i> You've successfully submitted the issue. Thanks for improving our platform.");
         },
-        failure: function(err) {
-            $('#result').html("<i class='fa fa-check' style='color:red'></i> There seems to be a network issue. Please reach out to us at support@ciruitverse.org");
+        error: function(err) {
+            $('#result').html("<i class='fa fa-check' style='color:red'></i> There seems to be a network issue. Please reach out to us at support@circuitverse.org");
         }
     });
 }


### PR DESCRIPTION

#### Describe the changes you have made in this PR -

Fixed broken error handling in jQuery $.ajax calls across the codebase

jQuery's $.ajax() supports `success`, `error`, `complete` there is no `failure` callback Four ajax calls were using `failure` which meant their error handlers **never fired**

**Changes:**
1. `public/js/data.js` 
2. `simulator/src/ux.js` 
3. `simulator/src/Verilog2CV.js`

---


Was reading through the ajax calls in data.js and noticed `failure:` being used as a callback. jQuery $.ajax only supports `error:` for handling failed requests — `failure` is not a valid option so it just gets ignored silently.
 While fixing them I also spotted that the support email in the error messages was missing a letter (`ciruitverse` instead of `circuitverse`)

For Verilog2CV.js, the ajax call already had a proper `error:` handler, so the `failure:` block below it was just dead code removed it entirely

