### PR TITLE
fix: nil project pundit error

### DIFF
--- a/app/controllers/simulator_controller.rb
+++ b/app/controllers/simulator_controller.rb
@@ -154,7 +154,7 @@ class SimulatorController < ApplicationController
 
     # FIXME: remove this logic after fixing production data
     def set_user_project
-      @project = current_user.projects.friendly.find_by(id: params[:id]) || Project.friendly.find(params[:id])
+      @project = current_user.projects.friendly.find_by(id: params[:id]) || Project.friendly.find_by!(id: params[:id])
     end
 
     def check_edit_access


### PR DESCRIPTION
Fixes #6800

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -
Minor change in the set_user_project policy in the simulator controller. Instead of using .find, used .find_by!, which never returns nil to project, and doesn't hinder the error handler.

Before: @project = current_user.projects.friendly.find_by(id: params[:id]) || Project.friendly.find(params[:id])
After: @project = current_user.projects.friendly.find_by(id: params[:id]) || Project.friendly.find_by!(id: params[:id])

### Screenshots of the UI changes (If any) -
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
I explored the controller and realized that in the Simulator Controller, under the set_user_project policy, 

def set_user_project
      @project = current_user.projects.friendly.find_by(id: params[:id]) || Project.friendly.find(params[:id])
end

The pre-existing code could possibly raise a nil || nil situation if it crosses a race condition, or if a project exists but the current user doesn't own it. I tried recreating it by:

1. Login and create a project
2. Delete it, but don't refresh the cache yet
3. Try accessing the project

Fix: Instead of using the find method, use find_by!, which doesn't return nil, thereby ensuring that project is never nil. 

def set_user_project
      @project = current_user.projects.friendly.find_by(id: params[:id]) || Project.friendly.find_by!(id: params[:id])
end

This doesn't create a nilPolicyError, and fixes the pundit error.
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

---

## Checklist before requesting a review
- [ ] I have added proper PR title and linked to the issue
- [ ] I have performed a self-review of my code
- [ ] **I can explain the purpose of every function, class, and logic block I added**
- [ ] I understand why my changes work and have tested them thoroughly
- [ ] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [ ] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in the simulator when accessing non-existent projects, ensuring proper 404 error responses instead of incomplete or broken states.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->