### PR TITLE
Fixed the crash in @project

### DIFF
--- a/app/controllers/simulator_controller.rb
+++ b/app/controllers/simulator_controller.rb
@@ -41,7 +41,7 @@ class SimulatorController < ApplicationController
 
   def edit
     @logix_project_id = params[:id]
-    @projectName = @project.name
+    @projectName = @project&.name.to_s
     if Flipper.enabled?(:vuesim, current_user)
       render :edit_vue, layout: false
     else
@@ -154,7 +154,9 @@ class SimulatorController < ApplicationController
 
     # FIXME: remove this logic after fixing production data
     def set_user_project
-      @project = current_user.projects.friendly.find_by(id: params[:id]) || Project.friendly.find(params[:id])
+      @project = current_user.projects.friendly.find(params[:id])
+    rescue ActiveRecord::RecordNotFound
+      @project = Project.friendly.find(params[:id])
     end
 
     def check_edit_access


### PR DESCRIPTION
Fixes #6802 

#### Describe the changes you have made in this PR -
This PR fixes a crash in SimulatorController#edit caused by @project being nil.

Previously, the controller used find_by(id: ...), which could return nil when FriendlyId slugs were passed instead of numeric IDs. This led to a NoMethodError when .name was called on @project.

To resolve this:

Updated the project lookup to use FriendlyId-aware find, which raises ActiveRecord::RecordNotFound instead of silently returning nil.

Made @projectName nil-safe using @project&.name.to_s to prevent unexpected crashes even in edge cases.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Problem

SimulatorController#edit could crash with NoMethodError: undefined method 'name' for nil when a project was accessed via a FriendlyId slug. This happened because find_by(id: ...) returns nil for slugs, leaving @project unset.

Solution

I replaced find_by(id: ...) with FriendlyId-aware find, which correctly resolves slug-based IDs and raises ActiveRecord::RecordNotFound when the project does not exist. This prevents silent failures and allows Rails to handle missing records properly.

Additionally, I made @projectName nil-safe using @project&.name.to_s as a defensive measure to avoid calling .name on nil in unexpected scenarios.

Alternatives Considered

I considered keeping find_by and adding manual nil checks, but using find is cleaner and aligns better with Rails conventions by surfacing missing records through exceptions.

Why This Approach

This solution:

Follows Rails best practices for record lookup

Properly supports FriendlyId slugs

Avoids silent failures

Adds a small defensive guard for extra safety

Keeps changes minimal and localized to the controller

Key Logic

Use FriendlyId-aware find to ensure @project is never silently nil.

Use safe navigation (&.) for @projectName to prevent crashes in edge cases.

This results in more predictable behavior and eliminates the reported crash.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced the reliability of the simulator project editor by preventing crashes when accessing project information under edge case conditions.
* Improved error recovery mechanisms to gracefully handle scenarios where projects cannot be found, providing a more stable user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->