### PR TITLE
Fixed the NilClassPolicy

### DIFF
--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -54,11 +54,13 @@ class GradesController < ApplicationController
   end
 
   def to_csv
-    assignment_id = params[:assignment_id].to_i
+    assignment = Assignment.find(params[:assignment_id])
+    authorize assignment, :mentor_access?
+
     respond_to do |format|
       format.csv do
-        send_data Grade.to_csv(assignment_id),
-                  filename: "#{Assignment.find(assignment_id).name} grades.csv"
+        send_data Grade.to_csv(assignment.id),
+                  filename: "#{assignment.name} grades.csv"
       end
     end
   end


### PR DESCRIPTION
Fixes #6817 

#### Describe the changes you have made in this PR -

This PR fixes a crash caused by Pundit::NotDefinedError: unable to find policy NilClassPolicy in GradesController#to_csv.

Previously, authorize was being called on a potentially nil grade, which resulted in Pundit attempting to resolve a NilClassPolicy.

To resolve this:

to_csv now explicitly loads the Assignment using Assignment.find(params[:assignment_id]).

Authorization is performed on the assignment itself using authorize assignment, :mentor_access?, ensuring proper access control.

The already-loaded assignment is reused for both Grade.to_csv(assignment.id) and generating the CSV filename, avoiding a redundant Assignment.find.

This not only fixes the crash but also tightens permissions so that only mentors/admins can export grades.

All changes are localized to grades_controller.rb.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Problem

GradesController#to_csv could crash with a NilClassPolicy error because authorization was being performed on a potentially nil grade. This caused Pundit to attempt to resolve a policy for nil, resulting in an exception.

Solution

I updated to_csv to explicitly load the related Assignment using Assignment.find(params[:assignment_id]) and perform authorization on the assignment via authorize assignment, :mentor_access?.

The loaded assignment is then reused for:

Calling Grade.to_csv(assignment.id)

Generating the CSV filename

This avoids duplicate queries and ensures authorization is always performed on a valid object.

Alternatives Considered

I considered adding nil checks around the grade object, but authorizing directly against the assignment is cleaner, aligns better with the intended permission model, and avoids relying on defensive nil handling.

Why This Approach

This approach:

Eliminates the NilClassPolicy crash

Enforces correct mentor/admin access for CSV exports

Reduces redundant database queries

Keeps the fix minimal and localized to the controller

Key Logic

Load assignment explicitly.

Authorize using mentor_access? on the assignment.

Reuse the same assignment for CSV generation and filename.

This results in safer authorization and more predictable behavior.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization verification for grade CSV exports to ensure only authorized users can access grade data exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->