### PR TITLE
Add User Manual link next to Simulator in header

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -15,15 +15,13 @@
           <li class="nav-item">
             <a class="nav-link navbar-item navbar-text" href="/simulator"><%= t("layout.link_to_simulator") %></a>
           </li>
-          
-         <li class="nav-item">
+          <li class="nav-item">
            <a class="nav-link navbar-item navbar-text"
              href="https://docs.circuitverse.org"
               target="_blank" rel="noopener">
               User Manual
             </a>
           `</li>
-
           <li class="nav-item">
             <a class="nav-link navbar-item navbar-text" href="/#ho`````me-features-section"><%= t("layout.link_to_features") %></a>
           </li>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -21,9 +21,9 @@
               target="_blank" rel="noopener">
               User Manual
             </a>
-          `</li>
+           </li>
           <li class="nav-item">
-            <a class="nav-link navbar-item navbar-text" href="/#ho`````me-features-section"><%= t("layout.link_to_features") %></a>
+            <a class="nav-link navbar-item navbar-text" href="/#home-features-section"><%= t("layout.link_to_features") %></a>
           </li>
           <% if Flipper.enabled?(:circuit_explore_page, current_user) %>
             <li class="nav-item">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -15,8 +15,17 @@
           <li class="nav-item">
             <a class="nav-link navbar-item navbar-text" href="/simulator"><%= t("layout.link_to_simulator") %></a>
           </li>
+          
+         <li class="nav-item">
+           <a class="nav-link navbar-item navbar-text"
+             href="https://docs.circuitverse.org"
+              target="_blank" rel="noopener">
+              User Manual
+            </a>
+          `</li>
+
           <li class="nav-item">
-            <a class="nav-link navbar-item navbar-text" href="/#home-features-section"><%= t("layout.link_to_features") %></a>
+            <a class="nav-link navbar-item navbar-text" href="/#ho`````me-features-section"><%= t("layout.link_to_features") %></a>
           </li>
           <% if Flipper.enabled?(:circuit_explore_page, current_user) %>
             <li class="nav-item">


### PR DESCRIPTION
Fixes 
#6778 
#### Describe the changes you have made in this PR -
- Added a “User Manual” link in the header navigation next to the Simulator link for better discoverability.
- The link opens https://docs.circuitverse.org in a new tab with rel="noopener".

### Screenshots of the UI changes (If any) -
<img width="1500" height="846" alt="Screenshot 2026-02-03 at 3 03 52 PM" src="https://github.com/user-attachments/assets/5c93a9c1-b0ea-4d77-83bb-2094a9144925" />



## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [x ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
This change solves the problem of the user manual not being easily discoverable for first-time users. Although CircuitVerse already has well-documented workflows, new users may not realize that a user manual exists unless they actively search for it or find it through external links.

I considered alternative approaches such as adding a prominent card on the homepage or introducing a separate “Getting Started” section. However, placing the User Manual link directly in the header navigation was chosen because the header is visible across all pages and aligns with existing navigation patterns like the Simulator link.

The implementation adds a new navigation item in the shared header layout (_header.html.erb) next to the Simulator link. The link points to the official documentation site and opens in a new tab using target="_blank" with rel="noopener" for security. No new logic or components were introduced; the change reuses the existing navigation structure to keep the implementation simple and consistent with the current codebase.

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions





Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "User Manual" link to the header navigation that opens the documentation portal in a new tab.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->