### PR TITLE
Add alt text to all About page and contributor images for accessibility

### DIFF
--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -42,7 +42,7 @@
         <% @cores.each do |member| %>
         <div class="team-member-container team-link ">
           <div class="team-underline">
-            <a target="_blank" href="<%= member[:link] %>"><%= image_tag member[:img], class: "about-contributor-image" %><p class="team-footer "><%= member[:name] %></p></a>
+            <a target="_blank" href="<%= member[:link] %>"><%= image_tag member[:img],alt: member[:name], class: "about-contributor-image" %><p class="team-footer "><%= member[:name] %></p></a>
           </div>
         </div>
         <% end %>
@@ -62,7 +62,7 @@
         <% @mentors.each do |member| %>
         <div class="team-member-container team-link">
           <div class="team-underline">
-            <a target="_blank" href="<%= member[:link] %>"><%= image_tag member[:img], class: "about-contributor-image" %><p class="team-footer"><%= member[:name] %></p></a>
+            <a target="_blank" href="<%= member[:link] %>"><%= image_tag member[:img], alt: member[:name],class: "about-contributor-image" %><p class="team-footer"><%= member[:name] %></p></a>
           </div>
         </div>
         <% end %>
@@ -83,7 +83,7 @@
         <% @issues_triaging.each do |member| %>
         <div class="team-member-container team-link">
           <div class="team-underline">
-            <a target="_blank" href="<%= member[:link] %>"><%= image_tag member[:img],alt: "User Image", class: "about-contributor-image" %><p class="team-footer"><%= member[:name] %></p></a>
+            <a target="_blank" href="<%= member[:link] %>"><%= image_tag member[:img],alt: member[:name], class: "about-contributor-image" %><p class="team-footer"><%= member[:name] %></p></a>
           </div>
         </div>
         <% end %>
@@ -104,7 +104,7 @@
         <% @alumni.each do |member| %>
         <div class="team-member-container team-link">
           <div class="team-underline">
-            <a target="_blank" href="<%= member[:link] %>"><%= image_tag member[:img], class: "about-contributor-image " %><p class="team-footer underline"><%= member[:name] %></p></a>
+            <a target="_blank" href="<%= member[:link] %>"><%= image_tag member[:img], alt: member[:name],class: "about-contributor-image " %><p class="team-footer underline"><%= member[:name] %></p></a>
           </div>
         </div>
         <% end %>
@@ -136,18 +136,22 @@
     let apiData = await fetch(url);
     let contributorsData = await apiData.json();
     let contributorUsers = contributorsData.filter(function(user) { return (user.type == 'User') });
-    for (let i=0; i<contributorUsers.length; i++){
-      let contributorElement = document.createElement('div');
-      let contributorElementAnchor = document.createElement('a');
-      let contributorElementImage = document.createElement('img');
-      contributorElement.classList.add('about-contributor');
-      contributorElementAnchor.href = await contributorUsers[i]['html_url'];
-      contributorElementImage.src = await contributorUsers[i]['avatar_url'];
-      contributorElementImage.classList.add('about-contributor-image');
-      contributorElementAnchor.appendChild(contributorElementImage);
-      contributorElement.appendChild(contributorElementAnchor);
-      document.getElementsByClassName('about-contributors-section')[0].appendChild(contributorElement);
-    }
+    for (let i = 0; i < contributorUsers.length; i++) {
+  let contributorElement = document.createElement('div');
+  let contributorElementAnchor = document.createElement('a');
+  let contributorElementImage = document.createElement('img');
+
+  contributorElement.classList.add('about-contributor');
+  contributorElementAnchor.href = contributorUsers[i]['html_url'];
+  contributorElementImage.src = contributorUsers[i]['avatar_url'];
+  contributorElementImage.alt = contributorUsers[i]['login']; // added alt
+  contributorElementImage.classList.add('about-contributor-image');
+
+  contributorElementAnchor.appendChild(contributorElementImage);
+  contributorElement.appendChild(contributorElementAnchor);
+  document.getElementsByClassName('about-contributors-section')[0].appendChild(contributorElement);
+}
+
   }
   getContributors('https://api.github.com/repos/CircuitVerse/CircuitVerse/contributors?per_page=100');
 </script>


### PR DESCRIPTION
Fixes #6657

- **Problem:**  
  Some images on the About page and contributor sections were missing `alt` attributes, reducing accessibility for screen readers.

- **Steps to Reproduce:**  
  - Open https://circuitverse.org/about  
  - Inspect images using browser Developer Tools  
  - Observe missing or empty `alt` attributes for team member images and dynamically loaded contributors

- **Result Before Fix:**  
  - Team member images (`@cores`, `@mentors`, `@alumni`, `@issues_triaging`) had no alt text  
  - Dynamically loaded GitHub contributor avatars had no `alt` attribute  
  - Static icons (email, Slack) already had alt text

- **What This PR Fixes:**  
  - Adds `alt: member[:name]` to all team member images  
  - Adds `alt = contributorUsers[i]['login']` to dynamically loaded GitHub contributor avatars  
  - Ensures static icons remain descriptive

- **Challenges Faced:**  
  - Contributors are loaded dynamically via JavaScript, so alt text had to be added in the script  
  - Identifying meaningful vs decorative images for proper alt text

- **Impact / Benefit:**  
  - Improves accessibility compliance for screen readers  
  - Makes About page and contributor section fully accessible  
  - Prepares the site for WCAG accessibility standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Enhanced site-wide accessibility by adding descriptive alt text to all images across contributor profiles, team member sections, dynamically generated user avatars, and issue triage pages. This improvement ensures comprehensive support for screen readers and users with visual impairments who rely on assistive technologies for effective navigation and content access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->