### PR TITLE
Fixed favicon not being displayed in production

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -9,7 +9,7 @@ Rails.application.config.assets.quite = false
 # Rails.application.config.assets.paths << Emoji.images_path
  Rails.application.config.assets.paths << Rails.root.join('node_modules')
  Rails.application.config.assets.precompile += %w[simulator.css simulator.js application_sprockets.js application.js testbench.js testbench.css mailer.css]
- Rails.application.config.assets.precompile += ["*.svg", "*.eot", "*.woff", "*.woff2", "*.ttf", "*.otf", "*.png"]
+ Rails.application.config.assets.precompile += ["*.svg", "*.eot", "*.woff", "*.woff2", "*.ttf", "*.otf", "*.png", "*.ico"]
 
 Rails.application.config.assets.paths << Rails.root.join('app', 'assets', 'images')
 


### PR DESCRIPTION
Fixes #6751

#### Describe the changes you have made in this PR -
This PR fixes a production-only favicon 404 issue by ensuring .ico files are included in the asset precompilation pipeline.

Previously, favicon_link_tag "favicon.ico" worked in development because Rails serves assets dynamically, but failed in production (config.assets.compile = false) since .ico files were not part of assets.precompile. As a result, the favicon was never generated into public/assets.

I updated assets.rb to explicitly precompile *.ico, ensuring the favicon is fingerprinted and available in production builds.

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The issue was caused by favicon assets not being precompiled in production. Since Rails does not dynamically serve assets in production, favicon.ico must exist in public/assets with a digest.

I solved this by adding *.ico to Rails.application.config.assets.precompile so favicon files are included during assets:precompile.

Alternative approaches considered:

Serving a static /public/favicon.ico

Hardcoding the favicon path

I chose asset precompilation because it aligns with Rails’ asset pipeline and preserves fingerprinting for cache busting.

Key change:

Updated assets.rb to include .ico files in precompile list.

After the change, production builds generate favicon-<digest>.ico, and the HTML correctly points to /assets/favicon-<digest>.ico.

I also verified that RAILS_SERVE_STATIC_FILES must be enabled when Rails is responsible for serving /public, otherwise assets may still 404 even when precompiled.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated asset pipeline configuration to ensure icon files are properly included in the precompilation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->