### PR TITLE
Fixed Uncaught ReferenceError: logix_project_id is not defined

### DIFF
--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -6,6 +6,7 @@
 
 <script>
   userSignedIn = <%= user_signed_in? %>;
+  logix_project_id = "<%= @logix_project_id %>";
   __logix_project_id = "<%= @logix_project_id %>";
   __projectName = "<%= @projectName %>"
 </script>

--- a/app/views/simulator/embed.html.erb
+++ b/app/views/simulator/embed.html.erb
@@ -68,6 +68,7 @@
 </div>
 
 <script type="text/javascript">
+    logix_project_id = "<%= @logix_project_id %>";
     __logix_project_id = "<%= @logix_project_id %>";
         embed=true;
         <% if @project&.assignment_id.present? %>


### PR DESCRIPTION
Fixes #6828 

#### Describe the changes you have made in this PR -
This PR fixes a black-canvas issue caused by the legacy simulator (data.js) expecting a global variable named logix_project_id.

In this repo, Rails views were only defining __logix_project_id (double underscore). As a result, when data.js loaded, it immediately threw a runtime error due to the missing logix_project_id, preventing the rest of the simulator initialization from running and leaving the canvas blank.

To resolve this, I defined the expected global variable in both legacy simulator templates:

edit.html.erb now sets logix_project_id alongside __logix_project_id.

embed.html.erb now sets logix_project_id alongside __logix_project_id (lines ~50–80).

This keeps compatibility with the legacy simulator without altering its JS logic and ensures initialization completes correctly.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The issue occurred because the legacy simulator (data.js) expects a global variable named logix_project_id, but the Rails views were only defining __logix_project_id. This mismatch caused data.js to throw an error during initialization, which prevented the simulator from loading and resulted in a black canvas.

Rather than modifying the legacy JavaScript (which could introduce unintended side effects), I chose to restore compatibility at the view layer by defining logix_project_id alongside the existing __logix_project_id.

I updated both legacy simulator templates:

edit.html.erb

embed.html.erb

to expose the missing global variable.

This approach was chosen because:

It preserves backward compatibility with the legacy simulator.

It avoids touching fragile or deprecated JS code.

It minimizes the scope of changes while directly addressing the root cause.

Key logic:

Both templates now assign logix_project_id using the same value as __logix_project_id, ensuring data.js initializes correctly.

After this change, the simulator loads as expected, and the canvas renders properly.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal JavaScript variable initialization across simulator views to enhance compatibility and ensure proper data availability during operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->