### PR TITLE
fix(security): prevent IDOR in StarsController

### DIFF
--- a/app/controllers/stars_controller.rb
+++ b/app/controllers/stars_controller.rb
@@ -26,8 +26,7 @@ class StarsController < ApplicationController
   # POST /stars
   # POST /stars.json
   def create
-    @star = Star.new(star_params)
-    @star.user_id = current_user.id  # SECURITY FIX: Force authenticated user's ID
+    @star = current_user.stars.build(star_params)
     if @star.save
       render plain: "Star added!"
     else
@@ -58,16 +57,11 @@ class StarsController < ApplicationController
 
   private
 
-    # Use callbacks to share common setup or constraints between actions.
-    # SECURITY FIX: Only allow users to manage their own stars
     def set_star
       @star = current_user.stars.find(params[:id])
-    rescue ActiveRecord::RecordNotFound
-      render plain: "Star not found or access denied", status: :not_found
     end
 
     # Never trust parameters from the scary internet, only allow the white list through.
-    # SECURITY FIX: Removed user_id from permitted params
     def star_params
       params.expect(star: [:project_id])
     end

--- a/spec/controllers/stars_controller_spec.rb
+++ b/spec/controllers/stars_controller_spec.rb
@@ -18,12 +18,12 @@ describe StarsController, type: :request do
         expect(Star.last.user_id).to eq(@user.id)
       end
 
-      it "ignores user_id param and uses current_user instead (IDOR protection)" do
+      it "ignores user_id param" do
         other_user = FactoryBot.create(:user)
         expect do
           post stars_path, params: { star: { user_id: other_user.id, project_id: @project.id } }
         end.to change(Star, :count).by(1)
-        # Verify the star was created for current_user, NOT the spoofed user_id
+
         expect(Star.last.user_id).to eq(@user.id)
         expect(Star.last.user_id).not_to eq(other_user.id)
       end
@@ -51,7 +51,7 @@ describe StarsController, type: :request do
       end
     end
 
-    context "when user does not own the star (IDOR protection)" do
+    context "when user does not own the star" do
       before do
         other_user = FactoryBot.create(:user)
         @other_star = FactoryBot.create(:star, project: @project, user: other_user)


### PR DESCRIPTION
Fixes # [GHSA-6j72-78p6-7xwp](https://github.com/CircuitVerse/CircuitVerse/security/advisories/GHSA-6j72-78p6-7xwp)
## Describe the changes you have made in this PR -

This PR fixes two critical **Insecure Direct Object Reference (IDOR)** vulnerabilities and a logic bug in the [StarsController](cci:2://file:///c:/Users/ASUS/OneDrive/Desktop/cv-yosys/CircuitVerse/app/controllers/stars_controller.rb:2:0-73:3).

**1. Fixed Forced Star Creation (Mass Assignment)**
- **Issue:** The [create](cci:1://file:///c:/Users/ASUS/OneDrive/Desktop/cv-yosys/CircuitVerse/app/controllers/api/v1/projects_controller.rb:91:2-108:5) action accepted `user_id` in [star_params](cci:1://file:///c:/Users/ASUS/OneDrive/Desktop/cv-yosys/CircuitVerse/app/controllers/stars_controller.rb:68:4-72:7), allowing any authenticated user to create stars on behalf of any other user (spoofing).
- **Fix:** Removed `user_id` from permitted parameters and explicitly assigned `@star.user_id = current_user.id` to ensure stars are always attributed to the authenticated user.

**2. Fixed Unauthorized Star Deletion (IDOR)**
- **Issue:** The [destroy](cci:1://file:///c:/Users/ASUS/OneDrive/Desktop/cv-yosys/CircuitVerse/app/controllers/group_members_controller.rb:91:2-102:5) action used `Star.find(params[:id])`, allowing any user to delete *any* star in the database by guessing its ID.
- **Fix:** Scoped the lookup to `current_user.stars.find(params[:id])`. This ensures users can only find and delete stars they actually own. Attempting to delete another user's star now raises `ActiveRecord::RecordNotFound` (caught and handled as 404).

**3. Fixed Crash on Unauthenticated Access**
- **Issue:** `before_action :set_star` ran *before* `before_action :authenticate_user!`. If an unauthenticated user tried to delete a star, the app would crash with `NoMethodError: undefined method 'stars' for nil:NilClass` before redirecting to login.
- **Fix:** Swapped the order of `before_action` calls. `authenticate_user!` now runs first, ensuring `current_user` is present before [set_star](cci:1://file:///c:/Users/ASUS/OneDrive/Desktop/cv-yosys/CircuitVerse/app/controllers/stars_controller.rb:60:4-66:7) executes.

**4. Added Comprehensive Security Tests**
- Created [spec/controllers/stars_controller_spec.rb](cci:7://file:///c:/Users/ASUS/OneDrive/Desktop/cv-yosys/CircuitVerse/spec/controllers/stars_controller_spec.rb:0:0-0:0) with 6 test cases covering:
    - Successful creation/deletion for owners.
    - **Security:** Verifies `user_id` parameter tampering is ignored.
    - **Security:** Verifies deleting another user's star returns 404.
    - **Security:** Verifies unauthenticated access redirects to login instead of crashing.

### Screenshots of the UI changes (If any) -
*N/A - Backend logic and security fixes only.*

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

## Explain your implementation approach:

**Problem:** The [StarsController](cci:2://file:///c:/Users/ASUS/OneDrive/Desktop/cv-yosys/CircuitVerse/app/controllers/stars_controller.rb:2:0-73:3) blindly trusted user input (`user_id` params) and failed to scope database queries to the authorized user, leading to Account Takeover (ATO) risks for starring functionality.

**Approach:**
1.  **Secure by Design (Scoping):** Instead of fetching a record and *then* checking if the user owns it (which can be prone to errors), I used **associative scoping** (`current_user.stars.find`). This makes it impossible to retrieve a record that doesn't belong to the user at the database level.
2.  **Hardcoded Safety:** For creation, I explicitly forced the `user_id` to be the session's `current_user.id`, rendering any spoofed params useless.
3.  **Fail-Safe Ordering:** Swapped the controller filters (`before_action`) to ensure authentication guards always run before any logic that assumes a logged-in user.

### Alternatives Considered:
I considered using Pundit policies (`authorize @star`), but for standard CRUD actions where a user manages their *own* resources, scoping (`current_user.stars`) is the Rails "Golden Path." It is more performant (one query) and less error-prone than authentication + separate authorization check.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication is required to create and delete starred items.
  * Users can only manage their own starred items; unauthorized attempts return not found.
  * Creation now assigns the star to the authenticated user, ignores any supplied owner ID (prevents IDOR), and surfaces success/failure outcomes.

* **Tests**
  * Expanded coverage for authenticated vs unauthenticated flows and ownership/forbidden scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->