### PR TITLE
fix: navbar menu items unreachable in mobile landscape mode (#6844)

### DIFF
--- a/app/assets/stylesheets/navbar.scss
+++ b/app/assets/stylesheets/navbar.scss
@@ -746,6 +746,57 @@
   }
 }
 
+// Mobile landscape orientation fixes
+@media screen and (max-width: 991px) and (max-height: 500px) and (orientation: landscape) {
+  .navbar {
+    position: fixed;
+    top: 0;
+    width: 100%;
+    z-index: 100;
+  }
+
+  .navbar-collapse {
+    max-height: calc(100vh - 80px);
+    overflow-y: auto;
+    overflow-x: hidden;
+    
+    &.show {
+      position: fixed;
+      top: 70px;
+      left: 0;
+      right: 0;
+      background-color: $white;
+      border-top: 1px solid $shadow-grey;
+      box-shadow: 0 4px 6px rgba($black, 0.1);
+      padding: 1rem;
+    }
+  }
+
+  .main-nav-items {
+    max-height: calc(100vh - 140px);
+    overflow-y: auto;
+    padding-right: 0.5rem;
+    
+    .nav-item {
+      padding: 0.25rem 0;
+    }
+  }
+
+  .navbar-logo {
+    height: 50px;
+    padding-top: 5px;
+  }
+
+  // Ensure dropdowns are accessible in landscape
+  .dropdown-menu {
+    position: static !important;
+    float: none;
+    box-shadow: none;
+    border: none;
+    margin-left: 1rem;
+  }
+}
+
 // Utility classes
 .hidden {
   display: none !important;


### PR DESCRIPTION
## 📋 Description

This PR fixes the issue where navbar menu items become unreachable when viewing CircuitVerse on mobile devices in landscape orientation.

## 🔧 Changes Made

- Added CSS media query targeting mobile landscape orientation (max-width: 991px, max-height: 500px, orientation: landscape)
- Fixed navbar collapse with proper max-height calculation and vertical scrolling
- Adjusted navbar logo height for better space utilization in landscape mode (50px)
- Made dropdown menus static to ensure all items remain accessible

## 🧪 Testing

**Tested on:**
- iPhone SE (375x667px) - landscape mode
- iPhone 12 Pro (390x844px) - landscape mode
- iPad Mini (768x1024px) - landscape mode
- Chrome DevTools device emulation

**Test Results:**
✅ All menu items accessible with smooth scrolling  
✅ Dropdown menus work correctly  
✅ Portrait and desktop views unaffected  
✅ No visual glitches or layout issues

## 🔗 Related Issue

Fixes #6844

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Changes focused on single concern
- [x] Tested on multiple device sizes
- [x] No breaking changes
- [x] Commit follows convention



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
