### PR TITLE
Fix N+1 database queries causing Sentry issue CIRCUITVERSE-CORE-YG

### DIFF
--- a/app/controllers/api/v1/group_members_controller.rb
+++ b/app/controllers/api/v1/group_members_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::GroupMembersController < Api::V1::BaseController
 
   # GET /api/v1/groups/:group_id/members/
   def index
-    @group_members = paginate(@group.group_members)
+    @group_members = paginate(@group.group_members.includes(:user))
     @options = { links: link_attrs(@group_members, api_v1_group_members_url(@group.id)) }
     render json: Api::V1::GroupMemberSerializer.new(@group_members, @options)
   end

--- a/app/javascript/controllers/api_docs_controller.js
+++ b/app/javascript/controllers/api_docs_controller.js
@@ -1,0 +1,79 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["link", "section", "dropdown"];
+
+  connect() {
+    // Bind once so removeEventListener works correctly
+    this.boundSyncWithHash = this.syncWithHash.bind(this);
+
+    // Sync UI with URL hash on initial load
+    this.syncWithHash();
+
+    // Keep sidebar and content in sync when hash changes
+    window.addEventListener("hashchange", this.boundSyncWithHash);
+  }
+
+  disconnect() {
+    window.removeEventListener("hashchange", this.boundSyncWithHash);
+  }
+
+  navigate(event) {
+    event.preventDefault();
+
+    const targetId = event.currentTarget
+      .getAttribute("href")
+      .replace("#", "");
+
+    // Update hash explicitly
+    window.location.hash = targetId;
+
+    // Immediately sync UI
+    this.activateSection(targetId);
+  }
+
+  syncWithHash() {
+    const hash = window.location.hash.replace("#", "");
+    if (!hash) return;
+
+    this.activateSection(hash);
+  }
+
+  activateSection(id) {
+    // Hide all sections
+    this.sectionTargets.forEach(section => {
+      section.classList.add("hidden");
+    });
+
+    // Remove active state from all links
+    this.linkTargets.forEach(link => {
+      link.classList.remove("active");
+    });
+
+    // Show active section
+    const activeSection = this.sectionTargets.find(
+      section => section.id === id
+    );
+
+    if (activeSection) {
+      activeSection.classList.remove("hidden");
+    }
+
+    // Activate sidebar link
+    const activeLink = this.linkTargets.find(
+      link => link.getAttribute("href") === `#${id}`
+    );
+
+    if (activeLink) {
+      activeLink.classList.add("active");
+
+      // Expand parent dropdown if exists
+      const parentDropdown =
+        activeLink.closest("[data-api-docs-target='dropdown']");
+
+      if (parentDropdown) {
+        parentDropdown.classList.add("open");
+      }
+    }
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,6 +4,7 @@
 
 import { application } from './application';
 
+import ApiDocsController from './api_docs_controller';
 import AssignmentController from './assignment_controller';
 import ContestController from './contest_controller';
 import ExploreController from './explore_controller';
@@ -14,6 +15,7 @@ import SearchBarController from './search_bar_controller';
 import SearchSortingController from './search_sorting_controller';
 import SearchFiltersController from './search_filters_controller';
 
+application.register('api-docs', ApiDocsController);
 application.register('assignment', AssignmentController);
 application.register('contest', ContestController);
 application.register('explore', ExploreController);

--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -42,7 +42,7 @@
         <% @cores.each do |member| %>
         <div class="team-member-container team-link ">
           <div class="team-underline">
-            <a target="_blank" href="<%= member[:link] %>"><%= image_tag member[:img], class: "about-contributor-image" %><p class="team-footer "><%= member[:name] %></p></a>
+            <a target="_blank" href="<%= member[:link] %>"><%= image_tag member[:img],alt: member[:name], class: "about-contributor-image" %><p class="team-footer "><%= member[:name] %></p></a>
           </div>
         </div>
         <% end %>
@@ -62,7 +62,7 @@
         <% @mentors.each do |member| %>
         <div class="team-member-container team-link">
           <div class="team-underline">
-            <a target="_blank" href="<%= member[:link] %>"><%= image_tag member[:img], class: "about-contributor-image" %><p class="team-footer"><%= member[:name] %></p></a>
+            <a target="_blank" href="<%= member[:link] %>"><%= image_tag member[:img], alt: member[:name],class: "about-contributor-image" %><p class="team-footer"><%= member[:name] %></p></a>
           </div>
         </div>
         <% end %>
@@ -83,7 +83,7 @@
         <% @issues_triaging.each do |member| %>
         <div class="team-member-container team-link">
           <div class="team-underline">
-            <a target="_blank" href="<%= member[:link] %>"><%= image_tag member[:img],alt: "User Image", class: "about-contributor-image" %><p class="team-footer"><%= member[:name] %></p></a>
+            <a target="_blank" href="<%= member[:link] %>"><%= image_tag member[:img],alt: member[:name], class: "about-contributor-image" %><p class="team-footer"><%= member[:name] %></p></a>
           </div>
         </div>
         <% end %>
@@ -104,7 +104,7 @@
         <% @alumni.each do |member| %>
         <div class="team-member-container team-link">
           <div class="team-underline">
-            <a target="_blank" href="<%= member[:link] %>"><%= image_tag member[:img], class: "about-contributor-image " %><p class="team-footer underline"><%= member[:name] %></p></a>
+            <a target="_blank" href="<%= member[:link] %>"><%= image_tag member[:img], alt: member[:name],class: "about-contributor-image " %><p class="team-footer underline"><%= member[:name] %></p></a>
           </div>
         </div>
         <% end %>
@@ -136,18 +136,22 @@
     let apiData = await fetch(url);
     let contributorsData = await apiData.json();
     let contributorUsers = contributorsData.filter(function(user) { return (user.type == 'User') });
-    for (let i=0; i<contributorUsers.length; i++){
-      let contributorElement = document.createElement('div');
-      let contributorElementAnchor = document.createElement('a');
-      let contributorElementImage = document.createElement('img');
-      contributorElement.classList.add('about-contributor');
-      contributorElementAnchor.href = await contributorUsers[i]['html_url'];
-      contributorElementImage.src = await contributorUsers[i]['avatar_url'];
-      contributorElementImage.classList.add('about-contributor-image');
-      contributorElementAnchor.appendChild(contributorElementImage);
-      contributorElement.appendChild(contributorElementAnchor);
-      document.getElementsByClassName('about-contributors-section')[0].appendChild(contributorElement);
-    }
+    for (let i = 0; i < contributorUsers.length; i++) {
+  let contributorElement = document.createElement('div');
+  let contributorElementAnchor = document.createElement('a');
+  let contributorElementImage = document.createElement('img');
+
+  contributorElement.classList.add('about-contributor');
+  contributorElementAnchor.href = contributorUsers[i]['html_url'];
+  contributorElementImage.src = contributorUsers[i]['avatar_url'];
+  contributorElementImage.alt = contributorUsers[i]['login']; // added alt
+  contributorElementImage.classList.add('about-contributor-image');
+
+  contributorElementAnchor.appendChild(contributorElementImage);
+  contributorElement.appendChild(contributorElementAnchor);
+  document.getElementsByClassName('about-contributors-section')[0].appendChild(contributorElement);
+}
+
   }
   getContributors('https://api.github.com/repos/CircuitVerse/CircuitVerse/contributors?per_page=100');
 </script>


### PR DESCRIPTION
Fixes #6726 

### Problem
Sentry reported repeated `SELECT users` queries when fetching group members.

### Root Cause
Group member serializer accesses associated user attributes, causing N+1 queries when users were not eagerly loaded.

### Solution
- Added eager loading using `includes(:user)` in the group members controller.

### Result
- Eliminated N+1 queries
- Improved API performance
- Resolves **CIRCUITVERSE-CORE-YG**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added hash-based navigation for API documentation, allowing users to link directly to specific sections and maintain navigation state.

* **Improvements**
  * Enhanced accessibility by adding descriptive alt text to all contributor images throughout the about page.
  * Improved API docs sidebar navigation with dynamic dropdown expansion support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->