### PR TITLE
Fix active state highlight for landing page navbar

### DIFF
--- a/app/assets/javascripts/navbar.js
+++ b/app/assets/javascripts/navbar.js
@@ -1,127 +1,127 @@
-document.addEventListener("DOMContentLoaded", function () {
-  const searchIcons = document.getElementsByClassName("fa-search");
-  const searchBar = document.getElementsByClassName("navbar-search-active")[0];
-  const dropdownButton = document.getElementById("dropdownButton");
-  const dropdownIcon = document.getElementById("dropdownIcon");
-  const collapseElement = document.getElementById("collapsed-navbar");
-  const gettingStartedLink = document.querySelector("#getting-started-dropdown");
-  const navbar = document.querySelector(".navbar");
+document.addEventListener('DOMContentLoaded', () => {
+    const searchIcons = document.getElementsByClassName('fa-search');
+    const searchBar = document.getElementsByClassName('navbar-search-active')[0];
+    const dropdownButton = document.getElementById('dropdownButton');
+    const dropdownIcon = document.getElementById('dropdownIcon');
+    const collapseElement = document.getElementById('collapsed-navbar');
+    const gettingStartedLink = document.querySelector('#getting-started-dropdown');
+    const navbar = document.querySelector('.navbar');
 
-  function handleNavbarShadow() {
-    if (!navbar) return;
-    if (window.scrollY > 0) {
-      navbar.classList.add("affix");
-    } else {
-      navbar.classList.remove("affix");
-    }
-  }
-
-  window.addEventListener("scroll", handleNavbarShadow);
-
-  if (gettingStartedLink && window.bootstrap) {
-    const gettingStartedDropdown = new bootstrap.Dropdown(gettingStartedLink);
-    gettingStartedLink.addEventListener("click", function (e) {
-      if (gettingStartedLink.classList.contains("rotate180")) {
-        gettingStartedLink.classList.remove("rotate180");
-        gettingStartedDropdown.hide();
-      } else {
-        gettingStartedLink.classList.add("rotate180");
-        gettingStartedDropdown.show();
-      }
-      e.stopPropagation();
-    });
-    document.addEventListener("click", function () {
-      gettingStartedLink.classList.remove("rotate180");
-      gettingStartedDropdown.hide();
-    });
-  }
-
-  function activeSearchBar() {
-    if (!searchBar) return;
-    const icons = Array.from(searchIcons);
-    const isActive = icons.some((icon) => icon.classList.contains("active"));
-    if (isActive) {
-      icons.forEach((icon) => icon.classList.remove("active"));
-      searchBar.style.display = "none";
-    } else {
-      icons.forEach((icon) => icon.classList.add("active"));
-      searchBar.style.display = "block";
-    }
-    if (collapseElement) collapseElement.classList.remove("show");
-  }
-
-  if (dropdownButton && collapseElement && dropdownIcon && window.bootstrap) {
-    const bsCollapse = new bootstrap.Collapse(collapseElement, { toggle: false });
-    collapseElement.addEventListener("show.bs.collapse", function () {
-      dropdownIcon.classList.replace("fa-bars", "fa-times");
-      dropdownButton.setAttribute("aria-expanded", "true");
-    });
-    collapseElement.addEventListener("hide.bs.collapse", function () {
-      dropdownIcon.classList.replace("fa-times", "fa-bars");
-      dropdownButton.setAttribute("aria-expanded", "false");
-    });
-    dropdownButton.addEventListener("click", function (e) {
-      e.preventDefault();
-      bsCollapse.toggle();
-    });
-  }
-
-  Array.from(searchIcons).forEach((icon) => icon.addEventListener("click", activeSearchBar));
-
-  if (searchBar && window.location.href.includes("search")) {
-    searchBar.style.display = "block";
-    Array.from(searchIcons).forEach((icon) => icon.classList.add("active"));
-  }
-
-  function setActiveNavbarItem() {
-    const navLinks = Array.from(document.querySelectorAll(".main-nav-items a.navbar-item.navbar-text")).filter(
-      (link) => {
-        const href = link.getAttribute("href") || "";
-        if (!href) return false;
-        if (link.matches('[data-bs-toggle="dropdown"]')) return false;
-        if (link.classList.contains("navbar-user-dropdown")) return false;
-        return href.startsWith("/") || href.startsWith("#");
-      }
-    );
-
-    navLinks.forEach((link) => link.classList.remove("active"));
-
-    const currentPath = window.location.pathname;
-    const currentHash = window.location.hash;
-
-    const normalizedPath = currentPath.endsWith("/") && currentPath !== "/" ? currentPath.slice(0, -1) : currentPath;
-
-    if (normalizedPath === "/" && currentHash) {
-      const hashMatch = navLinks.find((link) => {
-        const href = link.getAttribute("href") || "";
-        try {
-          const linkHash = new URL(href, window.location.origin).hash;
-          return linkHash === currentHash;
-        } catch (_) {
-          return false;
+    const handleNavbarShadow = () => {
+        if (!navbar) return;
+        if (window.scrollY > 0) {
+            navbar.classList.add('affix');
+        } else {
+            navbar.classList.remove('affix');
         }
-      });
+    };
 
-      if (hashMatch) {
-        hashMatch.classList.add("active");
-      }
-      return;
+    window.addEventListener('scroll', handleNavbarShadow);
+
+    if (gettingStartedLink && window.bootstrap) {
+        const gettingStartedDropdown = bootstrap.Dropdown.getOrCreateInstance(gettingStartedLink);
+        gettingStartedLink.addEventListener('click', (e) => {
+            if (gettingStartedLink.classList.contains('rotate180')) {
+                gettingStartedLink.classList.remove('rotate180');
+                gettingStartedDropdown.hide();
+            } else {
+                gettingStartedLink.classList.add('rotate180');
+                gettingStartedDropdown.show();
+            }
+            e.stopPropagation();
+        });
+        document.addEventListener('click', () => {
+            gettingStartedLink.classList.remove('rotate180');
+            gettingStartedDropdown.hide();
+        });
     }
 
-    const pathMatch = navLinks.find((link) => {
-      const href = link.getAttribute("href") || "";
-      if (!href.startsWith("/")) return false;
-      const hrefPath = href.split("#")[0];
-      const normalizedHrefPath = hrefPath.endsWith("/") && hrefPath !== "/" ? hrefPath.slice(0, -1) : hrefPath;
-      return normalizedHrefPath === normalizedPath;
-    });
+    const activeSearchBar = () => {
+        if (!searchBar) return;
+        const icons = Array.from(searchIcons);
+        const isActive = icons.some((icon) => icon.classList.contains('active'));
+        if (isActive) {
+            icons.forEach((icon) => icon.classList.remove('active'));
+            searchBar.style.display = 'none';
+        } else {
+            icons.forEach((icon) => icon.classList.add('active'));
+            searchBar.style.display = 'block';
+        }
+        if (collapseElement) collapseElement.classList.remove('show');
+    };
 
-    if (pathMatch) {
-      pathMatch.classList.add("active");
+    if (dropdownButton && collapseElement && dropdownIcon && window.bootstrap) {
+        const bsCollapse = new bootstrap.Collapse(collapseElement, { toggle: false });
+        collapseElement.addEventListener('show.bs.collapse', () => {
+            dropdownIcon.classList.replace('fa-bars', 'fa-times');
+            dropdownButton.setAttribute('aria-expanded', 'true');
+        });
+        collapseElement.addEventListener('hide.bs.collapse', () => {
+            dropdownIcon.classList.replace('fa-times', 'fa-bars');
+            dropdownButton.setAttribute('aria-expanded', 'false');
+        });
+        dropdownButton.addEventListener('click', (e) => {
+            e.preventDefault();
+            bsCollapse.toggle();
+        });
     }
-  }
 
-  setActiveNavbarItem();
-  window.addEventListener("hashchange", setActiveNavbarItem);
-  window.addEventListener("popstate", setActiveNavbarItem);
+    Array.from(searchIcons).forEach((icon) => icon.addEventListener('click', activeSearchBar));
+
+    if (searchBar && window.location.href.includes('search')) {
+        searchBar.style.display = 'block';
+        Array.from(searchIcons).forEach((icon) => icon.classList.add('active'));
+    }
+
+    const setActiveNavbarItem = () => {
+        const navLinks = Array.from(document.querySelectorAll('.main-nav-items a.navbar-item.navbar-text')).filter(
+            (link) => {
+                const href = link.getAttribute('href') || '';
+                if (!href) return false;
+                if (link.matches('[data-bs-toggle="dropdown"]')) return false;
+                if (link.classList.contains('navbar-user-dropdown')) return false;
+                return href.startsWith('/') || href.startsWith('#');
+            },
+        );
+
+        navLinks.forEach((link) => link.classList.remove('active'));
+
+        const currentPath = window.location.pathname;
+        const currentHash = window.location.hash;
+
+        const normalizedPath = currentPath.endsWith('/') && currentPath !== '/' ? currentPath.slice(0, -1) : currentPath;
+
+        if (normalizedPath === '/' && currentHash) {
+            const hashMatch = navLinks.find((link) => {
+                const href = link.getAttribute('href') || '';
+                try {
+                    const linkHash = new URL(href, window.location.origin).hash;
+                    return linkHash === currentHash;
+                } catch (_) {
+                    return false;
+                }
+            });
+
+            if (hashMatch) {
+                hashMatch.classList.add('active');
+            }
+            return;
+        }
+
+        const pathMatch = navLinks.find((link) => {
+            const href = link.getAttribute('href') || '';
+            if (!href.startsWith('/')) return false;
+            const hrefPath = href.split('#')[0];
+            const normalizedHrefPath = hrefPath.endsWith('/') && hrefPath !== '/' ? hrefPath.slice(0, -1) : hrefPath;
+            return normalizedHrefPath === normalizedPath;
+        });
+
+        if (pathMatch) {
+            pathMatch.classList.add('active');
+        }
+    };
+
+    setActiveNavbarItem();
+    window.addEventListener('hashchange', setActiveNavbarItem);
+    window.addEventListener('popstate', setActiveNavbarItem);
 });

--- a/app/assets/javascripts/navbar.js
+++ b/app/assets/javascripts/navbar.js
@@ -66,11 +66,15 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    Array.from(searchIcons).forEach((icon) => icon.addEventListener('click', activeSearchBar));
+    Array.from(searchIcons).forEach((icon) => {
+        icon.addEventListener('click', activeSearchBar);
+    });
 
-    if (searchBar && window.location.href.includes('search')) {
+    if (searchBar && /^\/search(\/|$)/.test(window.location.pathname)) {
         searchBar.style.display = 'block';
-        Array.from(searchIcons).forEach((icon) => icon.classList.add('active'));
+        Array.from(searchIcons).forEach((icon) => {
+            icon.classList.add('active');
+        });
     }
 
     const setActiveNavbarItem = () => {

--- a/app/assets/javascripts/navbar.js
+++ b/app/assets/javascripts/navbar.js
@@ -112,6 +112,9 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
         }
 
+        // On the home page with no hash, don't activate any section-specific link
+        if (normalizedPath === '/') return;
+
         const pathMatch = navLinks.find((link) => {
             const href = link.getAttribute('href') || '';
             if (!href.startsWith('/')) return false;

--- a/app/assets/javascripts/navbar.js
+++ b/app/assets/javascripts/navbar.js
@@ -1,3 +1,23 @@
+// Patch History API to dispatch custom event for client-side routing
+(function patchHistoryAPI() {
+    const originalPushState = window.history.pushState;
+    const originalReplaceState = window.history.replaceState;
+
+    const dispatchNavigationEvent = () => {
+        window.dispatchEvent(new Event('navigation'));
+    };
+
+    window.history.pushState = function pushState(...args) {
+        originalPushState.apply(this, args);
+        dispatchNavigationEvent();
+    };
+
+    window.history.replaceState = function replaceState(...args) {
+        originalReplaceState.apply(this, args);
+        dispatchNavigationEvent();
+    };
+}());
+
 document.addEventListener('DOMContentLoaded', () => {
     const searchIcons = document.getElementsByClassName('fa-search');
     const searchBar = document.getElementsByClassName('navbar-search-active')[0];
@@ -131,4 +151,5 @@ document.addEventListener('DOMContentLoaded', () => {
     setActiveNavbarItem();
     window.addEventListener('hashchange', setActiveNavbarItem);
     window.addEventListener('popstate', setActiveNavbarItem);
+    window.addEventListener('navigation', setActiveNavbarItem);
 });

--- a/app/assets/javascripts/navbar.js
+++ b/app/assets/javascripts/navbar.js
@@ -1,0 +1,127 @@
+document.addEventListener("DOMContentLoaded", function () {
+  const searchIcons = document.getElementsByClassName("fa-search");
+  const searchBar = document.getElementsByClassName("navbar-search-active")[0];
+  const dropdownButton = document.getElementById("dropdownButton");
+  const dropdownIcon = document.getElementById("dropdownIcon");
+  const collapseElement = document.getElementById("collapsed-navbar");
+  const gettingStartedLink = document.querySelector("#getting-started-dropdown");
+  const navbar = document.querySelector(".navbar");
+
+  function handleNavbarShadow() {
+    if (!navbar) return;
+    if (window.scrollY > 0) {
+      navbar.classList.add("affix");
+    } else {
+      navbar.classList.remove("affix");
+    }
+  }
+
+  window.addEventListener("scroll", handleNavbarShadow);
+
+  if (gettingStartedLink && window.bootstrap) {
+    const gettingStartedDropdown = new bootstrap.Dropdown(gettingStartedLink);
+    gettingStartedLink.addEventListener("click", function (e) {
+      if (gettingStartedLink.classList.contains("rotate180")) {
+        gettingStartedLink.classList.remove("rotate180");
+        gettingStartedDropdown.hide();
+      } else {
+        gettingStartedLink.classList.add("rotate180");
+        gettingStartedDropdown.show();
+      }
+      e.stopPropagation();
+    });
+    document.addEventListener("click", function () {
+      gettingStartedLink.classList.remove("rotate180");
+      gettingStartedDropdown.hide();
+    });
+  }
+
+  function activeSearchBar() {
+    if (!searchBar) return;
+    const icons = Array.from(searchIcons);
+    const isActive = icons.some((icon) => icon.classList.contains("active"));
+    if (isActive) {
+      icons.forEach((icon) => icon.classList.remove("active"));
+      searchBar.style.display = "none";
+    } else {
+      icons.forEach((icon) => icon.classList.add("active"));
+      searchBar.style.display = "block";
+    }
+    if (collapseElement) collapseElement.classList.remove("show");
+  }
+
+  if (dropdownButton && collapseElement && dropdownIcon && window.bootstrap) {
+    const bsCollapse = new bootstrap.Collapse(collapseElement, { toggle: false });
+    collapseElement.addEventListener("show.bs.collapse", function () {
+      dropdownIcon.classList.replace("fa-bars", "fa-times");
+      dropdownButton.setAttribute("aria-expanded", "true");
+    });
+    collapseElement.addEventListener("hide.bs.collapse", function () {
+      dropdownIcon.classList.replace("fa-times", "fa-bars");
+      dropdownButton.setAttribute("aria-expanded", "false");
+    });
+    dropdownButton.addEventListener("click", function (e) {
+      e.preventDefault();
+      bsCollapse.toggle();
+    });
+  }
+
+  Array.from(searchIcons).forEach((icon) => icon.addEventListener("click", activeSearchBar));
+
+  if (searchBar && window.location.href.includes("search")) {
+    searchBar.style.display = "block";
+    Array.from(searchIcons).forEach((icon) => icon.classList.add("active"));
+  }
+
+  function setActiveNavbarItem() {
+    const navLinks = Array.from(document.querySelectorAll(".main-nav-items a.navbar-item.navbar-text")).filter(
+      (link) => {
+        const href = link.getAttribute("href") || "";
+        if (!href) return false;
+        if (link.matches('[data-bs-toggle="dropdown"]')) return false;
+        if (link.classList.contains("navbar-user-dropdown")) return false;
+        return href.startsWith("/") || href.startsWith("#");
+      }
+    );
+
+    navLinks.forEach((link) => link.classList.remove("active"));
+
+    const currentPath = window.location.pathname;
+    const currentHash = window.location.hash;
+
+    const normalizedPath = currentPath.endsWith("/") && currentPath !== "/" ? currentPath.slice(0, -1) : currentPath;
+
+    if (normalizedPath === "/" && currentHash) {
+      const hashMatch = navLinks.find((link) => {
+        const href = link.getAttribute("href") || "";
+        try {
+          const linkHash = new URL(href, window.location.origin).hash;
+          return linkHash === currentHash;
+        } catch (_) {
+          return false;
+        }
+      });
+
+      if (hashMatch) {
+        hashMatch.classList.add("active");
+      }
+      return;
+    }
+
+    const pathMatch = navLinks.find((link) => {
+      const href = link.getAttribute("href") || "";
+      if (!href.startsWith("/")) return false;
+      const hrefPath = href.split("#")[0];
+      const normalizedHrefPath = hrefPath.endsWith("/") && hrefPath !== "/" ? hrefPath.slice(0, -1) : hrefPath;
+      return normalizedHrefPath === normalizedPath;
+    });
+
+    if (pathMatch) {
+      pathMatch.classList.add("active");
+    }
+  }
+
+  setActiveNavbarItem();
+  window.addEventListener("hashchange", setActiveNavbarItem);
+  window.addEventListener("popstate", setActiveNavbarItem);
+});

--- a/app/assets/stylesheets/navbar.scss
+++ b/app/assets/stylesheets/navbar.scss
@@ -4,9 +4,7 @@
   top: 0;
   width: 100%;
   z-index: 100;
-}
 
-.navbar {
   .nav-link.navbar-text.active {
     color: $primary-green !important;
   }

--- a/app/assets/stylesheets/navbar.scss
+++ b/app/assets/stylesheets/navbar.scss
@@ -6,6 +6,12 @@
   z-index: 100;
 }
 
+.navbar {
+  .nav-link.navbar-text.active {
+    color: $primary-green !important;
+  }
+}
+
 .navbar-logo {
   height: 70px;
   padding-top: 5px;
@@ -75,7 +81,10 @@
   }
 
   &.active {
-    color: $secondary-green;
+    color: $primary-green !important;
+    text-decoration: underline;
+    text-underline-offset: 6px;
+    text-decoration-thickness: 2px;
   }
 
   &:focus {
@@ -159,17 +168,17 @@
     padding: 8px 12px;
     font-size: 14px;
     min-width: 0;
-    
+
     &:focus {
       outline: 1px solid $primary-green;
       border-radius: 8px;
     }
-    
+
     &:first-child {
       border-right: 1px solid $shadow-grey;
       flex: 1;
     }
-    
+
     span {
       overflow: hidden;
       text-overflow: ellipsis;
@@ -239,7 +248,7 @@
   position: relative;
 
   button {
-    background: none; 
+    background: none;
     border: 1px solid $shadow-grey;
     border-radius: 8px;
     cursor: pointer;
@@ -297,12 +306,12 @@
     padding: 8px 10px;
     font-size: 14px;
     transition: border-color 0.2s ease;
-    
+
     &:focus {
       outline: none;
       border-color: $primary-green;
     }
-    
+
     &::placeholder {
       color: lighten($navbar-dark-grey, 20%);
     }
@@ -411,12 +420,12 @@
     appearance: none;
     width: 100%;
     cursor: pointer;
-    
+
     &:focus {
       outline: none;
       border-color: $primary-green;
     }
-    
+
     &:hover {
       border-color: darken($shadow-grey, 10%);
     }

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -13,22 +13,22 @@
       <div class="d-flex justify-content-between align-items-start align-items-lg-center w-100 flex-column flex-lg-row gap-3 px-2 px-lg-0">
         <ul class="navbar-nav main-nav-items mx-auto d-flex flex-lg-row flex-column gap-lg-3 margin-lg-0">
           <li class="nav-item">
-            <a class="nav-link navbar-item navbar-text <%= request.path == "/simulator" ? "active" : "" %>" href="/simulator"><%= t("layout.link_to_simulator") %></a>
+            <a class="nav-link navbar-item navbar-text" href="/simulator"><%= t("layout.link_to_simulator") %></a>
           </li>
           <li class="nav-item">
             <a class="nav-link navbar-item navbar-text" href="/#home-features-section"><%= t("layout.link_to_features") %></a>
           </li>
           <% if Flipper.enabled?(:circuit_explore_page, current_user) %>
             <li class="nav-item">
-              <a class="nav-link navbar-item navbar-text <%= request.path == "/explore" ? "active" : "" %>" href="/explore"><%= t("layout.link_to_explore") %></a>
+              <a class="nav-link navbar-item navbar-text" href="/explore"><%= t("layout.link_to_explore") %></a>
             </li>
           <% end %>
           <li class="nav-item">
-            <a class="nav-link navbar-item navbar-text <%= request.path == "/teachers" ? "active" : "" %>" href="/teachers"><%= t("layout.link_to_teachers") %></a>
+            <a class="nav-link navbar-item navbar-text" href="/teachers"><%= t("layout.link_to_teachers") %></a>
           </li>
           <% if Flipper.enabled?(:contests, current_user) %>
             <li class="nav-item">
-              <a class="nav-link navbar-item navbar-text <%= request.path == "/contests" ? "active" : "" %>" href="/contests"><%= t("layout.link_to_contests") %></a>
+              <a class="nav-link navbar-item navbar-text" href="/contests"><%= t("layout.link_to_contests") %></a>
             </li>
           <% end %>
           <li class="nav-item dropdown">
@@ -44,7 +44,7 @@
             <a class="nav-link navbar-item navbar-text" href="https://blog.circuitverse.org/" target="_blank" rel="noopener"><%= t("layout.link_to_blog") %></a>
           </li>
           <li class="nav-item">
-            <a class="nav-link navbar-item navbar-text <%= request.path == "/about" ? "active" : "" %>" href="/about"><%= t("layout.link_to_about") %></a>
+            <a class="nav-link navbar-item navbar-text" href="/about"><%= t("layout.link_to_about") %></a>
           </li>
           <li class="nav-item d-flex align-items-center">
             <i class="fa fa-search search-icon" tabindex="0" aria-label="search"></i>
@@ -87,122 +87,3 @@
     current_filters: @current_filters
   )) %>
 </div>
-<script type="text/javascript">
-  document.addEventListener("DOMContentLoaded", function() {
-    const searchIcons = document.getElementsByClassName("fa-search");
-    const searchBar = document.getElementsByClassName("navbar-search-active")[0];
-    const dropdownButton = document.getElementById('dropdownButton');
-    const dropdownIcon = document.getElementById('dropdownIcon');
-    const collapseElement = document.getElementById("collapsed-navbar");
-    const gettingStartedLink = document.querySelector("#getting-started-dropdown");
-    const navbar = document.querySelector('.navbar');
-
-    function handleNavbarShadow() {
-      if (window.scrollY > 0) {
-        navbar.classList.add('affix');
-      } else {
-        navbar.classList.remove('affix');
-      }
-    }
-    window.addEventListener('scroll', handleNavbarShadow);
-
-    if (gettingStartedLink) {
-      const gettingStartedDropdown = new bootstrap.Dropdown(gettingStartedLink);
-      gettingStartedLink.addEventListener("click", function (e) {
-        if (gettingStartedLink.classList.contains("rotate180")) {
-          gettingStartedLink.classList.remove("rotate180");
-          gettingStartedDropdown.hide();
-        } else {
-          gettingStartedLink.classList.add("rotate180");
-          gettingStartedDropdown.show();
-        }
-        e.stopPropagation();
-      });
-      document.addEventListener("click", function () {
-        gettingStartedLink.classList.remove("rotate180");
-        gettingStartedDropdown.hide();
-      });
-    }
-
-    function activeSearchBar() {
-      const icons = Array.from(searchIcons);
-      const isActive = icons.some(icon => icon.classList.contains("active"));
-      if (isActive) {
-        icons.forEach(icon => icon.classList.remove("active"));
-        searchBar.style.display = "none";
-      } else {
-        icons.forEach(icon => icon.classList.add("active"));
-        searchBar.style.display = "block";
-      }
-      collapseElement.classList.remove("show");
-    }
-
-    if (dropdownButton && collapseElement && dropdownIcon) {
-      const bsCollapse = new bootstrap.Collapse(collapseElement, { toggle: false });
-      collapseElement.addEventListener('show.bs.collapse', function() {
-        dropdownIcon.classList.replace('fa-bars','fa-times');
-        dropdownButton.setAttribute('aria-expanded','true');
-      });
-      collapseElement.addEventListener('hide.bs.collapse', function() {
-        dropdownIcon.classList.replace('fa-times','fa-bars');
-        dropdownButton.setAttribute('aria-expanded','false');
-      });
-      dropdownButton.addEventListener('click', function(e) {
-        e.preventDefault();
-        bsCollapse.toggle();
-      });
-    }
-
-    Array.from(searchIcons).forEach(icon => icon.addEventListener("click", activeSearchBar));
-
-    if (window.location.href.includes('search')) {
-      searchBar.style.display = "block";
-      Array.from(searchIcons).forEach(icon => icon.classList.add("active"));
-    }
-
-    function setActiveNavbarItem() {
-      const navLinks = Array.from(document.querySelectorAll('.main-nav-items a.navbar-item.navbar-text'))
-        .filter(link => {
-          const href = link.getAttribute('href') || '';
-          if (!href) return false;
-          if (link.matches('[data-bs-toggle="dropdown"]')) return false;
-          if (link.classList.contains('navbar-user-dropdown')) return false;
-          return href.startsWith('/') || href.startsWith('#');
-        });
-
-      navLinks.forEach(link => link.classList.remove('active'));
-
-      const currentPath = window.location.pathname;
-      const currentHash = window.location.hash;
-
-      const normalizedPath = currentPath.endsWith('/') && currentPath !== '/' ? currentPath.slice(0, -1) : currentPath;
-
-      if (normalizedPath === '/' && currentHash) {
-        const hashMatch = navLinks.find(link => {
-          const href = link.getAttribute('href') || '';
-          return href.includes(currentHash);
-        });
-        if (hashMatch) {
-          hashMatch.classList.add('active');
-        }
-        return;
-      }
-
-      const pathMatch = navLinks.find(link => {
-        const href = link.getAttribute('href') || '';
-        if (!href.startsWith('/')) return false;
-        const hrefPath = href.split('#')[0];
-        const normalizedHrefPath = hrefPath.endsWith('/') && hrefPath !== '/' ? hrefPath.slice(0, -1) : hrefPath;
-        return normalizedHrefPath === normalizedPath;
-      });
-
-      if (pathMatch) {
-        pathMatch.classList.add('active');
-      }
-    }
-
-    setActiveNavbarItem();
-    window.addEventListener('hashchange', setActiveNavbarItem);
-    window.addEventListener('popstate', setActiveNavbarItem);
-  });
-</script>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -13,7 +13,7 @@
       <div class="d-flex justify-content-between align-items-start align-items-lg-center w-100 flex-column flex-lg-row gap-3 px-2 px-lg-0">
         <ul class="navbar-nav main-nav-items mx-auto d-flex flex-lg-row flex-column gap-lg-3 margin-lg-0">
           <li class="nav-item">
-            <a class="nav-link navbar-item navbar-text" href="/simulator"><%= t("layout.link_to_simulator") %></a>
+            <a class="nav-link navbar-item navbar-text <%= request.path == "/simulator" ? "active" : "" %>" href="/simulator"><%= t("layout.link_to_simulator") %></a>
           </li>
           <li class="nav-item">
             <a class="nav-link navbar-item navbar-text" href="/#home-features-section"><%= t("layout.link_to_features") %></a>
@@ -24,7 +24,7 @@
             </li>
           <% end %>
           <li class="nav-item">
-            <a class="nav-link navbar-item navbar-text" href="/teachers"><%= t("layout.link_to_teachers") %></a>
+            <a class="nav-link navbar-item navbar-text <%= request.path == "/teachers" ? "active" : "" %>" href="/teachers"><%= t("layout.link_to_teachers") %></a>
           </li>
           <% if Flipper.enabled?(:contests, current_user) %>
             <li class="nav-item">
@@ -44,7 +44,7 @@
             <a class="nav-link navbar-item navbar-text" href="https://blog.circuitverse.org/" target="_blank" rel="noopener"><%= t("layout.link_to_blog") %></a>
           </li>
           <li class="nav-item">
-            <a class="nav-link navbar-item navbar-text" href="/about"><%= t("layout.link_to_about") %></a>
+            <a class="nav-link navbar-item navbar-text <%= request.path == "/about" ? "active" : "" %>" href="/about"><%= t("layout.link_to_about") %></a>
           </li>
           <li class="nav-item d-flex align-items-center">
             <i class="fa fa-search search-icon" tabindex="0" aria-label="search"></i>
@@ -159,5 +159,50 @@
       searchBar.style.display = "block";
       Array.from(searchIcons).forEach(icon => icon.classList.add("active"));
     }
+
+    function setActiveNavbarItem() {
+      const navLinks = Array.from(document.querySelectorAll('.main-nav-items a.navbar-item.navbar-text'))
+        .filter(link => {
+          const href = link.getAttribute('href') || '';
+          if (!href) return false;
+          if (link.matches('[data-bs-toggle="dropdown"]')) return false;
+          if (link.classList.contains('navbar-user-dropdown')) return false;
+          return href.startsWith('/') || href.startsWith('#');
+        });
+
+      navLinks.forEach(link => link.classList.remove('active'));
+
+      const currentPath = window.location.pathname;
+      const currentHash = window.location.hash;
+
+      const normalizedPath = currentPath.endsWith('/') && currentPath !== '/' ? currentPath.slice(0, -1) : currentPath;
+
+      if (normalizedPath === '/' && currentHash) {
+        const hashMatch = navLinks.find(link => {
+          const href = link.getAttribute('href') || '';
+          return href.includes(currentHash);
+        });
+        if (hashMatch) {
+          hashMatch.classList.add('active');
+        }
+        return;
+      }
+
+      const pathMatch = navLinks.find(link => {
+        const href = link.getAttribute('href') || '';
+        if (!href.startsWith('/')) return false;
+        const hrefPath = href.split('#')[0];
+        const normalizedHrefPath = hrefPath.endsWith('/') && hrefPath !== '/' ? hrefPath.slice(0, -1) : hrefPath;
+        return normalizedHrefPath === normalizedPath;
+      });
+
+      if (pathMatch) {
+        pathMatch.classList.add('active');
+      }
+    }
+
+    setActiveNavbarItem();
+    window.addEventListener('hashchange', setActiveNavbarItem);
+    window.addEventListener('popstate', setActiveNavbarItem);
   });
 </script>


### PR DESCRIPTION
Fixes #6806

#### Describe the changes you have made in this PR -
- Added a clear active state indicator (green + underline) for the landing page navigation items.
- Implemented client-side active-tab handling for hash-based navigation on the home page (e.g. `/#home-features-section`) since URL hashes are not available server-side.
- Added/kept route-based active styling for normal pages like `/simulator`, `/teachers`, and `/about`.

### Screenshots of the UI changes (If any) -
<img width="1848" height="964" alt="image" src="https://github.com/user-attachments/assets/c113d990-fae3-45f2-a070-dd62de1af82b" />
---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [X] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [X] I have reviewed every single line of the AI-generated code
- [X] I can explain the purpose and logic of each function/component I added
- [X] I have tested edge cases and understand how the code handles them
- [X] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!--
Problem:
Landing page navbar items (like Features -> `/#home-features-section`) did not show an active state because hashes are not sent to the server, and there was no client-side logic to apply the active class.

Approach:
1) For route-based pages (/simulator, /teachers, /about), apply `.active` server-side using `request.path`.
2) For the landing page hash link (Features), add a small JS function that:
   - clears any existing `.active` classes
   - checks `window.location.pathname` and `window.location.hash`
   - applies `.active` to the matching navbar link
   - updates on `hashchange` and `popstate`
3) Update SCSS to ensure the active navbar item is highlighted with the site's primary green color and an underline (override Bootstrap link color where needed).

Why this approach:
Hash-based state can’t be reliably handled on the server in Rails templates, so a small targeted JS solution keeps the change minimal and localized.
-->

---

## Checklist before requesting a review
- [X] I have added proper PR title and linked to the issue
- [X] I have performed a self-review of my code
- [X] **I can explain the purpose of every function, class, and logic block I added**
- [X] I understand why my changes work and have tested them thoroughly
- [X] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [X] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Navbar now auto-highlights active links in real time (hash/history changes included).
  * Improved navbar behavior: shadow/affix on scroll, animated dropdown, responsive collapse with updated icons/ARIA, and click-to-toggle search bar that auto-opens on search pages.

* **Style**
  * Active navigation styling updated to primary-green with underline, increased underline offset and thickness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->