### PR TITLE
fix: ensure complete text highlighting on dropdown item hover

### DIFF
--- a/app/assets/stylesheets/navbar.scss
+++ b/app/assets/stylesheets/navbar.scss
@@ -59,6 +59,9 @@
 }
 
 .dropdown-item {
+  display: block;
+  width: 100%;
+  
   &:hover {
     background-color: $primary-green;
     color: $white;


### PR DESCRIPTION
Fixes #2919 – Dropdown items fully highlight on hover

While testing the Help menu (for example, “Learn Digital Logic”), I noticed the hover effect on dropdown items looked off. Only part of the item was getting the background highlight, which made it feel inconsistent.

Issue

The .dropdown-item class didn’t explicitly define its display or width. Because of that, the hover background only covered part of the clickable area instead of the entire row.

Fix

Updated .dropdown-item to behave like a full-width block element so the hover state covers the whole item:

.dropdown-item {
  display: block;
  width: 100%;
  
  &:hover {
    background-color: $primary-green;
    color: $white;
  }
}


Now the entire dropdown item highlights on hover, making the interaction clearer and the UI more polished.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced dropdown menu item styling for improved layout and visual presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->