### PR TITLE
fix: standardize url capitalization in group invite notices

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -34,9 +34,9 @@ class GroupsController < ApplicationController
         notice = "Group member was successfully added."
       end
     elsif Group.exists?(group_token: params[:token])
-      notice = "Url is expired, request a new one from the primary mentor of the group."
+      notice = "URL is expired, request a new one from the primary mentor of the group."
     else
-      notice = "Invalid url"
+      notice = "Invalid URL"
     end
     redirect_to group_path(@group), notice: notice
   end

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -131,7 +131,7 @@ describe GroupsController, type: :request do
         get invite_group_path(id: @group.id, token: @group.group_token)
         expect(response.status).to eq(302)
         expect(flash[:notice])
-          .to eq("Url is expired, request a new one from the primary mentor of the group.")
+          .to eq("URL is expired, request a new one from the primary mentor of the group.")
       end
     end
 
@@ -140,6 +140,7 @@ describe GroupsController, type: :request do
         sign_in @user
         get invite_group_path(id: @group.id, token: "abc")
         expect(response.status).to eq(302)
+        expect(flash[:notice]).to eq("Invalid URL")
       end
     end
   end


### PR DESCRIPTION
Fixes #6924

#### Describe the changes you have made in this PR -
Updated the group invite notice strings to use consistent URL capitalization in `app/controllers/groups_controller.rb`.

The expired-token path now returns `URL is expired, request a new one from the primary mentor of the group.` and the invalid-token path now returns `Invalid URL`.

Updated `spec/controllers/groups_controller_spec.rb` to match the corrected expired-token text and added an explicit expectation for the invalid-token flash notice.

Behavioral change: users now see correctly capitalized URL in both invite error notices.

How to verify:
1. Run `bundle exec rspec spec/controllers/groups_controller_spec.rb`.
2. Open an expired invite link and confirm the flash notice shows `URL is expired...`.
3. Open an invalid invite link and confirm the flash notice shows `Invalid URL`.

### Screenshots of the UI changes (If any) -
Not applicable.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Adjusted two user-facing strings in `GroupsController#group_invite` to remove inconsistent capitalization and aligned controller specs with the updated copy. The change is intentionally minimal and scoped to invite notice messaging.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.