### PR TITLE
fix: correct separator typo in api pagination helper

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -89,7 +89,7 @@ class Api::V1::BaseController < ActionController::API
   private
 
     def paginated_url(base_url, page)
-      seperator = base_url.index("?").nil? ? "?" : "&"
-      "#{base_url}#{seperator}page[number]=#{page}" if page
+      separator = base_url.index("?").nil? ? "?" : "&"
+      "#{base_url}#{separator}page[number]=#{page}" if page
     end
 end


### PR DESCRIPTION
Fixes #6950

#### Describe the changes you have made in this PR -
Renamed a misspelled local variable in `app/controllers/api/v1/base_controller.rb` from `seperator` to `separator` inside `paginated_url`.

This is a readability/maintenance fix in the shared pagination URL helper and does not change behavior.

Behavioral change: none.

How to verify:
1. Open `app/controllers/api/v1/base_controller.rb`.
2. Confirm `paginated_url` uses `separator` in both assignment and interpolation.

### Screenshots of the UI changes (If any) -
Not applicable.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Kept the change minimal and only fixed the typo in the helper variable name.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a typographical error in pagination URL generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->