### PR TITLE
test: fix response typo in simulator post issue spec

### DIFF
--- a/spec/requests/api/v1/simulator_controller/post_issue_spec.rb
+++ b/spec/requests/api/v1/simulator_controller/post_issue_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Api::V1::SimulatorController, type: :request do
       end
     end
 
-    context "when SLACK_ISSUE_HOOK_URL is present and returns reponse ok" do
+    context "when SLACK_ISSUE_HOOK_URL is present and returns response ok" do
       before do
         allow(ENV).to receive(:fetch).with("SLACK_ISSUE_HOOK_URL", nil).and_return("https://circuitverse.valid")
         stub_request(:post, "https://circuitverse.valid").to_return(status: 200, body: "", headers: {})


### PR DESCRIPTION
Fixes #6956

#### Describe the changes you have made in this PR -
Corrected a typo in `spec/requests/api/v1/simulator_controller/post_issue_spec.rb` by replacing `reponse` with `response` in test description text.

This is a test readability fix only.

Behavioral change: none.

How to verify:
1. Run `bundle exec rspec spec/requests/api/v1/simulator_controller/post_issue_spec.rb`.
2. Confirm all tests pass.

### Screenshots of the UI changes (If any) -
Not applicable.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Applied a single typo correction in spec text and verified the target spec still passes.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.