### PR TITLE
test: fix typo strings in search controller spec

### DIFF
--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 describe SearchController, type: :request do
   describe "#search" do
-    context "search in a non-existant resource" do
+    context "search in a non-existent resource" do
       it "returns not found error" do
         get search_path, params: { q: "Dummy query", resource: "NonExistantResource" }
         expect(response.body).to include("OOPS,THE PAGE YOU ARE LOOKING FOR CAN'T BE FOUND!")
@@ -28,15 +28,15 @@ describe SearchController, type: :request do
 
       context "search through educational institute" do
         before do
-          FactoryBot.create(:user, name: "Dummy Techinical University")
-          FactoryBot.create(:user, name: "Another Dummy Techinical University")
+          FactoryBot.create(:user, name: "Dummy Technical University")
+          FactoryBot.create(:user, name: "Another Dummy Technical University")
         end
 
         it "returns results" do
-          get search_path, params: { q: "Techinical", resource: "Users" }
+          get search_path, params: { q: "Technical", resource: "Users" }
           expect(response.status).to eq(200)
-          expect(response.body).to include("Dummy Techinical University")
-          expect(response.body).to include("Another Dummy Techinical University")
+          expect(response.body).to include("Dummy Technical University")
+          expect(response.body).to include("Another Dummy Technical University")
         end
       end
     end
@@ -72,7 +72,7 @@ describe SearchController, type: :request do
         end
       end
 
-      context "searching for a non-existant project" do
+      context "searching for a non-existent project" do
         it "gets no results" do
           FactoryBot.create(:project, name: "Full adder using basic gates",
                                       project_access_type: "Public")


### PR DESCRIPTION
Fixes #6958

#### Describe the changes you have made in this PR -
Updated typo strings in `spec/controllers/search_controller_spec.rb`.

Replaced `non-existant` with `non-existent` and `Techinical` with `Technical` in test descriptions and related expected values.

Behavioral change: none; this is test text/data cleanup.

How to verify:
1. Run `bundle exec rspec spec/controllers/search_controller_spec.rb`.
2. Confirm all examples pass.

### Screenshots of the UI changes (If any) -
Not applicable.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Kept this PR scoped to typo cleanup in a single spec file and validated by running that spec file.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.