### PR TITLE
docs: fix announcement heading typo in locale

### DIFF
--- a/config/locales/views/announcements/en.yml
+++ b/config/locales/views/announcements/en.yml
@@ -3,5 +3,5 @@ en:
     learn_more: "Learn More"
     edit_announcement_heading: "Edit Announcement"
     recent_announcement_heading: "Recent Announcements"
-    new_announcement: "New Annnouncement"
+    new_announcement: "New Announcement"
     no_announcement_heading: "No announcements so far."


### PR DESCRIPTION
Fixes #6961

#### Describe the changes you have made in this PR -
Corrected a typo in `config/locales/views/announcements/en.yml` by updating `New Annnouncement` to `New Announcement`.

This is a text-only locale fix for the announcement heading.

Behavioral change: none.

How to verify:
1. Open `config/locales/views/announcements/en.yml`.
2. Confirm `new_announcement` is `New Announcement`.

### Screenshots of the UI changes (If any) -
Not included.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Applied a one-word correction in the English locale without touching unrelated translation keys.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.