### PR TITLE
test: fix callback description typo in pending invitation spec

### DIFF
--- a/spec/models/pending_invitation_spec.rb
+++ b/spec/models/pending_invitation_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe PendingInvitation, type: :model do
   end
 
   describe "callbacks" do
-    it "alls respective callbacks" do
+    it "calls respective callbacks" do
       expect_any_instance_of(described_class).to receive(:send_pending_invitation_mail)
       FactoryBot.create(:pending_invitation, group: @group)
     end


### PR DESCRIPTION
Fixes #6963

#### Describe the changes you have made in this PR -
Updated one typo in `spec/models/pending_invitation_spec.rb` by changing `alls respective callbacks` to `calls respective callbacks`.

This improves test output readability without changing behavior.

Behavioral change: none.

How to verify:
1. Run `bundle exec rspec spec/models/pending_invitation_spec.rb`.
2. Confirm all examples pass and the description text is corrected.

### Screenshots of the UI changes (If any) -
Not applicable.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Applied a single-line spec description correction and validated by running the target spec file.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Corrected a test description text for accuracy and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->