### PR TITLE
test: fix signed-in wording typo in grades spec

### DIFF
--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -25,7 +25,7 @@ describe GradesController, type: :request do
       }
     end
 
-    context "when primary_mentor is singed in" do
+    context "when primary_mentor is signed in" do
       before do
         sign_in @primary_mentor
       end
@@ -52,7 +52,7 @@ describe GradesController, type: :request do
       end
     end
 
-    context "when a mentor is singed in" do
+    context "when a mentor is signed in" do
       before do
         sign_in_group_mentor(@group)
       end


### PR DESCRIPTION
Fixes #6965

#### Describe the changes you have made in this PR -
Corrected two context description typos in `spec/controllers/grades_controller_spec.rb` by changing `singed in` to `signed in`.

This is a test-text cleanup for readability and consistency.

Behavioral change: none.

How to verify:
1. Run `bundle exec rspec spec/controllers/grades_controller_spec.rb`.
2. Confirm all tests pass and context descriptions are corrected.

### Screenshots of the UI changes (If any) -
Not applicable.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Applied direct wording fixes in the affected spec contexts and validated with the target spec run.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.