### PR TITLE
test: fix simulator context wording typo in spec

### DIFF
--- a/spec/controllers/simulator_controller_spec.rb
+++ b/spec/controllers/simulator_controller_spec.rb
@@ -167,7 +167,7 @@ describe SimulatorController, type: :request do
     end
 
     describe "#redirect_to_vue_simulator_if_enabled" do
-      context "when vuesim is enabled for user and user opens black simualtor" do
+      context "when vuesim is enabled for user and user opens blank simulator" do
         before do
           allow(Flipper).to receive(:enabled?).with(:vuesim, @user).and_return(true)
           get simulator_new_path


### PR DESCRIPTION
Fixes #6969

#### Describe the changes you have made in this PR -
Corrected one context description typo in `spec/controllers/simulator_controller_spec.rb` by changing `black simualtor` to `blank simulator`.

This aligns the wording with the intended blank simulator scenario and fixes spelling.

Behavioral change: none.

How to verify:
1. Run `bundle exec rspec spec/controllers/simulator_controller_spec.rb`.
2. Confirm all tests pass and context wording is corrected.

### Screenshots of the UI changes (If any) -
Not applicable.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Updated only the affected context text and validated by running the simulator controller spec file.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.