### PR TITLE
fix: remove duplicate assignment update call

### DIFF
--- a/app/controllers/api/v1/assignments_controller.rb
+++ b/app/controllers/api/v1/assignments_controller.rb
@@ -36,7 +36,6 @@ class Api::V1::AssignmentsController < Api::V1::BaseController
 
   # PATCH /api/v1/assignments/:id
   def update
-    @assignment.update!(assignment_update_params)
     if @assignment.update(assignment_update_params)
       render json: Api::V1::AssignmentSerializer.new(@assignment, @options), status: :accepted
     else


### PR DESCRIPTION
Fixes #6975

#### Describe the changes you have made in this PR -
- Removed the redundant `update!` call from `Api::V1::AssignmentsController#update`.
- The endpoint now performs a single update operation before rendering the response.
- Affected file: `app/controllers/api/v1/assignments_controller.rb`.

### Screenshots of the UI changes (If any) -
N/A

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
- The issue came from two back-to-back updates in the same action.
- Kept the existing conditional `update` flow and removed only the duplicate write to preserve current behavior and error handling.
- Verified with targeted request specs.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

#### Verification
- `bundle exec rubocop app/controllers/api/v1/assignments_controller.rb`
- `bundle exec rspec spec/requests/api/v1/assignments_controller/update_spec.rb`