### PR TITLE
fix: remove duplicate group create save call

### DIFF
--- a/app/controllers/api/v1/groups_controller.rb
+++ b/app/controllers/api/v1/groups_controller.rb
@@ -31,7 +31,6 @@ class Api::V1::GroupsController < Api::V1::BaseController
   # POST /api/v1/groups/
   def create
     @group = current_user.groups_owned.new(group_params)
-    @group.save!
     if @group.save
       render json: Api::V1::GroupSerializer.new(@group, @options), status: :created
     else


### PR DESCRIPTION
Fixes #6982

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -
Removed redundant save! call from Api::V1::GroupsController#create.
The endpoint now performs a single save operation before rendering response.
Affected file: app/controllers/api/v1/groups_controller.rb.

### Screenshots of the UI changes (If any) -
<!-- Do not add code diff here -->
N/A

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->
The issue was two back-to-back save calls in the create action. Removed the duplicate save! call while preserving the existing validation and response flow. Verified with targeted request specs.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.