### PR TITLE
Fix: Remove hardcoded placeholder text in test bench UI (#7007)

### DIFF
--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -416,7 +416,7 @@
           <button class="custom-btn--primary panel-button tb-dialog-button" id="runall-btn">Run All</button>
         </div>
         <span class="testbench-runall-label">
-          <span id="runall-summary">placeholder</span> Tests Passed <span id="runall-detailed-link" style="color: #18A2CD;">View Detailed</span>
+          <span id="runall-summary">0</span> Tests Passed <span id="runall-detailed-link" style="color: #18A2CD;">View Detailed</span>
         </span>
       </div>
   </div>


### PR DESCRIPTION
Fixes #7007

#### Describe the changes you have made in this PR -
I replaced the hardcoded "placeholder" text with "0" in `app/views/simulator/edit.html.erb`. This prevents the word "placeholder" from temporarily rendering on the screen before the JavaScript takes over, and stops screen readers from reading it incorrectly.

### Screenshots of the UI changes (If any) -
No screenshots attached as this just fixes the initial HTML state. The final rendered UI remains exactly the same.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The problem was a literal string "placeholder" sitting in the DOM inside `<span id="runall-summary">`. My approach was simply to change the initial HTML value to `0`. This way, if JS is delayed, fails, or is parsed by a screen reader early, the user sees a valid default numerical state instead of a weird text string. No new functions or logic were needed, just a simple HTML update!

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed test-run summary display to show "0" instead of "placeholder" on initial load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->