### PR TITLE
fix: correct horizontal rule placement between mentors and members section (#6898)

### DIFF
--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -41,13 +41,13 @@
     </button>
   <% end %>
 </div>
-<hr>
 <% if @group.group_members.mentor.blank? %>
   <span class="null-text"><%= t("groups.show.no_mentors_html") %></span>
 <% end %>
 <div class="row">
   <%= render partial: "group_mentors", locals: { group: @group } %>
 </div>
+<hr>
 
 <!-- Members Section -->
 <div class="d-flex justify-content-between align-items-center mb-2">
@@ -61,13 +61,13 @@
     </button>
   <% end %>
 </div>
-<hr>
 <% if @group.group_members.member.blank? %>
   <span class="null-text"><%= t("groups.show.no_members_html") %></span>
 <% end %>
 <div class="row">
   <%= render partial: "group_members", locals: { group: @group } %>
 </div>
+<hr>
 
 <!-- Assignments Section -->
 <div class="d-flex justify-content-between align-items-center mb-2">


### PR DESCRIPTION
## Description

Fixes the incorrect placement of the horizontal rule that caused the Mentors description to appear under the Members section.

The `<hr>` elements were positioned between section headers and content, which resulted in improper visual separation.

## Changes Made

- Repositioned `<hr>` elements to properly separate complete sections
- Maintained semantic HTML structure
- Ensured consistent layout between Mentors and Members sections
- No logic changes introduced

## Testing

- Verified layout renders correctly in browser
- Confirmed Mentors and Members sections are visually separated
- Ensured no functionality changes occurred

Fixes #6898

---

## Code Understanding and AI Usage

- I have reviewed the entire change manually.
- The fix is structural and does not introduce new logic.
- I tested the layout after the modification.
- I used AI assistance to help draft the explanation, but all code changes were reviewed and understood before submission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined visual layout by adjusting the placement of horizontal rule separators in group sections for improved page organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->