### PR TITLE
Fix: Correct input name in greet workflow (repo_token)

### DIFF
--- a/.github/workflows/greet.yml
+++ b/.github/workflows/greet.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Welcome new contributors
         uses: actions/first-interaction@v3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
           issue_message: |
             ## 🚀 Welcome to CircuitVerse! 
             


### PR DESCRIPTION
Fixes #

Fixes #7029 

## Summary

Fixes the Greet First-Time Contributors GitHub Actions workflow by correcting an invalid input parameter name.

## Problem
The workflow uses:

    repo-token: ${{ secrets.GITHUB_TOKEN }}

However, actions/first-interaction@v3 expects the parameter name `repo_token`.

This causes the warning:
Unexpected input(s) ‘repo-token’, valid inputs are ['issue_message', 'pr_message', 'repo_token']

As a result:
- The workflow fails during execution.
- First-time contributors do not receive greeting messages.
- CI reports a configuration warning.

## Solution
Updated `.github/workflows/greet.yml` to replace `repo-token` with `repo_token`.

## Result
- Workflow executes successfully.
- First-time contributors receive welcome messages.
- CI no longer reports invalid input warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->