### PR TITLE
fix-forgot

### DIFF
--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -25,10 +25,11 @@
             </div>
           </div>
           <div class="field mb-3">
-            <div class="input-group">
-              <%= f.submit t("users.passwords.send_reset_link"), class: "btn primary-button users-primary-button" %>
-              <%= link_to t("users.passwords.link_to_login_page"), new_user_session_path, class: "anchor-text mt-2" %>
-            </div>
+  <%= f.submit t("users.passwords.send_reset_link"), 
+      class: "btn primary-button users-primary-button w-100" %>
+  <%= link_to t("users.passwords.link_to_login_page"), 
+      new_user_session_path, 
+      class: "anchor-text mt-2 d-block" %>
           </div>
           <%= render(AuthComponents::SocialLoginComponent.new(devise_mapping: devise_mapping, resource_name: resource_name)) %>
         <% end %>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -24,11 +24,8 @@
             </div>
           </div>
           <div class="field mb-3">
-  <%= f.submit t("users.passwords.send_reset_link"), 
-      class: "btn primary-button users-primary-button w-100" %>
-  <%= link_to t("users.passwords.link_to_login_page"), 
-      new_user_session_path, 
-      class: "anchor-text mt-2 d-block" %>
+  <%= f.submit t("users.passwords.send_reset_link"), class: "btn primary-button users-primary-button w-100" %>
+  <%= link_to t("users.passwords.link_to_login_page"), new_user_session_path,class: "anchor-text mt-2 d-block" %>
           </div>
           <%= render(AuthComponents::SocialLoginComponent.new(devise_mapping: devise_mapping, resource_name: resource_name)) %>
         <% end %>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -4,7 +4,6 @@
       <%= image_tag "svgs/login.svg", alt: "Login Sketch", class: "users-image" %>
       <h5 class="users-image-text"><%= t("welcome_back_text") %></h5>
     </div>
-
     <div class="col-12 col-sm-12 col-md-6 col-lg-6">
       <div class="users-form-container">
         <h2 class="users-main-heading"><%= t("users.passwords.forgot_password_heading") %></h2>


### PR DESCRIPTION
Fixes #6760

#### Describe the changes you have made in this PR -

This PR fixes the inconsistent border-radius styling of the **"Send Password Reset Link"** button on the Forgot Password page.

Previously, the button had rounded corners only on the left side while the right-side corners appeared sharp. This was caused by the button being wrapped inside a Bootstrap `input-group`, which overrides the default border-radius behavior for buttons inside it.

### Changes made:
- Removed the `input-group` wrapper around the submit button.
- Kept the existing button classes (`btn primary-button users-primary-button`) to preserve consistent styling across the application.
- Ensured the button maintains full width and matches the styling of other primary buttons in the app.

This results in consistent border-radius on all four corners, aligning with the design system used across the application.

### Screenshots of the UI changes (If any) -

Before:
- Button had rounded corners only on the left side.

After:
- Button now has uniform border-radius on all four corners.
- Styling is consistent with other primary buttons.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The issue was caused by Bootstrap’s `input-group` styling, which modifies border-radius behavior for buttons placed inside it.

Instead of overriding styles with custom CSS, I removed the unnecessary `input-group` wrapper to allow the button to inherit the correct border-radius from existing project styles. This keeps the solution clean, avoids CSS overrides, and maintains consistency with other form buttons across the application.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the password reset form’s action area: the submit button now spans the full width and the login link is displayed as a block to improve spacing and vertical flow of the action elements. Layout changes only — submission behavior, form structure, and error handling remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->