### PR TITLE
 fix-homepage-lazy-loading

### DIFF
--- a/app/views/circuitverse/teachers.html.erb
+++ b/app/views/circuitverse/teachers.html.erb
@@ -17,7 +17,7 @@
         <p><%= t("circuitverse.teachers.create_group_description") %></p>
       </div>
       <div class="col-md-6">
-        <img class="img-fluid border border-2 border-secondary" src="img/groups.png" alt="Groups screenshot">
+        <img class="img-fluid border border-2 border-secondary" src="img/groups.png" alt="Groups screenshot" loading="lazy">
       </div>
     </div>
   </div>
@@ -30,7 +30,7 @@
         <p><%= t("circuitverse.teachers.post_assignment_description") %></p>
       </div>
       <div class="col-md-6">
-        <img class="img-fluid border border-2 border-secondary" src="img/assignment.png" alt="Assignments screenshot">
+        <img class="img-fluid border border-2 border-secondary" src="img/assignment.png" alt="Assignments screenshot" loading="lazy">
       </div>
     </div>
   </div>
@@ -43,7 +43,7 @@
         <p><%= t("circuitverse.teachers.grade_assignment_description") %></p>
       </div>
       <div class="col-md-6">
-        <img class="img-fluid border border-2 border-secondary" src="img/grading.png" alt="Grading screenshot">
+        <img class="img-fluid border border-2 border-secondary" src="img/grading.png" alt="Grading screenshot" loading="lazy">
       </div>
     </div>
   </div>
@@ -56,7 +56,7 @@
         <p><%= t("circuitverse.teachers.use_interactive_circuit_description") %></p>
       </div>
       <div class="col-md-6">
-        <img class="img-fluid border border-2 border-secondary" src="img/embed.png" alt="Embed screenshot">
+        <img class="img-fluid border border-2 border-secondary" src="img/embed.png" alt="Embed screenshot" loading="lazy">
       </div>
     </div>
   </div>


### PR DESCRIPTION
FFixes #7006

#### Describe the changes you have made in this PR -

This PR adds the `loading="lazy"` attribute to non-critical images on the teachers page.  
These images are below-the-fold and not required during the initial page load.

By enabling lazy loading, the browser defers loading these images until they are needed, which helps improve page load performance and reduces unnecessary initial network usage.

### Screenshots of the UI changes (If any) -

No visual UI changes. This is a performance improvement.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each change
- [x] I have tested the changes and understand their impact
- [x] I ensured the implementation follows the project's coding standards

**Explain your implementation approach:**

The issue required improving homepage performance by enabling lazy loading for non-critical images.  
I identified the `<img>` elements in `teachers.html.erb` that are displayed below the fold and added the `loading="lazy"` attribute to them.

This approach was chosen because it is a native browser feature that improves performance without requiring additional JavaScript libraries or complex changes.

The implementation is minimal, standards-compliant, and does not affect layout or functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized image loading on the teachers section to enhance page load performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->