### PR TITLE
feat: add active state to navbar links for current page indication

### DIFF
--- a/app/assets/stylesheets/navbar.scss
+++ b/app/assets/stylesheets/navbar.scss
@@ -76,6 +76,8 @@
 
   &.active {
     color: $secondary-green;
+    border-bottom: 2px solid $secondary-green;
+    padding-bottom: 2px;
   }
 
   &:focus {

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -13,7 +13,7 @@
       <div class="d-flex justify-content-between align-items-start align-items-lg-center w-100 flex-column flex-lg-row gap-3 px-2 px-lg-0">
         <ul class="navbar-nav main-nav-items mx-auto d-flex flex-lg-row flex-column gap-lg-3 margin-lg-0">
           <li class="nav-item">
-            <a class="nav-link navbar-item navbar-text" href="/simulator"><%= t("layout.link_to_simulator") %></a>
+            <a class="nav-link navbar-item navbar-text <%= request.path.start_with?("/simulator") ? "active" : "" %>" href="/simulator"><%= t("layout.link_to_simulator") %></a>
           </li>
           <li class="nav-item">
             <a class="nav-link navbar-item navbar-text" href="/#home-features-section"><%= t("layout.link_to_features") %></a>
@@ -24,7 +24,7 @@
             </li>
           <% end %>
           <li class="nav-item">
-            <a class="nav-link navbar-item navbar-text" href="/teachers"><%= t("layout.link_to_teachers") %></a>
+            <a class="nav-link navbar-item navbar-text <%= request.path == "/teachers" ? "active" : "" %>" href="/teachers"><%= t("layout.link_to_teachers") %></a>
           </li>
           <% if Flipper.enabled?(:contests, current_user) %>
             <li class="nav-item">
@@ -51,7 +51,7 @@
             <a class="nav-link navbar-item navbar-text" href="https://blog.circuitverse.org/" target="_blank" rel="noopener"><%= t("layout.link_to_blog") %></a>
           </li>
           <li class="nav-item">
-            <a class="nav-link navbar-item navbar-text" href="/about"><%= t("layout.link_to_about") %></a>
+            <a class="nav-link navbar-item navbar-text <%= request.path == "/about" ? "active" : "" %>" href="/about"><%= t("layout.link_to_about") %></a>
           </li>
           <li class="nav-item d-flex align-items-center">
             <i class="fa fa-search search-icon" tabindex="0" aria-label="search"></i>


### PR DESCRIPTION
This PR introduces active state highlighting for all primary navigation links to improve user orientation and clarity. Users can now easily identify which page they are currently viewing.

Previously, only hover styles were present, which disappeared after navigation and provided no persistent visual context.

Problem Statement

The navbar lacked a persistent visual indicator for the active page. While hover effects were implemented, they did not reflect the current route after navigation, potentially causing user confusion.

Changes Implemented
1. Added Active State Logic to Navbar Links

Extended the existing request.path pattern (already used by Explore and Contests) to the following links:

Simulator

Uses:

request.path.start_with?("/simulator")

Covers all simulator sub-routes for consistent highlighting.

Teachers

Uses:

request.path == "/teachers"

About

Uses:

request.path == "/about"

This ensures accurate route detection while remaining aligned with the existing codebase approach.

2. Enhanced Active State Styling

Updated .navbar-text.active in navbar.scss to improve visual feedback:

Retained the existing active color styling

Added:

border-bottom: 2px solid;

to create a clear underline indicator

This strengthens visibility and improves accessibility without introducing layout shifts.

Links Intentionally Excluded

The following links were intentionally not given an active state:

Features — homepage anchor link

Blog — external link

Getting Started — dropdown containing external links

These links either do not represent standalone routes or do not require active highlighting.

Files Modified

_header.html.erb

navbar.scss

Implementation Approach
Why Server-Side Route Checks?

A JavaScript-based solution was considered but not implemented because:

Server-side request.path checks:

Are simpler and more reliable

Avoid client-side flicker

Align with the existing project pattern

Require no additional JavaScript logic

This approach maintains consistency with how active states are already handled in the codebase.

Key Components

ERB ternary expressions in _header.html.erb
Dynamically append the active class based on the current request.path.

.navbar-text.active in navbar.scss
Applies color styling and bottom border underline for clear active indication.

Result

Clear persistent active state indicator

Improved navigation clarity

Consistent implementation with existing patterns

Minimal and maintainable code changes
This pull request improves the navigation bar by highlighting the active page both visually and semantically. The main changes involve updating the logic to add an "active" class to navigation links based on the current path, and enhancing the styling for active links for better user experience.

Navigation logic improvements:

* Updated the navigation links in the `_header.html.erb` partial to dynamically add the `active` class based on the current request path, so the correct link is highlighted for `/simulator`, `/teachers`, and `/about` pages. [[1]](diffhunk://#diff-6d2ef58207c92d1533287af551a075122ba98240a861819047a2ae77b7674f0bL16-R16) [[2]](diffhunk://#diff-6d2ef58207c92d1533287af551a075122ba98240a861819047a2ae77b7674f0bL27-R27) [[3]](diffhunk://#diff-6d2ef58207c92d1533287af551a075122ba98240a861819047a2ae77b7674f0bL54-R54)

Styling enhancements:

* Enhanced the `.active` class in `navbar.scss` to include a green bottom border and additional padding, making the active navigation item more visually distinct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Active navigation links now display enhanced visual styling with an improved underline effect, making it clearer which page section you're currently viewing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->