### PR TITLE
fix(ci): correct input names for actions/first-interaction in greet.yml

### DIFF
--- a/.github/workflows/greet.yml
+++ b/.github/workflows/greet.yml
@@ -22,11 +22,11 @@ jobs:
         uses: actions/first-interaction@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue_message: |
+          issue-message: |
             ## 🚀 Welcome to CircuitVerse! 
-            
+
             Thank you for opening your first issue here! We appreciate you taking the time to help improve our open-source digital logic simulator.
-            
+
             **Next Steps:**
             * Check out our [Contributor Guidelines](https://github.com/CircuitVerse/CircuitVerse/blob/master/CONTRIBUTING.md) to understand our workflow.
             * Join our [Slack Community](http://circuitverse.org/slack) to chat with the core team and other contributors.
@@ -34,14 +34,14 @@ jobs:
 
             Someone from the team will be with you shortly! ⚡
 
-          pr_message: |
+          pr-message: |
             ## 🎉 Thank you for your first Pull Request!
-            
+
             We are excited to see your contribution to **CircuitVerse**! Thank you for helping us make digital logic education accessible to everyone.
-            
+
             **Before a maintainer reviews this:**
             * Review our [Contributing Guide](https://github.com/CircuitVerse/CircuitVerse/blob/master/CONTRIBUTING.md).
             * Ensure your PR description clearly explains the changes and links to any related issues (e.g., `Closes #123`).
             * Double-check that all CI tests pass.
-            
+
             We'll get back to you as soon as possible. In the meantime, feel free to join the conversation on [Slack](http://circuitverse.org/slack). Happy coding! 🛠️


### PR DESCRIPTION
What I Changed

I noticed that the first-interaction GitHub Action wasn’t running properly. After checking the workflow file (.github/workflows/greet.yml), I found that the input names were written using underscores (issue_message, pr_message).

However, the actions/first-interaction@v3 action expects hyphenated input names (issue-message, pr-message). Because of this mismatch, GitHub Actions was throwing “unexpected inputs” errors and failing the workflow.

I’ve updated the input keys to use hyphens instead of underscores so they align with the official action documentation. This should resolve the workflow error and allow the welcome message to run correctly for new contributors.

No functional changes beyond fixing the input syntax.

Screenshots

N/A – This is a workflow configuration fix only.

Code Understanding and AI Usage

Did you use AI assistance?

 Yes

If yes:

 I have reviewed every line of the generated output

 I understand exactly what the change does

 I tested the workflow behavior after the fix

 The final change follows the project’s conventions

Implementation Approach

This was a straightforward syntax correction.

After seeing the workflow failure, I checked the official documentation for actions/first-interaction@v3 and verified the expected input names. The current workflow used underscores instead of hyphens, which caused the action to reject the inputs.

The solution was simply to replace:

issue_message → issue-message

pr_message → pr-message

Since this was purely a configuration mismatch with the action’s documented interface, no alternative approaches were needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration naming conventions for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->