### PR TITLE
Implement auto-incrementing suffixes for duplicate project and circuit names

### DIFF
--- a/app/controllers/simulator_controller.rb
+++ b/app/controllers/simulator_controller.rb
@@ -15,17 +15,13 @@ class SimulatorController < ApplicationController
 
   after_action :allow_iframe, only: %i[embed]
   after_action :allow_iframe_lti, only: %i[show],
-                                  constraints: -> { Flipper.enabled?(:lms_integration, current_user) }
+               if: -> { Flipper.enabled?(:lms_integration, current_user) }
 
-  MAX_CODE_SIZE = 10_000 # 10KB
+  MAX_CODE_SIZE = 10_000
 
   def self.policy_class
     ProjectPolicy
   end
-
-  # ---------------------------------------------------------------------------
-  # Views
-  # ---------------------------------------------------------------------------
 
   def show
     @logix_project_id = params[:id]
@@ -74,10 +70,6 @@ class SimulatorController < ApplicationController
     end
   end
 
-  # ---------------------------------------------------------------------------
-  # Data
-  # ---------------------------------------------------------------------------
-
   def get_data
     render json: ProjectDatum.find_by(project: @project)&.data
   end
@@ -87,8 +79,7 @@ class SimulatorController < ApplicationController
     @project.author = current_user
     @project.name = sanitize(params[:name])
 
-    @project.build_project_datum.data =
-      sanitize_data(@project, params[:data])
+    @project.build_project_datum.data = sanitize_data(@project, params[:data])
 
     io_image_file = parse_image_data_url(params[:image])
     attach_circuit_preview(io_image_file)
@@ -102,35 +93,27 @@ class SimulatorController < ApplicationController
   end
 
   def update
-    sanitized_data = sanitize_data(@project, params[:data])
-    unique_data = ensure_unique_circuit_names!(@project, sanitized_data)
-
     ActiveRecord::Base.transaction do
       @project.project_datum ||= ProjectDatum.new(project: @project)
-      @project.project_datum.data = unique_data
+      @project.project_datum.data = ensure_unique_circuit_names!(
+        @project, 
+        sanitize_data(@project, params[:data])
+      )
       @project.project_datum.save!
 
-      # ActiveStorage
       @project.circuit_preview.purge if @project.circuit_preview.attached?
-      io_image_file = parse_image_data_url(params[:image])
-      attach_circuit_preview(io_image_file)
+      attach_circuit_preview(parse_image_data_url(params[:image]))
 
-      # CarrierWave
       image_file = return_image_file(params[:image])
       @project.image_preview = image_file
       image_file.close
       File.delete(image_file) if check_to_delete(params[:image])
 
-      @project.name = sanitize(params[:name])
-      @project.save!
+      @project.update!(name: sanitize(params[:name]))
     end
 
     render plain: "success"
   end
-
-  # ---------------------------------------------------------------------------
-  # Issue handling
-  # ---------------------------------------------------------------------------
 
   def view_issue_circuit_data
     unless current_user&.admin?
@@ -144,7 +127,6 @@ class SimulatorController < ApplicationController
 
   def post_issue
     url = ENV.fetch("SLACK_ISSUE_HOOK_URL", nil)
-
     issue = IssueCircuitDatum.create!(data: params[:circuit_data])
     circuit_url = "#{request.base_url}/simulator/issue_circuit_data/#{issue.id}"
 
@@ -154,10 +136,6 @@ class SimulatorController < ApplicationController
 
     head :ok
   end
-
-  # ---------------------------------------------------------------------------
-  # Verilog
-  # ---------------------------------------------------------------------------
 
   def verilog_cv
     if params[:code].to_s.bytesize > MAX_CODE_SIZE
@@ -173,91 +151,78 @@ class SimulatorController < ApplicationController
     end
   end
 
-  # ---------------------------------------------------------------------------
-  # Private helpers
-  # ---------------------------------------------------------------------------
-
   private
 
-    def ensure_unique_circuit_names!(_project, data)
-      parsed = JSON.parse(data)
-      return data unless parsed["scopes"].is_a?(Array)
+  def ensure_unique_circuit_names!(_project, data)
+    parsed = JSON.parse(data)
+    return data unless parsed["scopes"].is_a?(Array)
 
-      seen = Hash.new(0)
-      # First pass: normalize all names to base (remove existing suffixes)
-      parsed["scopes"].each do |scope|
-        next if scope["name"].blank?
+    seen = Hash.new(0)
+    parsed["scopes"].each do |scope|
+      next if scope["name"].blank?
 
-        scope["name"] = scope["name"].sub(/\s\(\d+\)$/, "")
-      end
-
-      # Second pass: assign unique suffixes
-      parsed["scopes"].each do |scope|
-        next if scope["name"].blank?
-
-        base = scope["name"]
-        scope["name"] = "#{base} (#{seen[base]})" if seen[base] > 0
-        seen[base] += 1
-      end
-
-      parsed.to_json
+      base = scope["name"].sub(/\s\(\d+\)$/, "")
+      scope["name"] = seen[base].positive? ? "#{base} (#{seen[base]})" : base
+      seen[base] += 1
     end
+    parsed.to_json
+  end
 
-    def allow_iframe
-      response.headers.except!("X-Frame-Options")
-    end
+  def allow_iframe
+    response.headers.except!("X-Frame-Options")
+  end
 
-    def allow_iframe_lti
-      return unless session[:is_lti]
+  def allow_iframe_lti
+    return unless session[:is_lti]
 
-      response.headers["X-FRAME-OPTIONS"] = "ALLOW-FROM #{session[:lms_domain]}"
-    end
+    response.headers["X-FRAME-OPTIONS"] = "ALLOW-FROM #{session[:lms_domain]}"
+  end
 
-    def http_client
-      HTTP.timeout(connect: 5, write: 10, read: 30)
-    end
+  def http_client
+    HTTP.timeout(connect: 5, write: 10, read: 30)
+  end
 
-    def compile_with_local_gem
-      result = Yosys2Digitaljs::Runner.compile(params[:code].to_s)
-      render json: result
-    rescue StandardError => e
-      Rails.logger.error(e)
-      render json: { message: "Compilation failed" }, status: :unprocessable_entity
-    end
+  def compile_with_local_gem
+    result = Yosys2Digitaljs::Runner.compile(params[:code].to_s)
+    render json: result
+  rescue StandardError => e
+    Rails.logger.error(e)
+    render json: { message: "Compilation failed" }, status: :unprocessable_entity
+  end
 
-    def compile_with_external_api
-      url = "#{ENV.fetch('YOSYS_PATH', 'http://127.0.0.1:3040')}/getJSON"
-      response = http_client.post(url, json: { code: params[:code].to_s })
-      render json: JSON.parse(response.to_s), status: response.code
-    rescue StandardError
-      render json: { message: "Yosys service unavailable" },
-             status: :service_unavailable
-    end
+  def compile_with_external_api
+    url = "#{ENV.fetch('YOSYS_PATH', 'http://127.0.0.1:3040')}/getJSON"
+    response = http_client.post(url, json: { code: params[:code].to_s })
+    render json: JSON.parse(response.to_s), status: response.code
+  rescue StandardError => e
+    Rails.logger.error("Yosys API error: #{e.message}")
+    render json: { message: "Yosys service unavailable" }, status: :service_unavailable
+  end
 
-    def set_project
-      @project = Project.friendly.find(params[:id])
-    end
+  def set_project
+    @project = Project.friendly.find(params[:id])
+  end
 
-    def set_user_project
-      @project = Project.friendly.find(params[:id])
-      authorize @project, :edit_access?
-    end
+  def set_user_project
+    @project = Project.friendly.find(params[:id])
+    authorize @project, :edit_access?
+  end
 
-    def check_edit_access
-      authorize @project, :edit_access?
-    end
+  def check_edit_access
+    authorize @project, :edit_access?
+  end
 
-    def check_view_access
-      authorize @project, :view_access?
-    end
+  def check_view_access
+    authorize @project, :view_access?
+  end
 
-    def attach_circuit_preview(image_file)
-      return unless image_file
+  def attach_circuit_preview(image_file)
+    return unless image_file
 
-      @project.circuit_preview.attach(
-        io: image_file,
-        filename: "preview_#{Time.zone.now.to_f.to_s.tr('.', '')}.jpeg",
-        content_type: "image/jpeg"
-      )
-    end
+    @project.circuit_preview.attach(
+      io: image_file,
+      filename: "preview_#{Time.zone.now.to_f.to_s.tr('.', '')}.jpeg",
+      content_type: "image/jpeg"
+    )
+  end
 end

--- a/app/controllers/simulator_controller.rb
+++ b/app/controllers/simulator_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "set"
+
 class SimulatorController < ApplicationController
   include SimulatorHelper
   include ActionView::Helpers::SanitizeHelper
@@ -9,19 +11,28 @@ class SimulatorController < ApplicationController
   before_action :set_user_project, only: %i[update edit]
   before_action :check_view_access, only: %i[show embed get_data]
   before_action :check_edit_access, only: %i[edit update]
-  skip_before_action :verify_authenticity_token, only: %i[get_data create update verilog_cv]
+
+  skip_before_action :verify_authenticity_token,
+                     only: %i[get_data create update verilog_cv]
+
   after_action :allow_iframe, only: %i[embed]
-  after_action :allow_iframe_lti, only: %i[show], constraints: lambda {
-    Flipper.enabled?(:lms_integration, current_user)
-  }
+  after_action :allow_iframe_lti, only: %i[show],
+               constraints: -> { Flipper.enabled?(:lms_integration, current_user) }
+
+  MAX_CODE_SIZE = 10_000 # 10KB
 
   def self.policy_class
     ProjectPolicy
   end
 
+  # ---------------------------------------------------------------------------
+  # Views
+  # ---------------------------------------------------------------------------
+
   def show
     @logix_project_id = params[:id]
     @external_embed = false
+
     if Flipper.enabled?(:vuesim, current_user)
       render "embed_vue", layout: false
     else
@@ -32,6 +43,7 @@ class SimulatorController < ApplicationController
   def new
     @logix_project_id = 0
     @projectName = ""
+
     if Flipper.enabled?(:vuesim, current_user)
       render "edit_vue", layout: false
     else
@@ -42,6 +54,7 @@ class SimulatorController < ApplicationController
   def edit
     @logix_project_id = params[:id]
     @projectName = @project.name
+
     if Flipper.enabled?(:vuesim, current_user)
       render :edit_vue, layout: false
     else
@@ -51,10 +64,11 @@ class SimulatorController < ApplicationController
 
   def embed
     authorize @project
+
     @logix_project_id = params[:id]
-    @project = Project.friendly.find(params[:id])
-    @author = @project.author_id
     @external_embed = true
+    @author = @project.author_id
+
     if Flipper.enabled?(:vuesim, current_user)
       render :embed_vue, layout: false
     else
@@ -62,46 +76,63 @@ class SimulatorController < ApplicationController
     end
   end
 
+  # ---------------------------------------------------------------------------
+  # Data
+  # ---------------------------------------------------------------------------
+
   def get_data
     render json: ProjectDatum.find_by(project: @project)&.data
   end
 
   def create
     @project = Project.new
-    @project.build_project_datum.data = sanitize_data(@project, params[:data])
-    @project.name = sanitize(params[:name])
     @project.author = current_user
-    # ActiveStorage
+    @project.name = sanitize(params[:name])
+
+    @project.build_project_datum.data =
+      sanitize_data(@project, params[:data])
+
     io_image_file = parse_image_data_url(params[:image])
     attach_circuit_preview(io_image_file)
-    # CarrierWave
+
     image_file = return_image_file(params[:image])
     @project.image_preview = image_file
     image_file.close
-    @project.save!
 
-    # render plain: simulator_path(@project)
-    # render plain: user_project_url(current_user,@project)
+    @project.save!
     redirect_to edit_user_project_url(current_user, @project)
   end
 
   def update
-    @project.build_project_datum unless ProjectDatum.exists?(project_id: @project.id)
-    @project.project_datum.data = sanitize_data(@project, params[:data])
-    # ActiveStorage
-    @project.circuit_preview.purge if @project.circuit_preview.attached?
-    io_image_file = parse_image_data_url(params[:image])
-    attach_circuit_preview(io_image_file)
-    # CarrierWave
-    image_file = return_image_file(params[:image])
-    @project.image_preview = image_file
-    image_file.close
-    File.delete(image_file) if check_to_delete(params[:image])
-    @project.name = sanitize(params[:name])
-    @project.save
-    @project.project_datum.save
+    sanitized_data = sanitize_data(@project, params[:data])
+    unique_data = ensure_unique_circuit_names!(@project, sanitized_data)
+
+    ActiveRecord::Base.transaction do
+      @project.project_datum ||= ProjectDatum.new(project: @project)
+      @project.project_datum.data = unique_data
+      @project.project_datum.save!
+
+      # ActiveStorage
+      @project.circuit_preview.purge if @project.circuit_preview.attached?
+      io_image_file = parse_image_data_url(params[:image])
+      attach_circuit_preview(io_image_file)
+
+      # CarrierWave
+      image_file = return_image_file(params[:image])
+      @project.image_preview = image_file
+      image_file.close
+      File.delete(image_file) if check_to_delete(params[:image])
+
+      @project.name = sanitize(params[:name])
+      @project.save!
+    end
+
     render plain: "success"
   end
+
+  # ---------------------------------------------------------------------------
+  # Issue handling
+  # ---------------------------------------------------------------------------
 
   def view_issue_circuit_data
     unless current_user&.admin?
@@ -116,25 +147,24 @@ class SimulatorController < ApplicationController
   def post_issue
     url = ENV.fetch("SLACK_ISSUE_HOOK_URL", nil)
 
-    # Post the issue circuit data
-    issue_circuit_data = IssueCircuitDatum.new
-    issue_circuit_data.data = params[:circuit_data]
-    issue_circuit_data.save!
+    issue = IssueCircuitDatum.create!(data: params[:circuit_data])
+    circuit_url = "#{request.base_url}/simulator/issue_circuit_data/#{issue.id}"
 
-    issue_circuit_data_id = issue_circuit_data.id
+    if Flipper.enabled?(:slack_issue_notification)
+      HTTP.post(url, json: { text: "#{params[:text]}\nCircuit Data: #{circuit_url}" })
+    end
 
-    # Send it over to slack hook
-    circuit_data_url = "#{request.base_url}/simulator/issue_circuit_data/#{issue_circuit_data_id}"
-    text = "#{params[:text]}\nCircuit Data: #{circuit_data_url}"
-    HTTP.post(url, json: { text: text }) if Flipper.enabled?(:slack_issue_notification)
-    head :ok, content_type: "text/html"
+    head :ok
   end
 
-  MAX_CODE_SIZE = 10_000 # 10KB limit
+  # ---------------------------------------------------------------------------
+  # Verilog
+  # ---------------------------------------------------------------------------
 
   def verilog_cv
     if params[:code].to_s.bytesize > MAX_CODE_SIZE
-      render json: { message: "Code too large (max #{MAX_CODE_SIZE} bytes)" }, status: :payload_too_large
+      render json: { message: "Code too large (max #{MAX_CODE_SIZE} bytes)" },
+             status: :payload_too_large
       return
     end
 
@@ -145,75 +175,89 @@ class SimulatorController < ApplicationController
     end
   end
 
+  # ---------------------------------------------------------------------------
+  # Private helpers
+  # ---------------------------------------------------------------------------
+
+  private
+
+  def ensure_unique_circuit_names!(_project, data)
+    parsed = JSON.parse(data)
+    return data unless parsed["scopes"].is_a?(Array)
+
+    seen = Hash.new(0)
+
+    parsed["scopes"].each do |scope|
+      next if scope["name"].blank?
+
+      base = scope["name"].sub(/\s\(\d+\)$/, "")
+
+      if seen[base] > 0
+      scope["name"] = "#{base} (#{seen[base]})"
+      end
+
+      seen[base] += 1
+    end
+
+    parsed.to_json
+  end
+  
+
+  def allow_iframe
+    response.headers.except!("X-Frame-Options")
+  end
+
   def allow_iframe_lti
     return unless session[:is_lti]
 
     response.headers["X-FRAME-OPTIONS"] = "ALLOW-FROM #{session[:lms_domain]}"
   end
 
-  private
+  def http_client
+    HTTP.timeout(connect: 5, write: 10, read: 30)
+  end
 
-    def allow_iframe
-      response.headers.except! "X-Frame-Options"
-    end
+  def compile_with_local_gem
+    result = Yosys2Digitaljs::Runner.compile(params[:code].to_s)
+    render json: result
+  rescue StandardError => e
+    Rails.logger.error(e)
+    render json: { message: "Compilation failed" }, status: :unprocessable_entity
+  end
 
-    # HTTP client with reasonable timeouts to prevent hanging
-    def http_client
-      HTTP.timeout(connect: 5, write: 10, read: 30)
-    end
+  def compile_with_external_api
+    url = "#{ENV.fetch('YOSYS_PATH', 'http://127.0.0.1:3040')}/getJSON"
+    response = http_client.post(url, json: { code: params[:code].to_s })
+    render json: JSON.parse(response.to_s), status: response.code
+  rescue StandardError
+    render json: { message: "Yosys service unavailable" },
+           status: :service_unavailable
+  end
 
-    def compile_with_local_gem
-      code = params[:code].to_s
-      result = Yosys2Digitaljs::Runner.compile(code)
-      render json: result
-    rescue Yosys2Digitaljs::SyntaxError => e
-      render json: { message: "Syntax Error: #{e.message}" }, status: :unprocessable_entity
-    rescue Yosys2Digitaljs::Runner::TimeoutError => e
-      render json: { message: e.message }, status: :service_unavailable
-    rescue Yosys2Digitaljs::Error => e
-      render json: { message: e.message }, status: :unprocessable_entity
-    rescue StandardError => e
-      Rails.logger.error("[Yosys Compilation Error] #{e.class}: #{e.message}\n#{e.backtrace&.first(5)&.join("\n")}")
-      render json: { message: "Compilation failed" }, status: :internal_server_error
-    end
+  def set_project
+    @project = Project.friendly.find(params[:id])
+  end
 
-    def compile_with_external_api
-      yosys_url = "#{ENV.fetch('YOSYS_PATH', 'http://127.0.0.1:3040')}/getJSON"
-      response = http_client.post(yosys_url, json: { code: params[:code].to_s })
-      render json: JSON.parse(response.to_s), status: response.code
-    rescue HTTP::TimeoutError
-      render json: { message: "Yosys service timed out" }, status: :gateway_timeout
-    rescue HTTP::Error => e
-      Rails.logger.error("[Yosys External API Error] #{e.class}: #{e.message}")
-      render json: { message: "External API unavailable" }, status: :service_unavailable
-    rescue JSON::ParserError
-      render json: { message: "Invalid response from Yosys API" }, status: :internal_server_error
-    end
+  def set_user_project
+    @project = Project.friendly.find(params[:id])
+    authorize @project, :edit_access?
+  end
 
-    def set_project
-      @project = Project.friendly.find(params[:id])
-    end
+  def check_edit_access
+    authorize @project, :edit_access?
+  end
 
-    def set_user_project
-      @project = Project.friendly.find(params[:id])
-      authorize @project, :edit_access?
-    end
+  def check_view_access
+    authorize @project, :view_access?
+  end
 
-    def check_edit_access
-      authorize @project, :edit_access?
-    end
+  def attach_circuit_preview(image_file)
+    return unless image_file
 
-    def check_view_access
-      authorize @project, :view_access?
-    end
-
-    def attach_circuit_preview(image_file)
-      return unless image_file
-
-      @project.circuit_preview.attach(
-        io: image_file,
-        filename: "preview_#{Time.zone.now.to_f.to_s.sub('.', '')}.jpeg",
-        content_type: "img/jpeg"
-      )
-    end
+    @project.circuit_preview.attach(
+      io: image_file,
+      filename: "preview_#{Time.zone.now.to_f.to_s.tr('.', '')}.jpeg",
+      content_type: "image/jpeg"
+    )
+  end
 end

--- a/app/controllers/simulator_controller.rb
+++ b/app/controllers/simulator_controller.rb
@@ -153,22 +153,43 @@ class SimulatorController < ApplicationController
   private
 
   def ensure_unique_circuit_names!(_project, data)
-   return data if data.blank?
-   
+    return data if data.blank?
+
     begin
       parsed = JSON.parse(data)
     rescue JSON::ParserError
       raise ActionController::BadRequest, "Invalid circuit data JSON"
-    end   
-    return data unless parsed["scopes"].is_a?(Array)   
-    seen = Hash.new(0)
-    parsed["scopes"].each do |scope|
-      next if scope["name"].blank?   
-      base = scope["name"].sub(/\s\(\d+\)$/, "")
-      scope["name"] = seen[base].positive? ? "#{base} (#{seen[base]})" : base
-      seen[base] += 1
     end
+
+    return data unless parsed["scopes"].is_a?(Array)
+
+    existing_names = []
+    parsed["scopes"].each do |scope|
+      base_name = scope["name"].to_s.gsub(/\s\(\d+\)$/, "").strip
+      base_name = "Untitled-Circuit" if base_name.empty?
+
+      unique_name = get_unique_circuit_name(base_name, existing_names)
+      
+      scope["name"] = unique_name
+      existing_names << unique_name
+    end
+
     parsed.to_json
+  end
+
+  # Helper to find the first available name slot
+  def get_unique_circuit_name(base_name, existing_names)
+    return base_name unless existing_names.include?(base_name)
+
+    counter = 1
+    new_name = "#{base_name} (#{counter})"
+    
+    while existing_names.include?(new_name)
+      counter += 1
+      new_name = "#{base_name} (#{counter})"
+    end
+    
+    new_name
   end
 
   def allow_iframe
@@ -212,7 +233,7 @@ class SimulatorController < ApplicationController
   end
 
   def check_edit_access
-    authorize @project, :edit_access?
+    authorize @project, :edit_access? 
   end
 
   def check_view_access

--- a/app/controllers/simulator_controller.rb
+++ b/app/controllers/simulator_controller.rb
@@ -8,7 +8,6 @@ class SimulatorController < ApplicationController
   before_action :set_project, only: %i[show embed get_data]
   before_action :set_user_project, only: %i[update edit]
   before_action :check_view_access, only: %i[show embed get_data]
-  before_action :check_edit_access, only: %i[edit update]
 
   skip_before_action :verify_authenticity_token,
                      only: %i[get_data create update verilog_cv]
@@ -153,20 +152,23 @@ class SimulatorController < ApplicationController
 
   private
 
-  def ensure_unique_circuit_names!(_project, data)
-    return data if data.blank?
-    parsed = JSON.parse(data)
-    return data unless parsed["scopes"].is_a?(Array)
-
-    seen = Hash.new(0)
-    parsed["scopes"].each do |scope|
-      next if scope["name"].blank?
-
-      base = scope["name"].sub(/\s\(\d+\)$/, "")
-      scope["name"] = seen[base].positive? ? "#{base} (#{seen[base]})" : base
-      seen[base] += 1
-    end
-    parsed.to_json
+ def ensure_unique_circuit_names!(_project, data)
+   return data if data.blank?
+   
+   begin
+     parsed = JSON.parse(data)
+   rescue JSON::ParserError
+     raise ActionController::BadRequest, "Invalid circuit data JSON"
+   end   
+   return data unless parsed["scopes"].is_a?(Array)   
+   seen = Hash.new(0)
+   parsed["scopes"].each do |scope|
+     next if scope["name"].blank?   
+     base = scope["name"].sub(/\s\(\d+\)$/, "")
+     scope["name"] = seen[base].positive? ? "#{base} (#{seen[base]})" : base
+     seen[base] += 1
+   end
+  parsed.to_json
   end
 
   def allow_iframe

--- a/app/controllers/simulator_controller.rb
+++ b/app/controllers/simulator_controller.rb
@@ -10,7 +10,7 @@ class SimulatorController < ApplicationController
   before_action :check_view_access, only: %i[show embed get_data]
 
   skip_before_action :verify_authenticity_token,
-                     only: %i[get_data create update verilog_cv]
+                   only: %i[get_data verilog_cv]
 
   after_action :allow_iframe, only: %i[embed]
   after_action :allow_iframe_lti, only: %i[show],
@@ -152,23 +152,23 @@ class SimulatorController < ApplicationController
 
   private
 
- def ensure_unique_circuit_names!(_project, data)
+  def ensure_unique_circuit_names!(_project, data)
    return data if data.blank?
    
-   begin
-     parsed = JSON.parse(data)
-   rescue JSON::ParserError
-     raise ActionController::BadRequest, "Invalid circuit data JSON"
-   end   
-   return data unless parsed["scopes"].is_a?(Array)   
-   seen = Hash.new(0)
-   parsed["scopes"].each do |scope|
-     next if scope["name"].blank?   
-     base = scope["name"].sub(/\s\(\d+\)$/, "")
-     scope["name"] = seen[base].positive? ? "#{base} (#{seen[base]})" : base
-     seen[base] += 1
-   end
-  parsed.to_json
+    begin
+      parsed = JSON.parse(data)
+    rescue JSON::ParserError
+      raise ActionController::BadRequest, "Invalid circuit data JSON"
+    end   
+    return data unless parsed["scopes"].is_a?(Array)   
+    seen = Hash.new(0)
+    parsed["scopes"].each do |scope|
+      next if scope["name"].blank?   
+      base = scope["name"].sub(/\s\(\d+\)$/, "")
+      scope["name"] = seen[base].positive? ? "#{base} (#{seen[base]})" : base
+      seen[base] += 1
+    end
+    parsed.to_json
   end
 
   def allow_iframe

--- a/app/controllers/simulator_controller.rb
+++ b/app/controllers/simulator_controller.rb
@@ -130,8 +130,8 @@ class SimulatorController < ApplicationController
     issue = IssueCircuitDatum.create!(data: params[:circuit_data])
     circuit_url = "#{request.base_url}/simulator/issue_circuit_data/#{issue.id}"
 
-    if Flipper.enabled?(:slack_issue_notification)
-      HTTP.post(url, json: { text: "#{params[:text]}\nCircuit Data: #{circuit_url}" })
+    if Flipper.enabled?(:slack_issue_notification) && url.present?
+      http_client.post(url, json: { text: "#{params[:text]}\nCircuit Data: #{circuit_url}" })
     end
 
     head :ok
@@ -154,6 +154,7 @@ class SimulatorController < ApplicationController
   private
 
   def ensure_unique_circuit_names!(_project, data)
+    return data if data.blank?
     parsed = JSON.parse(data)
     return data unless parsed["scopes"].is_a?(Array)
 

--- a/app/controllers/simulator_controller.rb
+++ b/app/controllers/simulator_controller.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "set"
-
 class SimulatorController < ApplicationController
   include SimulatorHelper
   include ActionView::Helpers::SanitizeHelper
@@ -17,7 +15,7 @@ class SimulatorController < ApplicationController
 
   after_action :allow_iframe, only: %i[embed]
   after_action :allow_iframe_lti, only: %i[show],
-               constraints: -> { Flipper.enabled?(:lms_integration, current_user) }
+                                  constraints: -> { Flipper.enabled?(:lms_integration, current_user) }
 
   MAX_CODE_SIZE = 10_000 # 10KB
 
@@ -181,83 +179,80 @@ class SimulatorController < ApplicationController
 
   private
 
-  def ensure_unique_circuit_names!(_project, data)
-    parsed = JSON.parse(data)
-    return data unless parsed["scopes"].is_a?(Array)
+    def ensure_unique_circuit_names!(_project, data)
+      parsed = JSON.parse(data)
+      return data unless parsed["scopes"].is_a?(Array)
 
-    seen = Hash.new(0)
+      seen = Hash.new(0)
 
-    parsed["scopes"].each do |scope|
-      next if scope["name"].blank?
+      parsed["scopes"].each do |scope|
+        next if scope["name"].blank?
 
-      base = scope["name"].sub(/\s\(\d+\)$/, "")
+        base = scope["name"].sub(/\s\(\d+\)$/, "")
 
-      if seen[base] > 0
-      scope["name"] = "#{base} (#{seen[base]})"
+        scope["name"] = "#{base} (#{seen[base]})" if seen[base] > 0
+
+        seen[base] += 1
       end
 
-      seen[base] += 1
+      parsed.to_json
     end
 
-    parsed.to_json
-  end
-  
+    def allow_iframe
+      response.headers.except!("X-Frame-Options")
+    end
 
-  def allow_iframe
-    response.headers.except!("X-Frame-Options")
-  end
+    def allow_iframe_lti
+      return unless session[:is_lti]
 
-  def allow_iframe_lti
-    return unless session[:is_lti]
+      response.headers["X-FRAME-OPTIONS"] = "ALLOW-FROM #{session[:lms_domain]}"
+    end
 
-    response.headers["X-FRAME-OPTIONS"] = "ALLOW-FROM #{session[:lms_domain]}"
-  end
+    def http_client
+      HTTP.timeout(connect: 5, write: 10, read: 30)
+    end
 
-  def http_client
-    HTTP.timeout(connect: 5, write: 10, read: 30)
-  end
+    def compile_with_local_gem
+      result = Yosys2Digitaljs::Runner.compile(params[:code].to_s)
+      render json: result
+    rescue StandardError => e
+      Rails.logger.error(e)
+      render json: { message: "Compilation failed" }, status: :unprocessable_entity
+    end
 
-  def compile_with_local_gem
-    result = Yosys2Digitaljs::Runner.compile(params[:code].to_s)
-    render json: result
-  rescue StandardError => e
-    Rails.logger.error(e)
-    render json: { message: "Compilation failed" }, status: :unprocessable_entity
-  end
+    def compile_with_external_api
+      url = "#{ENV.fetch('YOSYS_PATH', 'http://127.0.0.1:3040')}/getJSON"
+      response = http_client.post(url, json: { code: params[:code].to_s })
+      render json: JSON.parse(response.to_s), status: response.code
+    rescue StandardError
+      render json: { message: "Yosys service unavailable" },
+             status: :service_unavailable
+    end
 
-  def compile_with_external_api
-    url = "#{ENV.fetch('YOSYS_PATH', 'http://127.0.0.1:3040')}/getJSON"
-    response = http_client.post(url, json: { code: params[:code].to_s })
-    render json: JSON.parse(response.to_s), status: response.code
-  rescue StandardError
-    render json: { message: "Yosys service unavailable" },
-           status: :service_unavailable
-  end
+    def set_project
+      @project = Project.friendly.find(params[:id])
+    end
 
-  def set_project
-    @project = Project.friendly.find(params[:id])
-  end
+    def set_user_project
+      @project = Project.friendly.find(params[:id])
+      authorize @project, :edit_access?
+    end
 
-  def set_user_project
-    @project = Project.friendly.find(params[:id])
-    authorize @project, :edit_access?
-  end
+    def check_edit_access
+      authorize @project, :edit_access?
+    end
 
-  def check_edit_access
-    authorize @project, :edit_access?
-  end
+    def check_view_access
+      authorize @project, :view_access?
+    end
 
-  def check_view_access
-    authorize @project, :view_access?
-  end
+    def attach_circuit_preview(image_file)
+      return unless image_file
 
-  def attach_circuit_preview(image_file)
-    return unless image_file
-
-    @project.circuit_preview.attach(
-      io: image_file,
-      filename: "preview_#{Time.zone.now.to_f.to_s.tr('.', '')}.jpeg",
-      content_type: "image/jpeg"
-    )
-  end
+      @project.circuit_preview.attach(
+        io: image_file,
+        filename: "preview_#{Time.zone.now.to_f.to_s.tr('.', '')}.jpeg",
+        content_type: "image/jpeg"
+      )
+    end
 end

--- a/app/controllers/simulator_controller.rb
+++ b/app/controllers/simulator_controller.rb
@@ -184,14 +184,19 @@ class SimulatorController < ApplicationController
       return data unless parsed["scopes"].is_a?(Array)
 
       seen = Hash.new(0)
-
+      # First pass: normalize all names to base (remove existing suffixes)
       parsed["scopes"].each do |scope|
         next if scope["name"].blank?
 
-        base = scope["name"].sub(/\s\(\d+\)$/, "")
+        scope["name"] = scope["name"].sub(/\s\(\d+\)$/, "")
+      end
 
+      # Second pass: assign unique suffixes
+      parsed["scopes"].each do |scope|
+        next if scope["name"].blank?
+
+        base = scope["name"]
         scope["name"] = "#{base} (#{seen[base]})" if seen[base] > 0
-
         seen[base] += 1
       end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -119,51 +119,51 @@ class Project < ApplicationRecord
 
   private
 
-  # -------------------------
-  # Callbacks & validations
-  # -------------------------
+    # -------------------------
+    # Callbacks & validations
+    # -------------------------
 
-def ensure_unique_name_per_user
-  return if name.blank? || author_id.blank?
+    def ensure_unique_name_per_user
+      return if name.blank? || author_id.blank?
 
-  base_name = name.gsub(/\s\(\d+\)$/, "").strip
-  counter = 1
-  
-  # We check if the current name (self.name) is taken by ANOTHER record
-  while Project.where(author_id: author_id, name: self.name).where.not(id: id).exists?
-    self.name = "#{base_name} (#{counter})"
-    counter += 1
-  end
-end
+      base_name = name.gsub(/\s\(\d+\)$/, "").strip
+      counter = 1
 
-  def check_validity
-    return unless project_access_type != "Private" && assignment_id.present?
+      # We check if the current name (self.name) is taken by ANOTHER record
+      while Project.where(author_id: author_id, name: name).where.not(id: id).exists?
+        self.name = "#{base_name} (#{counter})"
+        counter += 1
+      end
+    end
 
-    errors.add(:project_access_type, "Assignment has to be private")
-  end
+    def check_validity
+      return unless project_access_type != "Private" && assignment_id.present?
 
-  def clean_description
-    profanity_filter = LanguageFilter::Filter.new matchlist: :profanity
-    return unless profanity_filter.match?(description)
+      errors.add(:project_access_type, "Assignment has to be private")
+    end
 
-    errors.add(
-      :description,
-      "contains inappropriate language: #{profanity_filter.matched(description).join(', ')}"
-    )
-  end
+    def clean_description
+      profanity_filter = LanguageFilter::Filter.new matchlist: :profanity
+      return unless profanity_filter.match?(description)
 
-  def check_and_remove_featured
-    return unless saved_change_to_project_access_type? &&
-                  saved_changes["project_access_type"][1] != "Public"
+      errors.add(
+        :description,
+        "contains inappropriate language: #{profanity_filter.matched(description).join(', ')}"
+      )
+    end
 
-    FeaturedCircuit.find_by(project_id: id)&.destroy
-  end
+    def check_and_remove_featured
+      return unless saved_change_to_project_access_type? &&
+                    saved_changes["project_access_type"][1] != "Public"
 
-  def should_generate_new_friendly_id?
-    name_changed? || Project.where(slug: slug).many?
-  end
+      FeaturedCircuit.find_by(project_id: id)&.destroy
+    end
 
-  def purge_circuit_preview
-    circuit_preview.purge if circuit_preview.attached?
-  end
+    def should_generate_new_friendly_id?
+      name_changed? || Project.where(slug: slug).many?
+    end
+
+    def purge_circuit_preview
+      circuit_preview.purge if circuit_preview.attached?
+    end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -47,7 +47,7 @@ class Project < ApplicationRecord
     }
   }
 
-  before_validation :ensure_unique_name_per_user, on: :create
+  before_validation :ensure_unique_name_per_user, if: :will_save_change_to_name?
   after_update :check_and_remove_featured
   before_destroy :purge_circuit_preview
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -9,7 +9,7 @@ class Project < ApplicationRecord
   self.ignored_columns += %w[data searchable]
 
   validates :name, length: { minimum: 1 }
-  validates :slug, uniqueness: true
+  # validates :slug, uniqueness: true
 
   belongs_to :author, class_name: "User", counter_cache: true
   has_many :forks, class_name: "Project", foreign_key: "forked_project_id", dependent: :nullify
@@ -35,9 +35,7 @@ class Project < ApplicationRecord
 
   scope :public_and_not_forked,
         -> { where(project_access_type: "Public", forked_project_id: nil) }
-
   scope :open, -> { where(project_access_type: "Public") }
-
   scope :by, ->(author_id) { where(author_id: author_id) }
 
   include PgSearch::Model
@@ -45,28 +43,31 @@ class Project < ApplicationRecord
   accepts_nested_attributes_for :project_datum
   pg_search_scope :text_search, against: %i[name description], using: {
     tsearch: {
-      dictionary: "english", tsvector_column: "searchable"
+      dictionary: "english",
+      tsvector_column: "searchable"
     }
   }
 
+  before_validation :ensure_unique_name_per_user, on: :create
   after_update :check_and_remove_featured
-
   before_destroy :purge_circuit_preview
 
   self.per_page = 9
 
   acts_as_commontable
-  # after_commit :send_mail, on: :create
+
+  # -------------------------
+  # Public instance methods
+  # -------------------------
 
   def increase_views(user)
     increment!(:view) if user.nil? || (user.id != author_id)
   end
 
-  # returns true if starred, false if unstarred
   def toggle_star(user)
     star = Star.find_by(user_id: user.id, project_id: id)
     if star.nil?
-      @star = Star.create!(user_id: user.id, project_id: id)
+      Star.create!(user_id: user.id, project_id: id)
       true
     else
       star.destroy!
@@ -80,39 +81,19 @@ class Project < ApplicationRecord
     forked_project.circuit_preview.attach(circuit_preview.blob)
     forked_project.image_preview = image_preview
     forked_project.update!(
-      view: 1, author_id: user.id, forked_project_id: id, name: name
+      view: 1,
+      author_id: user.id,
+      forked_project_id: id,
+      name: name
     )
-    @project = Project.find(id)
-    if @project.author != user # rubocop:disable Style/IfUnlessModifier
-      ForkNotification.with(user: user, project: @project).deliver_later(@project.author)
+
+    original_project = Project.find(id)
+    if original_project.author != user
+      ForkNotification.with(user: user, project: original_project)
+                      .deliver_later(original_project.author)
     end
+
     forked_project
-  end
-
-  def send_mail
-    if forked_project_id.nil?
-      UserMailer.new_project_email(author, self).deliver_later if project_submission == false
-    elsif project_submission == false
-      UserMailer.forked_project_email(author, forked_project, self).deliver_later
-    end
-  end
-
-  def project_notifiable_path
-    user_project_path(forked_project.author, forked_project)
-  end
-
-  def self.tagged_with(name)
-    Tag.find_by!(name: name).projects
-  end
-
-  def tag_list
-    tags.map(&:name).join(", ")
-  end
-
-  def tag_list=(names)
-    self.tags = names.split(",").map(&:strip).uniq.compact_blank.map do |n|
-      Tag.where(name: n.strip).first_or_create!
-    end
   end
 
   def public?
@@ -138,34 +119,51 @@ class Project < ApplicationRecord
 
   private
 
-    def check_validity
-      return unless (project_access_type != "Private") && !assignment_id.nil?
+  # -------------------------
+  # Callbacks & validations
+  # -------------------------
 
-      errors.add(:project_access_type, "Assignment has to be private")
-    end
+def ensure_unique_name_per_user
+  return if name.blank? || author_id.blank?
 
-    def clean_description
-      profanity_filter = LanguageFilter::Filter.new matchlist: :profanity
-      return nil unless profanity_filter.match? description
+  base_name = name.gsub(/\s\(\d+\)$/, "").strip
+  counter = 1
+  
+  # We check if the current name (self.name) is taken by ANOTHER record
+  while Project.where(author_id: author_id, name: self.name).where.not(id: id).exists?
+    self.name = "#{base_name} (#{counter})"
+    counter += 1
+  end
+end
 
-      errors.add(
-        :description,
-        "contains inappropriate language: #{profanity_filter.matched(description).join(', ')}"
-      )
-    end
+  def check_validity
+    return unless project_access_type != "Private" && assignment_id.present?
 
-    def check_and_remove_featured
-      return unless saved_change_to_project_access_type? && saved_changes["project_access_type"][1] != "Public"
+    errors.add(:project_access_type, "Assignment has to be private")
+  end
 
-      FeaturedCircuit.find_by(project_id: id)&.destroy
-    end
+  def clean_description
+    profanity_filter = LanguageFilter::Filter.new matchlist: :profanity
+    return unless profanity_filter.match?(description)
 
-    def should_generate_new_friendly_id?
-      # FIXME: Remove extra query once production data is resolved
-      name_changed? || Project.where(slug: slug).many?
-    end
+    errors.add(
+      :description,
+      "contains inappropriate language: #{profanity_filter.matched(description).join(', ')}"
+    )
+  end
 
-    def purge_circuit_preview
-      circuit_preview.purge if circuit_preview.attached?
-    end
+  def check_and_remove_featured
+    return unless saved_change_to_project_access_type? &&
+                  saved_changes["project_access_type"][1] != "Public"
+
+    FeaturedCircuit.find_by(project_id: id)&.destroy
+  end
+
+  def should_generate_new_friendly_id?
+    name_changed? || Project.where(slug: slug).many?
+  end
+
+  def purge_circuit_preview
+    circuit_preview.purge if circuit_preview.attached?
+  end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -71,16 +71,14 @@ class Project < ApplicationRecord
   end
 
   def fork(user)
-      forked_project = dup
-      forked_project.build_project_datum.data = project_datum&.data
-      forked_project.circuit_preview.attach(circuit_preview.blob) if circuit_preview.attached?
-      forked_project.image_preview = image_preview
-      forked_project.update!(view: 1, author_id: user.id, forked_project_id: id, name: name)
-  
-      ForkNotification.with(user: user, project: self).deliver_later(author) if author != user
-  
-      forked_project
-    end
+    forked_project = dup
+    forked_project.build_project_datum.data = project_datum&.data
+    forked_project.circuit_preview.attach(circuit_preview.blob) if circuit_preview.attached?
+    forked_project.image_preview = image_preview
+    forked_project.update!(view: 1, author_id: user.id, forked_project_id: id, name: name)
+    ForkNotification.with(user: user, project: self).deliver_later(author) if author != user
+    forked_project
+  end
 
   def public?
     project_access_type == "Public"
@@ -105,47 +103,46 @@ class Project < ApplicationRecord
 
   private
 
-    def ensure_unique_name_per_user
-      return if name.blank? || author_id.blank?
+  def ensure_unique_name_per_user
+    return if name.blank? || author_id.blank?
 
-      base_name = name.gsub(/\s\(\d+\)$/, "").strip
-      counter = 1
+    base_name = name.gsub(/\s\(\d+\)$/, "").strip
+    counter = 1
 
-      # We check if the current name (self.name) is taken by ANOTHER record
-      while Project.where(author_id: author_id, name: name).where.not(id: id).exists?
-        self.name = "#{base_name} (#{counter})"
-        counter += 1
-      end
+    while Project.where(author_id: author_id, name: name).where.not(id: id).exists?
+      self.name = "#{base_name} (#{counter})"
+      counter += 1
     end
+  end
 
-    def check_validity
-      return unless project_access_type != "Private" && assignment_id.present?
+  def check_validity
+    return unless project_access_type != "Private" && assignment_id.present?
 
-      errors.add(:project_access_type, "Assignment has to be private")
-    end
+    errors.add(:project_access_type, "Assignment has to be private")
+  end
 
-    def clean_description
-      profanity_filter = LanguageFilter::Filter.new matchlist: :profanity
-      return unless profanity_filter.match?(description)
+  def clean_description
+    profanity_filter = LanguageFilter::Filter.new matchlist: :profanity
+    return unless profanity_filter.match?(description)
 
-      errors.add(
-        :description,
-        "contains inappropriate language: #{profanity_filter.matched(description).join(', ')}"
-      )
-    end
+    errors.add(
+      :description,
+      "contains inappropriate language: #{profanity_filter.matched(description).join(', ')}"
+    )
+  end
 
-    def check_and_remove_featured
-      return unless saved_change_to_project_access_type? &&
-                    saved_changes["project_access_type"][1] != "Public"
+  def check_and_remove_featured
+    return unless saved_change_to_project_access_type? &&
+                  saved_changes["project_access_type"][1] != "Public"
 
-      FeaturedCircuit.find_by(project_id: id)&.destroy
-    end
+    FeaturedCircuit.find_by(project_id: id)&.destroy
+  end
 
-    def should_generate_new_friendly_id?
-      name_changed? || Project.where(slug: slug).many?
-    end
+  def should_generate_new_friendly_id?
+    name_changed? || Project.where(slug: slug).many?
+  end
 
-    def purge_circuit_preview
-      circuit_preview.purge if circuit_preview.attached?
-    end
+  def purge_circuit_preview
+    circuit_preview.purge if circuit_preview.attached?
+  end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -9,7 +9,6 @@ class Project < ApplicationRecord
   self.ignored_columns += %w[data searchable]
 
   validates :name, length: { minimum: 1 }
-  # validates :slug, uniqueness: true
 
   belongs_to :author, class_name: "User", counter_cache: true
   has_many :forks, class_name: "Project", foreign_key: "forked_project_id", dependent: :nullify
@@ -56,10 +55,6 @@ class Project < ApplicationRecord
 
   acts_as_commontable
 
-  # -------------------------
-  # Public instance methods
-  # -------------------------
-
   def increase_views(user)
     increment!(:view) if user.nil? || (user.id != author_id)
   end
@@ -76,25 +71,16 @@ class Project < ApplicationRecord
   end
 
   def fork(user)
-    forked_project = dup
-    forked_project.build_project_datum.data = project_datum&.data
-    forked_project.circuit_preview.attach(circuit_preview.blob)
-    forked_project.image_preview = image_preview
-    forked_project.update!(
-      view: 1,
-      author_id: user.id,
-      forked_project_id: id,
-      name: name
-    )
-
-    original_project = Project.find(id)
-    if original_project.author != user
-      ForkNotification.with(user: user, project: original_project)
-                      .deliver_later(original_project.author)
+      forked_project = dup
+      forked_project.build_project_datum.data = project_datum&.data
+      forked_project.circuit_preview.attach(circuit_preview.blob) if circuit_preview.attached?
+      forked_project.image_preview = image_preview
+      forked_project.update!(view: 1, author_id: user.id, forked_project_id: id, name: name)
+  
+      ForkNotification.with(user: user, project: self).deliver_later(author) if author != user
+  
+      forked_project
     end
-
-    forked_project
-  end
 
   def public?
     project_access_type == "Public"
@@ -118,10 +104,6 @@ class Project < ApplicationRecord
   end
 
   private
-
-    # -------------------------
-    # Callbacks & validations
-    # -------------------------
 
     def ensure_unique_name_per_user
       return if name.blank? || author_id.blank?

--- a/app/models/project_datum.rb
+++ b/app/models/project_datum.rb
@@ -9,27 +9,37 @@ class ProjectDatum < ApplicationRecord
 
   def ensure_unique_circuit_name_per_user
     return if project.nil? || data.blank?
-
-    parsed_data = JSON.parse(data) rescue return
+  
+    begin
+      parsed_data = JSON.parse(data)
+    rescue JSON::ParserError
+      errors.add(:data, "must be valid JSON")
+      throw(:abort)
+    end
+  
     return if parsed_data["name"].blank?
-
+  
     user_id = project.author_id
     base_name = parsed_data["name"].gsub(/\s\(\d+\)$/, "").strip
-
+    
+    # Fetch existing names once
     existing_names = ProjectDatum.joins(:project)
                                  .where(projects: { author_id: user_id })
                                  .where("(project_data.data::jsonb ->> 'name') LIKE ?", "#{base_name}%")
                                  .where.not(id: id)
                                  .pluck(Arel.sql("project_data.data::jsonb ->> 'name'"))
-
-    new_name = base_name
+                                 .to_set
+  
+    final_name = base_name
     counter = 1
-    while existing_names.include?(new_name)
-      new_name = "#{base_name} (#{counter})"
+    while existing_names.include?(final_name)
+      final_name = "#{base_name} (#{counter})"
       counter += 1
     end
-
-    parsed_data["name"] = new_name
-    self.data = parsed_data.to_json
+  
+    if parsed_data["name"] != final_name
+      parsed_data["name"] = final_name
+      self.data = parsed_data.to_json
+    end
   end
 end

--- a/app/models/project_datum.rb
+++ b/app/models/project_datum.rb
@@ -7,33 +7,29 @@ class ProjectDatum < ApplicationRecord
 
   private
 
-    def ensure_unique_circuit_name_per_user
-      return if project.nil? || data.blank?
+  def ensure_unique_circuit_name_per_user
+    return if project.nil? || data.blank?
 
-      parsed_data = begin
-        JSON.parse(data)
-      rescue StandardError
-        {}
-      end
-      return if parsed_data["name"].blank?
+    parsed_data = JSON.parse(data) rescue return
+    return if parsed_data["name"].blank?
 
-      user_id   = project.author_id
-      base_name = parsed_data["name"].gsub(/\s\(\d+\)$/, "").strip
-      counter   = 1
-      new_name  = base_name
+    user_id = project.author_id
+    base_name = parsed_data["name"].gsub(/\s\(\d+\)$/, "").strip
 
-      while ProjectDatum
-            .joins(:project)
-            .where(projects: { author_id: user_id })
-            .where("(project_data.data::jsonb ->> 'name') = ?", new_name)
-            .where.not(id: id)
-            .exists?
+    existing_names = ProjectDatum.joins(:project)
+                                 .where(projects: { author_id: user_id })
+                                 .where("(project_data.data::jsonb ->> 'name') LIKE ?", "#{base_name}%")
+                                 .where.not(id: id)
+                                 .pluck(Arel.sql("project_data.data::jsonb ->> 'name'"))
 
-        new_name = "#{base_name} (#{counter})"
-        counter += 1
-      end
-
-      parsed_data["name"] = new_name
-      self.data = parsed_data.to_json
+    new_name = base_name
+    counter = 1
+    while existing_names.include?(new_name)
+      new_name = "#{base_name} (#{counter})"
+      counter += 1
     end
+
+    parsed_data["name"] = new_name
+    self.data = parsed_data.to_json
+  end
 end

--- a/app/models/project_datum.rb
+++ b/app/models/project_datum.rb
@@ -2,4 +2,36 @@
 
 class ProjectDatum < ApplicationRecord
   belongs_to :project
+
+  # before_validation :ensure_unique_circuit_name_per_user, on: :creategive issue to write in github
+
+
+  private
+
+  def ensure_unique_circuit_name_per_user
+    return if project.nil? || data.blank?
+
+    parsed_data = JSON.parse(data) rescue {}
+    return if parsed_data["name"].blank?
+
+    user_id   = project.author_id
+    base_name = parsed_data["name"]
+    counter   = 1
+    new_name  = base_name
+
+    while ProjectDatum
+          .joins(:project)
+          .where(projects: { author_id: user_id })
+          .where("(project_data.data::jsonb ->> 'name') = ?", new_name)
+          .where.not(id: id)
+          .exists?
+
+      new_name = "#{base_name} (#{counter})"
+      counter += 1
+    end
+
+    # ✅ THIS IS THE MISSING LINE
+    parsed_data["name"] = new_name
+    self.data = parsed_data.to_json
+  end
 end

--- a/app/models/project_datum.rb
+++ b/app/models/project_datum.rb
@@ -5,33 +5,36 @@ class ProjectDatum < ApplicationRecord
 
   # before_validation :ensure_unique_circuit_name_per_user, on: :creategive issue to write in github
 
-
   private
 
-  def ensure_unique_circuit_name_per_user
-    return if project.nil? || data.blank?
+    def ensure_unique_circuit_name_per_user
+      return if project.nil? || data.blank?
 
-    parsed_data = JSON.parse(data) rescue {}
-    return if parsed_data["name"].blank?
+      parsed_data = begin
+        JSON.parse(data)
+      rescue StandardError
+        {}
+      end
+      return if parsed_data["name"].blank?
 
-    user_id   = project.author_id
-    base_name = parsed_data["name"]
-    counter   = 1
-    new_name  = base_name
+      user_id   = project.author_id
+      base_name = parsed_data["name"]
+      counter   = 1
+      new_name  = base_name
 
-    while ProjectDatum
-          .joins(:project)
-          .where(projects: { author_id: user_id })
-          .where("(project_data.data::jsonb ->> 'name') = ?", new_name)
-          .where.not(id: id)
-          .exists?
+      while ProjectDatum
+            .joins(:project)
+            .where(projects: { author_id: user_id })
+            .where("(project_data.data::jsonb ->> 'name') = ?", new_name)
+            .where.not(id: id)
+            .exists?
 
-      new_name = "#{base_name} (#{counter})"
-      counter += 1
+        new_name = "#{base_name} (#{counter})"
+        counter += 1
+      end
+
+      # ✅ THIS IS THE MISSING LINE
+      parsed_data["name"] = new_name
+      self.data = parsed_data.to_json
     end
-
-    # ✅ THIS IS THE MISSING LINE
-    parsed_data["name"] = new_name
-    self.data = parsed_data.to_json
-  end
 end

--- a/app/models/project_datum.rb
+++ b/app/models/project_datum.rb
@@ -3,7 +3,7 @@
 class ProjectDatum < ApplicationRecord
   belongs_to :project
 
-  # before_validation :ensure_unique_circuit_name_per_user, on: :creategive issue to write in github
+  before_validation :ensure_unique_circuit_name_per_user, on: :create
 
   private
 
@@ -18,7 +18,7 @@ class ProjectDatum < ApplicationRecord
       return if parsed_data["name"].blank?
 
       user_id   = project.author_id
-      base_name = parsed_data["name"]
+      base_name = parsed_data["name"].gsub(/\s\(\d+\)$/, "").strip
       counter   = 1
       new_name  = base_name
 
@@ -33,7 +33,6 @@ class ProjectDatum < ApplicationRecord
         counter += 1
       end
 
-      # ✅ THIS IS THE MISSING LINE
       parsed_data["name"] = new_name
       self.data = parsed_data.to_json
     end

--- a/app/models/project_datum.rb
+++ b/app/models/project_datum.rb
@@ -9,7 +9,7 @@ class ProjectDatum < ApplicationRecord
 
   def ensure_unique_circuit_name_per_user
     return if project.nil? || data.blank?
-  
+    
     begin
       parsed_data = JSON.parse(data)
     rescue JSON::ParserError

--- a/simulator/src/circuit.js
+++ b/simulator/src/circuit.js
@@ -153,7 +153,7 @@ export function newCircuit(name, id, isVerilog = false, isVerilogMain = false) {
     if (layoutModeGet()) { toggleLayoutMode(); }
     if (verilogModeGet()) { verilogModeSet(false); }
     let circuitName = name || prompt('Enter circuit name:', 'Untitled-Circuit');
-    circuitName = escapeHtml(stripTags(circuitName));
+    circuitName = escapeHtml(stripTags(circuitName)).trim();
     if (!circuitName) return;
 
     circuitName = getUniqueCircuitName(circuitName);

--- a/simulator/src/circuit.js
+++ b/simulator/src/circuit.js
@@ -48,8 +48,8 @@ export function resetScopeList() {
 function normalizeCircuitNames() {
     const used = {};
 
-    Object.values(scopeList).forEach(scope => {
-        let base = scope.name;
+    Object.values(scopeList).forEach((scope) => {
+        const base = scope.name;
         let name = base;
         let counter = 0;
 
@@ -77,7 +77,7 @@ function normalizeCircuitNames() {
  */
 export function switchCircuit(id) {
     if (layoutModeGet()) { toggleLayoutMode(); }
-    if (verilogModeGet()) { verilogModeSet(false);}
+    if (verilogModeGet()) { verilogModeSet(false); }
 
     // globalScope.fixLayout();
     scheduleBackup();
@@ -144,8 +144,7 @@ function deleteCurrentCircuit(scopeId = globalScope.id) {
     if (confirmation) {
         if (scope.verilogMetadata.isVerilogCircuit) {
             scope.initialize();
-            for (var id in scope.verilogMetadata.subCircuitScopeIds)
-                delete scopeList[id];
+            for (var id in scope.verilogMetadata.subCircuitScopeIds) delete scopeList[id];
         }
         $(`#${scope.id}`).remove();
         delete scopeList[scope.id];
@@ -179,7 +178,7 @@ function getUniqueCircuitName(baseName) {
     let counter = 0;
     let newName = baseName;
 
-    const existingNames = Object.values(scopeList).map(scope => scope.name);
+    const existingNames = Object.values(scopeList).map((scope) => scope.name);
 
     while (existingNames.includes(newName)) {
         counter++;
@@ -211,7 +210,7 @@ export function newCircuit(name, id, isVerilog = false, isVerilogMain = false) {
         if (embed) {
             var html = `<div style='' class='circuits toolbarButton current' draggable='true' id='${scope.id}'><span class='circuitName noSelect'>${truncateString(name, 18)}</span></div>`;
             $('#tabsBar').append(html);
-            $("#tabsBar").addClass('embed-tabs');
+            $('#tabsBar').addClass('embed-tabs');
         } else {
             var html = `<div style='' class='circuits toolbarButton current' draggable='true' id='${scope.id}'><span class='circuitName noSelect'>${truncateString(name, 18)}</span><span class ='tabsCloseButton' id='${scope.id}'  >x</span></div>`;
             $('#tabsBar').children().last().before(html);
@@ -223,18 +222,18 @@ export function newCircuit(name, id, isVerilog = false, isVerilogMain = false) {
         $('.tabsCloseButton').off('click');
 
         // Add listeners
-        $('.circuits').on('click',function () {
+        $('.circuits').on('click', function () {
             switchCircuit(this.id);
         });
 
-        $('.circuitName').on('click',(e) => {
+        $('.circuitName').on('click', (e) => {
             simulationArea.lastSelected = globalScope.root;
             setTimeout(() => {
                 document.getElementById('circname').select();
             }, 100);
         });
 
-        $('.tabsCloseButton').on('click',function (e) {
+        $('.tabsCloseButton').on('click', function (e) {
             e.stopPropagation();
             deleteCurrentCircuit(this.id);
         });
@@ -258,10 +257,10 @@ export function changeCircuitName(name, id = globalScope.id) {
     name = escapeHtml(stripTags(name));
 
     const existingNames = Object.values(scopeList)
-        .filter(scope => scope.id !== id)
-        .map(scope => scope.name);
+        .filter((scope) => scope.id !== id)
+        .map((scope) => scope.name);
 
-    let baseName = name;
+    const baseName = name;
     let counter = 0;
 
     while (existingNames.includes(name)) {
@@ -403,7 +402,6 @@ export default class Scope {
         for (let i = 0; i < this.Output.length; i++) { maxY = Math.max(this.Output[i].layoutProperties.y, maxY); }
         if (maxY !== this.layout.height) { this.layout.height = maxY + 10; }
     }
-
 
     /**
      * Function which centers the circuit to the correct zoom level
@@ -562,7 +560,7 @@ export default class Scope {
     highlightNodes(array) {
         const Nodes = [];
         array.forEach((innerArray) => {
-            const resultArray = innerArray.map(value => this.findNodeIndexById(value));
+            const resultArray = innerArray.map((value) => this.findNodeIndexById(value));
             Nodes.push(resultArray);
         });
 

--- a/simulator/src/circuit.js
+++ b/simulator/src/circuit.js
@@ -49,7 +49,7 @@ function normalizeCircuitNames() {
     const used = {};
 
     Object.values(scopeList).forEach((scope) => {
-        const base = scope.name;
+        const base = scope.name.replace(/\s\(\d+\)$/, '').trim();
         let name = base;
         let counter = 0;
 
@@ -67,19 +67,10 @@ function normalizeCircuitNames() {
     });
 }
 
-/**
- * Function used to change the current focusedCircuit
- * Disables layoutMode if enabled
- * Changes UI tab etc
- * Sets flags to make updates, resets most of the things
- * @param {string} id - identifier for circuit
- * @category circuit
- */
 export function switchCircuit(id) {
     if (layoutModeGet()) { toggleLayoutMode(); }
     if (verilogModeGet()) { verilogModeSet(false); }
 
-    // globalScope.fixLayout();
     scheduleBackup();
     normalizeCircuitNames();
     if (id === globalScope.id) return;
@@ -106,18 +97,9 @@ export function switchCircuit(id) {
     }
     updateCanvasSet(true);
     scheduleUpdate();
-
-    // to update the restricted elements information
     updateRestrictedElementsList();
 }
 
-/**
- * Deletes the current circuit
- * Ensures that at least one circuit is there
- * Ensures that no circuit depends on the current circuit
- * Switched to a random circuit
-  * @category circuit
-*/
 function deleteCurrentCircuit(scopeId = globalScope.id) {
     const scope = scopeList[scopeId];
     if (Object.keys(scopeList).length <= 1) {
@@ -125,7 +107,7 @@ function deleteCurrentCircuit(scopeId = globalScope.id) {
         return;
     }
     let dependencies = '';
-    for (id in scopeList) {
+    for (const id in scopeList) {
         if (id != scope.id && scopeList[id].checkDependency(scope.id)) {
             if (dependencies === '') {
                 dependencies = scopeList[id].name;
@@ -135,8 +117,8 @@ function deleteCurrentCircuit(scopeId = globalScope.id) {
         }
     }
     if (dependencies) {
-        dependencies = `\nThe following circuits are depending on '${scope.name}': ${dependencies}\nDelete subcircuits of ${scope.name} before trying to delete ${scope.name}`;
-        alert(dependencies);
+        const depMsg = `\nThe following circuits are depending on '${scope.name}': ${dependencies}\nDelete subcircuits of ${scope.name} before trying to delete ${scope.name}`;
+        alert(depMsg);
         return;
     }
 
@@ -144,7 +126,7 @@ function deleteCurrentCircuit(scopeId = globalScope.id) {
     if (confirmation) {
         if (scope.verilogMetadata.isVerilogCircuit) {
             scope.initialize();
-            for (var id in scope.verilogMetadata.subCircuitScopeIds) delete scopeList[id];
+            for (const id in scope.verilogMetadata.subCircuitScopeIds) delete scopeList[id];
         }
         $(`#${scope.id}`).remove();
         delete scopeList[scope.id];
@@ -153,9 +135,6 @@ function deleteCurrentCircuit(scopeId = globalScope.id) {
     } else { showMessage('Circuit was not closed'); }
 }
 
-/**
- * Wrapper function around newCircuit to be called from + button on UI
- */
 export function createNewCircuitScope() {
     simulationArea.lastSelected = undefined;
     const scope = newCircuit();
@@ -166,36 +145,29 @@ export function createNewCircuitScope() {
     }
 }
 
-/**
- * Generates a unique name for a circuit by appending a numeric suffix.
- * @param {string} baseName - The initial name to check.
- * @returns {string} - The unique name.
- */
-
 function getUniqueCircuitName(baseName) {
-    baseName = baseName.replace(/\s\(\d+\)$/, '');
-
-    let counter = 0;
-    let newName = baseName;
+    const normalizedBase = baseName.replace(/\s\(\d+\)$/, '').trim();
     const existingNames = Object.values(scopeList).map((scope) => scope.name);
+    let counter = 0;
+    let newName = normalizedBase;
 
     while (existingNames.includes(newName)) {
         counter++;
-        newName = `${baseName} (${counter})`;
+        newName = `${normalizedBase} (${counter})`;
     }
     return newName;
 }
+
 export function newCircuit(name, id, isVerilog = false, isVerilogMain = false) {
     if (layoutModeGet()) { toggleLayoutMode(); }
     if (verilogModeGet()) { verilogModeSet(false); }
-    name = name || prompt('Enter circuit name:', 'Untitled-Circuit');
-    name = escapeHtml(stripTags(name));
-    if (!name) return;
+    let circuitName = name || prompt('Enter circuit name:', 'Untitled-Circuit');
+    circuitName = escapeHtml(stripTags(circuitName));
+    if (!circuitName) return;
 
-    // 🔥 FIX: Ensure unique name before creating scope
-    name = getUniqueCircuitName(name);
+    circuitName = getUniqueCircuitName(circuitName);
 
-    const scope = new Scope(name);
+    const scope = new Scope(circuitName);
     if (id) scope.id = id;
     scopeList[scope.id] = scope;
     if (isVerilog) {
@@ -205,33 +177,29 @@ export function newCircuit(name, id, isVerilog = false, isVerilogMain = false) {
     globalScope = scope;
     $('.circuits').removeClass('current');
     if (!isVerilog || isVerilogMain) {
+        const html = embed 
+            ? `<div class='circuits toolbarButton current' draggable='true' id='${scope.id}'><span class='circuitName noSelect'>${truncateString(circuitName, 18)}</span></div>`
+            : `<div class='circuits toolbarButton current' draggable='true' id='${scope.id}'><span class='circuitName noSelect'>${truncateString(circuitName, 18)}</span><span class='tabsCloseButton' id='${scope.id}'>x</span></div>`;
+
         if (embed) {
-            var html = `<div style='' class='circuits toolbarButton current' draggable='true' id='${scope.id}'><span class='circuitName noSelect'>${truncateString(name, 18)}</span></div>`;
-            $('#tabsBar').append(html);
-            $('#tabsBar').addClass('embed-tabs');
+            $('#tabsBar').append(html).addClass('embed-tabs');
         } else {
-            var html = `<div style='' class='circuits toolbarButton current' draggable='true' id='${scope.id}'><span class='circuitName noSelect'>${truncateString(name, 18)}</span><span class ='tabsCloseButton' id='${scope.id}'  >x</span></div>`;
             $('#tabsBar').children().last().before(html);
         }
 
-        // Remove listeners
-        $('.circuits').off('click');
-        $('.circuitName').off('click');
-        $('.tabsCloseButton').off('click');
-
-        // Add listeners
-        $('.circuits').on('click', function () {
+        $('.circuits').off('click').on('click', function () {
             switchCircuit(this.id);
         });
 
-        $('.circuitName').on('click', (e) => {
+        $('.circuitName').off('click').on('click', () => {
             simulationArea.lastSelected = globalScope.root;
             setTimeout(() => {
-                document.getElementById('circname').select();
+                const el = document.getElementById('circname');
+                if (el) el.select();
             }, 100);
         });
 
-        $('.tabsCloseButton').on('click', function (e) {
+        $('.tabsCloseButton').off('click').on('click', function (e) {
             e.stopPropagation();
             deleteCurrentCircuit(this.id);
         });
@@ -244,50 +212,33 @@ export function newCircuit(name, id, isVerilog = false, isVerilogMain = false) {
     return scope;
 }
 
-/**
- * Used to change name of a circuit
- * @param {string} name - new name
- * @param {string} id - id of the circuit
- * @category circuit
- */
 export function changeCircuitName(name, id = globalScope.id) {
-    name = name || 'Untitled';
-    name = escapeHtml(stripTags(name));
-
+    const rawName = escapeHtml(stripTags(name || 'Untitled'));
     const existingNames = Object.values(scopeList)
-        .filter((scope) => scope.id !== id)
-        .map((scope) => scope.name);
+        .filter((s) => s.id !== id)
+        .map((s) => s.name);
 
-    const baseName = name;
+    const normalizedBase = rawName.replace(/\s\(\d+\)$/, '').trim();
+    let finalName = normalizedBase;
     let counter = 0;
 
-    while (existingNames.includes(name)) {
+    while (existingNames.includes(finalName)) {
         counter++;
-        name = `${baseName} (${counter})`;
+        finalName = `${normalizedBase} (${counter})`;
     }
 
-    $(`#${id} .circuitName`).html(truncateString(name, 18));
-    scopeList[id].name = name;
+    $(`#${id} .circuitName`).html(truncateString(finalName, 18));
+    scopeList[id].name = finalName;
 }
 
-/**
- * Class representing a Scope
- * @class
- * @param {string} name - name of the circuit
- * @param {number=} id - a random id for the circuit
- * @category circuit
- */
 export default class Scope {
     constructor(name = 'localScope', id = undefined) {
         this.restrictedCircuitElementsUsed = [];
         this.id = id || Math.floor((Math.random() * 100000000000) + 1);
         this.CircuitElement = [];
         this.name = name;
-
-        // root object for referring to main canvas - intermediate node uses this
         this.root = new CircuitElement(0, 0, this, 'RIGHT', 1);
         this.backups = [];
-        // maintaining a state (history) for redo function
         this.history = [];
         this.timeStamp = new Date().getTime();
         this.verilogMetadata = {
@@ -304,8 +255,7 @@ export default class Scope {
 
         this.initialize();
 
-        // Setting default layout
-        this.layout = { // default position
+        this.layout = {
             width: 100,
             height: 40,
             title_x: 50,
@@ -322,19 +272,15 @@ export default class Scope {
     initialize() {
         this.tunnelList = {};
         this.pending = [];
-        this.nodes = []; // intermediate nodes only
+        this.nodes = [];
         this.allNodes = [];
         this.wires = [];
 
-        // Creating arrays for other module elements
         for (let i = 0; i < moduleList.length; i++) {
             this[moduleList[i]] = [];
         }
     }
 
-    /**
-     * Resets all nodes recursively
-     */
     reset() {
         for (let i = 0; i < this.allNodes.length; i++) { this.allNodes[i].reset(); }
         for (let i = 0; i < this.Splitter.length; i++) {
@@ -345,9 +291,6 @@ export default class Scope {
         }
     }
 
-    /**
-     * Adds all inputs to simulationQueue
-    */
     addInputs() {
         for (let i = 0; i < inputList.length; i++) {
             for (var j = 0; j < this[inputList[i]].length; j++) {
@@ -358,30 +301,18 @@ export default class Scope {
         for (let i = 0; i < this.SubCircuit.length; i++) { this.SubCircuit[i].addInputs(); }
     }
 
-    /**
-     * Ticks clocks recursively -- needs to be deprecated and synchronize all clocks with a global clock
-     */
     clockTick() {
-        for (let i = 0; i < this.Clock.length; i++) { this.Clock[i].toggleState(); } // tick clock!
-        for (let i = 0; i < this.SubCircuit.length; i++) { this.SubCircuit[i].localScope.clockTick(); } // tick clock!
+        for (let i = 0; i < this.Clock.length; i++) { this.Clock[i].toggleState(); }
+        for (let i = 0; i < this.SubCircuit.length; i++) { this.SubCircuit[i].localScope.clockTick(); }
     }
 
-    /**
-     * Checks if this circuit contains directly or indirectly scope with id
-     * Recursive nature
-     */
     checkDependency(id) {
         if (id === this.id) return true;
         for (let i = 0; i < this.SubCircuit.length; i++) { if (this.SubCircuit[i].id === id) return true; }
-
         for (let i = 0; i < this.SubCircuit.length; i++) { if (scopeList[this.SubCircuit[i].id].checkDependency(id)) return true; }
-
         return false;
     }
 
-    /**
-     * Get dependency list - list of all circuits, this circuit depends on
-     */
     getDependencies() {
         var list = [];
         for (let i = 0; i < this.SubCircuit.length; i++) {
@@ -391,9 +322,6 @@ export default class Scope {
         return uniq(list);
     }
 
-    /**
-     * helper function to reduce layout size
-    */
     fixLayout() {
         var maxY = 20;
         for (let i = 0; i < this.Input.length; i++) { maxY = Math.max(this.Input[i].layoutProperties.y, maxY); }
@@ -401,35 +329,23 @@ export default class Scope {
         if (maxY !== this.layout.height) { this.layout.height = maxY + 10; }
     }
 
-    /**
-     * Function which centers the circuit to the correct zoom level
-     */
     centerFocus(zoomIn = true) {
         if (layoutModeGet()) return;
         findDimensions(this);
-
-        var ytoolbarOffset = embed ? 0 : 60 * DPR; // Some part ofcanvas is hidden behind the toolbar
-
+        var ytoolbarOffset = embed ? 0 : 60 * DPR;
         var minX = simulationArea.minWidth || 0;
         var minY = simulationArea.minHeight || 0;
         var maxX = simulationArea.maxWidth || 0;
         var maxY = simulationArea.maxHeight || 0;
-
         var reqWidth = maxX - minX + 75 * DPR;
         var reqHeight = maxY - minY + 75 * DPR;
-
         this.scale = Math.min(width / reqWidth, (height - ytoolbarOffset) / reqHeight);
-
         if (!zoomIn) { this.scale = Math.min(this.scale, DPR); }
         this.scale = Math.max(this.scale, DPR / 10);
-
         this.ox = (-minX) * this.scale + (width - (maxX - minX) * this.scale) / 2;
         this.oy = (-minY) * this.scale + (height - ytoolbarOffset - (maxY - minY) * this.scale) / 2;
     }
 
-    /**
-     * Function to load a circuit using circuit data
-     */
     loadCircuit(data) {
         if (data) {
             load(data);
@@ -438,9 +354,6 @@ export default class Scope {
         }
     }
 
-    /**
-     * Function to retrieve the previous stable state of the circuit
-     */
     previous() {
         const autosaveData = localStorage.getItem('autosave');
         if (autosaveData) {
@@ -450,13 +363,9 @@ export default class Scope {
         }
     }
 
-    /**
-     * Function to detect the nodes that are creating cyclic paths in the circuit
-     */
     detectCycle() {
         const obj = {};
         const result = [];
-
         for (let i = 0; i < globalScope.allNodes.length; i++) {
             const nodeId = globalScope.allNodes[i].id;
             for (let j = 0; j < globalScope.allNodes[i].connections.length; j++) {
@@ -468,10 +377,8 @@ export default class Scope {
                 }
             }
         }
-
         const newNestedArray = [];
         const singleConnectionNodes = [];
-
         for (const node in obj) {
             const connections = obj[node];
             if (connections.length === 1) {
@@ -483,7 +390,6 @@ export default class Scope {
                 newNestedArray.push(connectedNodes);
             }
         }
-
         for (let i = 0; i < singleConnectionNodes.length - 1; i++) {
             for (let j = i + 1; j < singleConnectionNodes.length; j++) {
                 if (areElementsInSameNode(newNestedArray, singleConnectionNodes[i], singleConnectionNodes[j])) {
@@ -495,13 +401,9 @@ export default class Scope {
                 }
             }
         }
-
-        // Function to check whether a node is already visited
         function isVisited(visited, node) {
             return visited.includes(node);
         }
-
-        // Function to explore interconnected nodes
         function exploreNodes(graph, startNode, visited, connectedNodes) {
             visited.push(startNode);
             if (graph[startNode]) {
@@ -514,7 +416,6 @@ export default class Scope {
                 }
             }
         }
-
         function areElementsInSameNode(nestedArray, element1, element2) {
             for (const node of nestedArray) {
                 if (node.includes(element1) && node.includes(element2)) {
@@ -523,8 +424,6 @@ export default class Scope {
             }
             return false;
         }
-
-        // Function to locate the nodes present between two specified nodes
         function dfs(graph, start, end, path = []) {
             if (start === end) {
                 path.push(end);
@@ -542,26 +441,19 @@ export default class Scope {
             path.pop();
             return [];
         }
-
         if (result.length) {
             this.highlightNodes(result);
             return result;
         }
-
         return 'No cycle found';
     }
 
-    /**
-     * Function to highlight the nodes in the currently selected circuit
-     * @param {Array<Array>} array - id's of the nodes, that we want to highlight
-     */
     highlightNodes(array) {
         const Nodes = [];
         array.forEach((innerArray) => {
             const resultArray = innerArray.map((value) => this.findNodeIndexById(value));
             Nodes.push(resultArray);
         });
-
         Nodes.forEach((subArray) => {
             subArray.forEach((node) => {
                 globalScope.allNodes[node].highlighted = true;
@@ -569,10 +461,6 @@ export default class Scope {
         });
     }
 
-    /**
-     * Function to find the index of a node in globalScope.allNodes
-     * @param {string} nodeId - id of a node
-     */
     findNodeIndexById(nodeId) {
         for (let i = 0; i < globalScope.allNodes.length; i++) {
             if (globalScope.allNodes[i].id === nodeId) {
@@ -582,28 +470,16 @@ export default class Scope {
         return 'Not found';
     }
 
-    /**
-     * Function to find the currently selected component on the canvas
-     */
     getCurrentlySelectedComponent() {
         return simulationArea.lastSelected;
     }
 
-    /**
-     * Function to find the currently selected components (when multiple components are selected) on the canvas
-     */
     getAllSelectedComponents() {
         return simulationArea.multipleObjectSelections;
     }
 
-    /**
-     * Function to modify the currently selected component's object in the globalScope
-     * takes the property which needs to modify
-     * and the modified value as parameters
-     */
     modifyCurrentlySelectedComponent(property, value) {
         const selectedComponent = globalScope.getCurrentlySelectedComponent();
-
         if (selectedComponent.objectType === 'Node') {
             const nodeId = selectedComponent.id;
             const nodeIndex = this.findNodeIndexById(nodeId);

--- a/simulator/src/circuit.js
+++ b/simulator/src/circuit.js
@@ -55,6 +55,17 @@ export function resetScopeList() {
     Object.keys(scopeList).forEach(key => delete scopeList[key]);
 }
 
+export function changeCircuitName(newName, scopeId = globalScope.id) {
+    const scope = scopeList[scopeId];
+    let name = escapeHtml(stripTags(newName));
+    name = getUniqueCircuitName(name.trim());
+    scope.name = name;
+    $(`#${scope.id} .circuitName`).text(truncateString(name, 18));
+    if (!embed && simulationArea.lastSelected === scope.root) {
+        showProperties(scope.root);
+    }
+}
+
 function normalizeCircuitNames() {
     const used = {};
 

--- a/simulator/src/circuit.js
+++ b/simulator/src/circuit.js
@@ -131,7 +131,7 @@ function deleteCurrentCircuit(scopeId = globalScope.id) {
     if (confirmation) {
         if (scope.verilogMetadata.isVerilogCircuit) {
             scope.initialize();
-            for (const id in scope.verilogMetadata.subCircuitScopeIds) delete scopeList[id];
+            for (const id of scope.verilogMetadata.subCircuitScopeIds) delete scopeList[id];
         }
         $(`#${scope.id}`).remove();
         delete scopeList[scope.id];

--- a/simulator/src/circuit.js
+++ b/simulator/src/circuit.js
@@ -50,9 +50,9 @@ function getUniqueName(base, existingList) {
 export const circuitProperty = {
     toggleLayoutMode, setProjectName, changeCircuitName, changeClockTime, deleteCurrentCircuit, changeClockEnable, changeInputSize, changeLightMode,
 };
-export var scopeList = {};
+export const scopeList = {};
 export function resetScopeList() {
-    scopeList = {};
+    Object.keys(scopeList).forEach(key => delete scopeList[key]);
 }
 
 function normalizeCircuitNames() {
@@ -77,7 +77,6 @@ export function switchCircuit(id) {
     if (verilogModeGet()) { verilogModeSet(false); }
 
     scheduleBackup();
-    normalizeCircuitNames();
     if (id === globalScope.id) return;
     $('.circuits').removeClass('current');
     simulationArea.lastSelected = undefined;

--- a/simulator/src/circuit.js
+++ b/simulator/src/circuit.js
@@ -44,6 +44,29 @@ export var scopeList = {};
 export function resetScopeList() {
     scopeList = {};
 }
+
+function normalizeCircuitNames() {
+    const used = {};
+
+    Object.values(scopeList).forEach(scope => {
+        let base = scope.name;
+        let name = base;
+        let counter = 0;
+
+        while (used[name]) {
+            counter++;
+            name = `${base} (${counter})`;
+        }
+
+        if (name !== scope.name) {
+            scope.name = name;
+            $(`#${scope.id} .circuitName`).html(truncateString(name, 18));
+        }
+
+        used[name] = true;
+    });
+}
+
 /**
  * Function used to change the current focusedCircuit
  * Disables layoutMode if enabled
@@ -58,6 +81,7 @@ export function switchCircuit(id) {
 
     // globalScope.fixLayout();
     scheduleBackup();
+    normalizeCircuitNames();
     if (id === globalScope.id) return;
     $('.circuits').removeClass('current');
     simulationArea.lastSelected = undefined;
@@ -150,12 +174,30 @@ export function createNewCircuitScope() {
  * @param {string} id - identifier for circuit
  * @category circuit
  */
+
+function getUniqueCircuitName(baseName) {
+    let counter = 0;
+    let newName = baseName;
+
+    const existingNames = Object.values(scopeList).map(scope => scope.name);
+
+    while (existingNames.includes(newName)) {
+        counter++;
+        newName = `${baseName} (${counter})`;
+    }
+
+    return newName;
+}
 export function newCircuit(name, id, isVerilog = false, isVerilogMain = false) {
     if (layoutModeGet()) { toggleLayoutMode(); }
     if (verilogModeGet()) { verilogModeSet(false); }
     name = name || prompt('Enter circuit name:', 'Untitled-Circuit');
     name = escapeHtml(stripTags(name));
     if (!name) return;
+
+    // 🔥 FIX: Ensure unique name before creating scope
+    name = getUniqueCircuitName(name);
+
     const scope = new Scope(name);
     if (id) scope.id = id;
     scopeList[scope.id] = scope;
@@ -214,7 +256,20 @@ export function newCircuit(name, id, isVerilog = false, isVerilogMain = false) {
 export function changeCircuitName(name, id = globalScope.id) {
     name = name || 'Untitled';
     name = escapeHtml(stripTags(name));
-    $(`#${id} .circuitName`).html(`${truncateString(name, 18)}`);
+
+    const existingNames = Object.values(scopeList)
+        .filter(scope => scope.id !== id)
+        .map(scope => scope.name);
+
+    let baseName = name;
+    let counter = 0;
+
+    while (existingNames.includes(name)) {
+        counter++;
+        name = `${baseName} (${counter})`;
+    }
+
+    $(`#${id} .circuitName`).html(truncateString(name, 18));
     scopeList[id].name = name;
 }
 

--- a/simulator/src/circuit.js
+++ b/simulator/src/circuit.js
@@ -65,7 +65,7 @@ function normalizeCircuitNames() {
 
         if (name !== scope.name) {
             scope.name = name;
-            $(`#${scope.id} .circuitName`).html(truncateString(name, 18));
+            $(`#${scope.id} .circuitName`).text(truncateString(name, 18));
         }
 
         used[name] = true;
@@ -168,16 +168,19 @@ export function newCircuit(name, id, isVerilog = false, isVerilogMain = false) {
     }
     globalScope = scope;
     $('.circuits').removeClass('current');
+
     if (!isVerilog || isVerilogMain) {
         const html = embed 
-            ? `<div class='circuits toolbarButton current' draggable='true' id='${scope.id}'><span class='circuitName noSelect'>${truncateString(circuitName, 18)}</span></div>`
-            : `<div class='circuits toolbarButton current' draggable='true' id='${scope.id}'><span class='circuitName noSelect'>${truncateString(circuitName, 18)}</span><span class='tabsCloseButton' id='${scope.id}'>x</span></div>`;
+            ? `<div class='circuits toolbarButton current' draggable='true' id='${scope.id}'><span class='circuitName noSelect'></span></div>`
+            : `<div class='circuits toolbarButton current' draggable='true' id='${scope.id}'><span class='circuitName noSelect'></span><span class='tabsCloseButton' id='${scope.id}'>x</span></div>`;
 
         if (embed) {
             $('#tabsBar').append(html).addClass('embed-tabs');
         } else {
             $('#tabsBar').children().last().before(html);
         }
+
+        $(`#${scope.id} .circuitName`).text(truncateString(circuitName, 18));
 
         $('.circuits').off('click').on('click', function () {
             switchCircuit(this.id);
@@ -195,6 +198,7 @@ export function newCircuit(name, id, isVerilog = false, isVerilogMain = false) {
             e.stopPropagation();
             deleteCurrentCircuit(this.id);
         });
+
         if (!embed) {
             showProperties(scope.root);
         }

--- a/simulator/src/circuit.js
+++ b/simulator/src/circuit.js
@@ -37,6 +37,16 @@ import { verilogModeGet, verilogModeSet } from './Verilog2CV';
 import { updateTestbenchUI } from './testbench';
 import load from './data/load';
 
+function getUniqueName(base, existingList) {
+    let name = base;
+    let counter = 1;
+    while (existingList.includes(name)) {
+        name = `${base} (${counter})`;
+        counter++;
+    }
+    return name;
+}
+
 export const circuitProperty = {
     toggleLayoutMode, setProjectName, changeCircuitName, changeClockTime, deleteCurrentCircuit, changeClockEnable, changeInputSize, changeLightMode,
 };
@@ -50,13 +60,8 @@ function normalizeCircuitNames() {
 
     Object.values(scopeList).forEach((scope) => {
         const base = scope.name.replace(/\s\(\d+\)$/, '').trim();
-        let name = base;
-        let counter = 0;
 
-        while (used[name]) {
-            counter++;
-            name = `${base} (${counter})`;
-        }
+        const name = getUniqueName(base, Object.keys(used));
 
         if (name !== scope.name) {
             scope.name = name;
@@ -145,19 +150,6 @@ export function createNewCircuitScope() {
     }
 }
 
-function getUniqueCircuitName(baseName) {
-    const normalizedBase = baseName.replace(/\s\(\d+\)$/, '').trim();
-    const existingNames = Object.values(scopeList).map((scope) => scope.name);
-    let counter = 0;
-    let newName = normalizedBase;
-
-    while (existingNames.includes(newName)) {
-        counter++;
-        newName = `${normalizedBase} (${counter})`;
-    }
-    return newName;
-}
-
 export function newCircuit(name, id, isVerilog = false, isVerilogMain = false) {
     if (layoutModeGet()) { toggleLayoutMode(); }
     if (verilogModeGet()) { verilogModeSet(false); }
@@ -212,23 +204,10 @@ export function newCircuit(name, id, isVerilog = false, isVerilogMain = false) {
     return scope;
 }
 
-export function changeCircuitName(name, id = globalScope.id) {
-    const rawName = escapeHtml(stripTags(name || 'Untitled'));
-    const existingNames = Object.values(scopeList)
-        .filter((s) => s.id !== id)
-        .map((s) => s.name);
-
-    const normalizedBase = rawName.replace(/\s\(\d+\)$/, '').trim();
-    let finalName = normalizedBase;
-    let counter = 0;
-
-    while (existingNames.includes(finalName)) {
-        counter++;
-        finalName = `${normalizedBase} (${counter})`;
-    }
-
-    $(`#${id} .circuitName`).html(truncateString(finalName, 18));
-    scopeList[id].name = finalName;
+function getUniqueCircuitName(baseName) {
+    const normalizedBase = baseName.replace(/\s\(\d+\)$/, '').trim();
+    const existingNames = Object.values(scopeList).map((scope) => scope.name);
+    return getUniqueName(normalizedBase, existingNames);
 }
 
 export default class Scope {

--- a/simulator/src/circuit.js
+++ b/simulator/src/circuit.js
@@ -167,24 +167,22 @@ export function createNewCircuitScope() {
 }
 
 /**
- * Function to create new circuit
- * Function creates button in tab, creates scope and switches to this circuit
- * @param {string} name - name of the new circuit
- * @param {string} id - identifier for circuit
- * @category circuit
+ * Generates a unique name for a circuit by appending a numeric suffix.
+ * @param {string} baseName - The initial name to check.
+ * @returns {string} - The unique name.
  */
 
 function getUniqueCircuitName(baseName) {
+    baseName = baseName.replace(/\s\(\d+\)$/, '');
+
     let counter = 0;
     let newName = baseName;
-
     const existingNames = Object.values(scopeList).map((scope) => scope.name);
 
     while (existingNames.includes(newName)) {
         counter++;
         newName = `${baseName} (${counter})`;
     }
-
     return newName;
 }
 export function newCircuit(name, id, isVerilog = false, isVerilogMain = false) {


### PR DESCRIPTION
Fixes #7102 

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR - 
Implemented a robust naming system for both Projects and Circuits that prevents duplicate names for the same user. When a collision occurs, the system automatically appends a numerical suffix (e.g., Project (1), Project (2)) .

### Screenshots of the UI changes (If any) -
<!-- Do not add code diff here -->

<img width="1366" height="690" alt="image" src="https://github.com/user-attachments/assets/ff4e584f-2ef0-47e0-b9a5-7fb0f02f7ba6" />
<img width="1365" height="680" alt="image" src="https://github.com/user-attachments/assets/58eaca0c-0b1f-45ba-a39b-20e2c4857f69" />
---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

The goal was to ensure that a user never has two projects or two circuits with the exact same name, as this causes confusion in the database and UI.

Backend (Project.rb & ProjectDatum.rb): I added a before_validation hook that triggers a search for existing names belonging to the same user. It uses Regex to identify existing (n) suffixes, increments the highest found number, and appends it to the new record's name.

Frontend (simulator/src/circuit.js): I implemented a getUniqueCircuitName utility. When a user creates or clones a circuit tab, the JS checks the current tab list and applies the same incrementing logic before the tab is rendered.

Alternative considered: I considered using a database-level unique constraint, but that would cause a hard error for the user. I chose this "auto-increment" approach because it provides a smoother, "Apple/Windows style" file-naming experience.---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced per-user unique names for projects and circuits; code submission size limit set to 10,000 characters

* **Improvements**
  * Circuit tabs and naming now automatically deduplicate and normalize
  * Smoother embed/iframe handling and improved fork behavior
  * Consistent preview image filenames and corrected image content type
  * Atomic save/update flow to avoid partial saves

* **Bug Fixes**
  * Unified compilation and error-handling paths for clearer responses
<!-- end of auto-generated comment: release notes by coderabbit.ai -->