### PR TITLE
fix(api): correct circuit_data unavailable error message

### DIFF
--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -80,7 +80,7 @@ class Api::V1::ProjectsController < Api::V1::BaseController
     if circuit_data
       render json: circuit_data.data
     else
-      render json: { error: "Circuit data unavailabe for the project!" }, status: :not_found
+      render json: { error: "Circuit data unavailable for the project!" }, status: :not_found
     end
   end
 

--- a/spec/requests/api/v1/projects_controller/circuit_data_spec.rb
+++ b/spec/requests/api/v1/projects_controller/circuit_data_spec.rb
@@ -131,9 +131,9 @@ RSpec.describe Api::V1::ProjectsController, "#circuit_data", type: :request do
         get "/api/v1/projects/#{empty_project.id}/circuit_data", as: :json
       end
 
-      it "returns Circuit data unavailabe for the project!" do
+      it "returns Circuit data unavailable for the project!" do
         expect(response).to have_http_status(:not_found)
-        expect(response.parsed_body["error"]).to eq("Circuit data unavailabe for the project!")
+        expect(response.parsed_body["error"]).to eq("Circuit data unavailable for the project!")
       end
     end
   end


### PR DESCRIPTION
Fixes a typo in the API circuit_data not-found error response and updates its request spec.\n\n### What changed\n- Updated not-found error message in Api::V1::ProjectsController#circuit_data\n- Updated request spec expectation in spec/requests/api/v1/projects_controller/circuit_data_spec.rb\n\n### Why\n- Improves API response quality and consistency for clients.\n- Prevents typo propagation to downstream UI/API consumers.\n\n### Validation\n- Ran: .\\bin\\bundle exec rspec spec/requests/api/v1/projects_controller/circuit_data_spec.rb\n- Result: pass (exit code 0)\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a spelling error in the error message shown when circuit data is unavailable for a project; corresponding test text updated. No behavior, control-flow, or public API changes were introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->