### PR TITLE
Add model-level uniqueness validation for PendingInvitation (#6638)

### DIFF
--- a/app/models/pending_invitation.rb
+++ b/app/models/pending_invitation.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+# Represents a pending group invitation for a user who hasn't signed up yet.
+# Ensures uniqueness of email per group at the model level.
 class PendingInvitation < ApplicationRecord
   belongs_to :group
+  validates :email, uniqueness: { scope: :group_id }
   after_commit :send_pending_invitation_mail, on: :create
 
+  # Enqueues an invitation email to the pending user.
   def send_pending_invitation_mail
     PendingInvitationMailer.new_pending_email(self).deliver_later
   end

--- a/spec/models/pending_invitation_spec.rb
+++ b/spec/models/pending_invitation_spec.rb
@@ -12,6 +12,22 @@ RSpec.describe PendingInvitation, type: :model do
     it { is_expected.to belong_to(:group) }
   end
 
+  describe "validations" do
+    it "is invalid with a duplicate email in the same group" do
+      FactoryBot.create(:pending_invitation, group: @group, email: "test@example.com")
+      duplicate = FactoryBot.build(:pending_invitation, group: @group, email: "test@example.com")
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:email]).to include("has already been taken")
+    end
+
+    it "is valid with the same email in a different group" do
+      other_group = FactoryBot.create(:group, primary_mentor: @primary_mentor)
+      FactoryBot.create(:pending_invitation, group: @group, email: "test@example.com")
+      invitation = FactoryBot.build(:pending_invitation, group: other_group, email: "test@example.com")
+      expect(invitation).to be_valid
+    end
+  end
+
   describe "callbacks" do
     it "alls respective callbacks" do
       expect_any_instance_of(described_class).to receive(:send_pending_invitation_mail)


### PR DESCRIPTION
Fixes #6638

#### Describe the changes you have made in this PR -

The `pending_invitations` table has a database-level unique index on `[group_id, email]`, but the `PendingInvitation` model did not have a corresponding Rails-level validation.

This caused duplicate invitations (same email within the same group) to raise `ActiveRecord::RecordNotUnique` instead of failing gracefully with a validation error.

This PR adds:

```ruby
validates :email, uniqueness: { scope: :group_id }

to mirror the existing database constraint at the model level.

Additionally, model specs were added to verify:

A duplicate email within the same group is invalid.

The same email across different groups is valid.

No migrations were added, and the database index remains the source of truth for enforcing uniqueness at the persistence layer.


---

### Screenshots of the UI changes (If any)


N/A (no UI changes)


---

## Code Understanding and AI Usage


 Yes, I used AI assistance (continue below)

 I have reviewed every single line of the AI-generated code

 I can explain the purpose and logic of each function/component I added

 I have tested edge cases and understand how the code handles them

 I have modified the AI output to follow this project's coding standards and conventions


---

### Explain your implementation approach:

```markdown
The issue arises because the database enforces uniqueness of `[group_id, email]`, but the model lacked a corresponding Rails validation. This meant duplicate records would raise a database exception instead of returning a structured validation error.

To align the model behavior with the existing database constraint, I added a `validates :email, uniqueness: { scope: :group_id }` validation.

I intentionally kept the change minimal and scoped strictly to this issue:
- No schema changes were made.
- No controller logic was modified.
- The validation mirrors the exact behavior of the database index.

Model specs were added to ensure correct behavior for both duplicate and cross-group scenarios.
Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data integrity by preventing duplicate pending invitations for the same email address within individual groups.
  * The system now enforces validation to ensure each email can only have one active pending invitation per group, while allowing the same email to be invited across different groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->