### PR TITLE
fix: add model-level uniqueness validation for PendingInvitation email scoped to group (#6638)

### DIFF
--- a/app/models/pending_invitation.rb
+++ b/app/models/pending_invitation.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+# Represents a pending group invitation for a user who hasn't signed up yet.
+# Ensures uniqueness of email per group at the model level.
 class PendingInvitation < ApplicationRecord
   belongs_to :group
+  validates :email, uniqueness: { scope: :group_id }
   after_commit :send_pending_invitation_mail, on: :create
 
+  # Enqueues an invitation email to the pending user.
   def send_pending_invitation_mail
     PendingInvitationMailer.new_pending_email(self).deliver_later
   end

--- a/spec/models/pending_invitation_spec.rb
+++ b/spec/models/pending_invitation_spec.rb
@@ -12,6 +12,22 @@ RSpec.describe PendingInvitation, type: :model do
     it { is_expected.to belong_to(:group) }
   end
 
+  describe "validations" do
+    it "is invalid with a duplicate email in the same group" do
+      FactoryBot.create(:pending_invitation, group: @group, email: "test@example.com")
+      duplicate = FactoryBot.build(:pending_invitation, group: @group, email: "test@example.com")
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:email]).to include("has already been taken")
+    end
+
+    it "is valid with the same email in a different group" do
+      other_group = FactoryBot.create(:group, primary_mentor: @primary_mentor)
+      FactoryBot.create(:pending_invitation, group: @group, email: "test@example.com")
+      invitation = FactoryBot.build(:pending_invitation, group: other_group, email: "test@example.com")
+      expect(invitation).to be_valid
+    end
+  end
+
   describe "callbacks" do
     it "alls respective callbacks" do
       expect_any_instance_of(described_class).to receive(:send_pending_invitation_mail)


### PR DESCRIPTION
Fixes #6638

#### Describe the changes you have made in this PR -

The `pending_invitations` table already enforces uniqueness of `[group_id, email]` through a database-level unique index. However, the `PendingInvitation` model did not have a corresponding Rails validation.

Because of this, attempting to create duplicate invitations (same email within the same group) raised an `ActiveRecord::RecordNotUnique` exception instead of returning a structured validation error.

This PR adds a model-level validation:

validates :email, uniqueness: { scope: :group_id }

This mirrors the existing database constraint and ensures duplicate invitations are caught at the application level before reaching the database.

Additionally, model specs were added to verify the expected behavior:
- A duplicate email within the same group is invalid
- The same email across different groups is valid

No schema or migration changes were required, since the database index already enforces uniqueness at the persistence layer.

---

### Screenshots of the UI changes (If any)

N/A (no UI changes)

---

## Code Understanding and AI Usage

- [x] Yes, I used AI assistance

**If you used AI assistance:**

- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

---

### Explain your implementation approach:

The issue arises because the database already enforces uniqueness of `[group_id, email]`, but the model lacked a corresponding Rails validation. As a result, duplicate records caused a database exception instead of a validation error.

To align the model behavior with the existing database constraint, a model-level validation was added:

`validates :email, uniqueness: { scope: :group_id }`

This ensures duplicate invitations are rejected at the model layer while keeping the database index as the ultimate source of truth.

The change was intentionally kept minimal and scoped strictly to this issue. No controller logic or schema changes were required.

Model specs were also added to confirm that duplicate invitations within the same group are rejected and that the same email remains valid across different groups.

---

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation to prevent duplicate email invitations within the same group. Users attempting to invite the same email address twice to a group will now receive a validation error, ensuring data integrity while allowing the same email to be invited to different groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->