### PR TITLE
docs: improve grammar in README description

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CircleCI Status](https://img.shields.io/circleci/build/github/CircuitVerse/CircuitVerse/master?label=circleci&style=for-the-badge&logo=circleci)](https://circleci.com/gh/CircuitVerse/CircuitVerse)
 [![Coveralls Coverage Status](https://img.shields.io/coveralls/github/CircuitVerse/CircuitVerse/master?label=coveralls&style=for-the-badge&logo=coveralls)](https://coveralls.io/github/CircuitVerse/CircuitVerse?branch=master)
 -----
-[CircuitVerse](https://circuitverse.org) is a free, open-source platform which allows users to construct digital logic circuits online. We also offer the [Interactive Book](https://learn.circuitverse.org) which teaches users on the fundamentals of modern, digital circuits. Please also see our [documentation](https://docs.circuitverse.org) or [GitHub Wiki](https://github.com/CircuitVerse/CircuitVerse/wiki/).
+[CircuitVerse](https://circuitverse.org) is a free, open-source platform which allows users to construct digital logic circuits online. We also offer the [Interactive Book](https://learn.circuitverse.org) which teaches users about the fundamentals of modern, digital circuits. Please also see our [documentation](https://docs.circuitverse.org) or [GitHub Wiki](https://github.com/CircuitVerse/CircuitVerse/wiki/).
 
 ## Getting Started with CircuitVerse code base 📹
 To help new contributors get started, we've created a video guide titled **"Getting Started with CircuitVerse"**. This video covers:


### PR DESCRIPTION

## Description

Fixed a grammatical error in `README.md`:
- **Before**: "teaches users **on** the fundamentals ❌"
- **After**: "teaches users **about** the fundamentals ✔️"

## Why This Matters

While small, typo fixes are valuable because they:
- ✅ Improve documentation quality
- ✅ Make the project more professional
- ✅ Help non-native English speakers understand better
- ✅ Show attention to detail
- ✅ Are quick wins that help the project

## File Changed

```
README.md (1 line)
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Improved clarity in the Interactive Book description with a minor wording refinement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->