### PR TITLE
fix: align project title and stats properly (#4107)

### DIFF
--- a/app/components/project/project_card_component.html.erb
+++ b/app/components/project/project_card_component.html.erb
@@ -9,7 +9,7 @@
         ) %>
   </div>
   <div class="project-card-content">
-    <div class="project-card-header">
+<div class="project-card-header" style="display:flex; align-items:center; justify-content:space-between;">
       <div class="project-card-title">
         <h3><%= project.name %></h3>
       </div>


### PR DESCRIPTION
Fixes #4107

#### Describe the changes you have made in this PR -

This PR fixes the alignment issue between the project title and project statistics in the project card.

Previously, the layout was not properly aligned, causing inconsistent UI appearance. This change uses flexbox to align the elements correctly and ensure proper spacing between the title and stats.

### Screenshots of the UI changes (If any) -

No UI screenshots attached.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**

- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**Explain your implementation approach:**

The issue was caused by improper alignment of elements inside the project card header.

To fix this, I applied CSS flexbox properties (`display: flex`, `align-items: center`, and `justify-content: space-between`) to the container div. This ensures that the project title stays on the left and the statistics section aligns properly on the right.

This approach was chosen because flexbox is a simple and effective way to handle horizontal alignment and spacing in UI layouts.

---

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I understand why my changes work and have tested them thoroughly

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the project card header layout for better element alignment and spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->