### PR TITLE
Fix: align view button with project title using flexbox

### DIFF
--- a/app/views/featured_circuits/index.html.erb
+++ b/app/views/featured_circuits/index.html.erb
@@ -19,9 +19,7 @@
                 class: "card-img-top circuit-card-image"
               ) %>
 
-          
           <div class="card-footer circuit-card-footer d-flex justify-content-between align-items-center">
-            
             <div class="circuit-card-name text-truncate" style="max-width: 70%;">
               <p class="mb-0 text-truncate"><%= project.name %></p>
               <span class="tooltiptext"><%= project.name %></span>
@@ -32,9 +30,7 @@
                href="<%= user_project_url(project.author, project) %>">
               <%= t("view") %>
             </a>
-
           </div>
-          <!--  END FIX -->
 
         </div>
       </div>

--- a/app/views/featured_circuits/index.html.erb
+++ b/app/views/featured_circuits/index.html.erb
@@ -7,22 +7,35 @@
       <p class="main-description"><%= t("featured_circuits.main_description") %></p>
     </div>
   </div>
+
   <div class="row center-row examples-container">
     <% @projects.each do |project| %>
       <div class="col-12 col-sm-12 col-md-6 col-lg-4">
         <div class="card circuit-card">
+
           <%= image_tag(
                 project.circuit_preview.attached? ? project.circuit_preview : image_path("empty_project/default.png"),
                 alt: project.name,
                 class: "card-img-top circuit-card-image"
               ) %>
-          <div class="card-footer circuit-card-footer">
-            <div class="circuit-card-name">
-              <p><%= project.name %></p>
+
+          
+          <div class="card-footer circuit-card-footer d-flex justify-content-between align-items-center">
+            
+            <div class="circuit-card-name text-truncate" style="max-width: 70%;">
+              <p class="mb-0 text-truncate"><%= project.name %></p>
               <span class="tooltiptext"><%= project.name %></span>
             </div>
-            <a class="btn primary-button circuit-card-primary-button" target="_blank" href="<%= user_project_url(project.author, project) %>"><%= t("view") %></a>
+
+            <a class="btn primary-button circuit-card-primary-button"
+               target="_blank"
+               href="<%= user_project_url(project.author, project) %>">
+              <%= t("view") %>
+            </a>
+
           </div>
+          <!--  END FIX -->
+
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
Fixes #4107

**Explain your implementation approach:**

### Problem
The "View" button and project title in the featured circuits section were not properly aligned. This caused inconsistent UI layout, especially when project names varied in length.

### Solution
- Applied flexbox (`d-flex`) to the card footer container
- Used `justify-content-between` to separate title and button
- Used `align-items-center` to vertically align elements
- Added `text-truncate` and `max-width` to handle long project names without breaking layout

### Why this approach
Flexbox provides a simple and responsive way to align elements horizontally and vertically. It ensures consistent spacing and works well across different screen sizes.

### Key Changes
- Updated `featured_circuits/index.html.erb`
- Improved layout structure of card footer
- Handled edge cases like long project names

### Result
- Proper horizontal alignment of project title and "View" button
- Improved UI consistency and responsiveness
- - [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved layout of featured circuits card footers for clearer spacing and alignment.
  * Positioned project name and View link on opposite sides for better visual balance and usability.
  * Added truncation to project names to preserve tidy card appearance with long titles.
  * Reformatted the View link for consistent presentation and spacing within the card footer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->