### PR TITLE
fix: remove duplicate update! call in Api::V1::AssignmentsController#update

### DIFF
--- a/app/controllers/api/v1/assignments_controller.rb
+++ b/app/controllers/api/v1/assignments_controller.rb
@@ -36,7 +36,6 @@ class Api::V1::AssignmentsController < Api::V1::BaseController
 
   # PATCH /api/v1/assignments/:id
   def update
-    @assignment.update!(assignment_update_params)
     if @assignment.update(assignment_update_params)
       render json: Api::V1::AssignmentSerializer.new(@assignment, @options), status: :accepted
     else


### PR DESCRIPTION
## Summary

- Removes the redundant `@assignment.update!(assignment_update_params)` call that preceded the `if @assignment.update(...)` conditional in `Api::V1::AssignmentsController#update`
- Every successful PATCH was previously firing all `after_commit` callbacks twice (duplicate emails, duplicate `AssignmentDeadlineSubmissionJob` enqueues)
- The `invalid_resource!` error path was dead code because `update!` would raise before the conditional was evaluated

## What changed and why

**Before:**
```ruby
def update
  @assignment.update!(assignment_update_params)   # ← fires all after_commit callbacks
  if @assignment.update(assignment_update_params) # ← fires them again
    render json: ..., status: :accepted
  else
    invalid_resource!(@assignment.errors)         # ← unreachable
  end
end
```

**After:**
```ruby
def update
  if @assignment.update(assignment_update_params)
    render json: ..., status: :accepted
  else
    invalid_resource!(@assignment.errors)
  end
end
```

## How to test

1. Run the existing spec: `bundle exec rspec spec/requests/api/v1/assignments_controller/update_spec.rb`
2. All four existing contexts (unauthenticated, unauthorized, not found, invalid params, successful update) should pass.
3. Add a test that counts `after_commit` callback invocations and verify it fires exactly once per PATCH.

Closes #7179

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API error handling for assignment updates so validation failures return consistent error responses instead of triggering exceptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->