### PR TITLE
fix: scope AssignmentsController#index to current user's groups

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -17,7 +17,7 @@ class AssignmentsController < ApplicationController
   # GET /assignments
   # GET /assignments.json
   def index
-    @assignments = Assignment.all
+    @assignments = policy_scope(Assignment)
   end
 
   # GET /assignments/1

--- a/app/policies/assignment_policy.rb
+++ b/app/policies/assignment_policy.rb
@@ -3,6 +3,16 @@
 class AssignmentPolicy < ApplicationPolicy
   attr_reader :user, :assignment
 
+  class Scope < Scope
+    def resolve
+      if user.admin?
+        scope.all
+      else
+        scope.where(group_id: user.groups.select(:id))
+      end
+    end
+  end
+
   def initialize(user, assignment)
     super
     @user = user


### PR DESCRIPTION
## Summary

- Adds `AssignmentPolicy::Scope` that returns only assignments belonging to the current user's groups (or all assignments for admins)
- Replaces `Assignment.all` in `AssignmentsController#index` with `policy_scope(Assignment)`

## What changed and why

`GET /assignments` was returning every assignment across the entire platform to any logged-in user. A student in Group A could see assignment names, deadlines, descriptions, and grading scales for Group B's classes. This is a data-exposure bug: `before_action :authenticate_user!` only requires login; there was no authorization check and no scoping.

**`app/policies/assignment_policy.rb`** — new `Scope` class:
```ruby
class Scope < Scope
  def resolve
    if user.admin?
      scope.all
    else
      scope.where(group_id: user.groups.select(:id))
    end
  end
end
```

**`app/controllers/assignments_controller.rb`** — controller change:
```ruby
def index
  @assignments = policy_scope(Assignment)
end
```

## How to test

1. Create two groups with different mentors and assignments.
2. Log in as mentor A — `GET /assignments` should return only Group A's assignments.
3. Log in as admin — `GET /assignments` should return all assignments.
4. Run: `bundle exec rspec spec/requests/` — existing request specs should pass.

Closes #7180

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted assignment visibility so regular users only see assignments tied to their groups, preventing exposure of unrelated records.
  * Administrators retain full visibility of all assignments to preserve management capabilities.
  * This improves data access control and ensures users only access assignments relevant to their group memberships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->