### PR TITLE
fix: block grade writes when assignment grades_finalized is true

### DIFF
--- a/app/policies/grade_policy.rb
+++ b/app/policies/grade_policy.rb
@@ -9,6 +9,8 @@ class GradePolicy < ApplicationPolicy
   end
 
   def mentor?
+    return false if grade.assignment&.grades_finalized?
+
     grade.assignment&.group&.primary_mentor_id == user.id \
     || grade.assignment&.group&.group_members&.exists?(user_id: user.id, mentor: true)
   end


### PR DESCRIPTION
## Summary

- Adds a `grades_finalized?` guard to `GradePolicy#mentor?` so that `GradesController#create` (and `destroy`) return 403 Forbidden when grades are locked

## What changed and why

`assignments.grades_finalized` is a boolean flag meant to lock grades after a course ends. The UI respects it (hides the grading form), but `GradesController#create` calls only `authorize @grade, :mentor?`, which previously had no finalization check. A mentor could bypass the UI and POST to `/grades` to create or overwrite locked grades.

**Before (`app/policies/grade_policy.rb`)**:
```ruby
def mentor?
  grade.assignment&.group&.primary_mentor_id == user.id \
  || grade.assignment&.group&.group_members&.exists?(user_id: user.id, mentor: true)
end
```

**After**:
```ruby
def mentor?
  return false if grade.assignment&.grades_finalized?

  grade.assignment&.group&.primary_mentor_id == user.id \
  || grade.assignment&.group&.group_members&.exists?(user_id: user.id, mentor: true)
end
```

## How to test

```bash
bundle exec rspec spec/requests/api/v1/grades_controller/
```

Manual test:
1. Create assignment and finalize grades (`assignment.update!(grades_finalized: true)`).
2. POST to `/grades` as the mentor — expect 403 Forbidden.
3. Set `grades_finalized: false` — expect normal grade creation.

Closes #7182

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed permissions to prevent mentors from making changes to assignments after grades are finalized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->