### PR TITLE
fix: add partial unique index on assignments.lti_consumer_key for LTI 1.1 lookups

### DIFF
--- a/db/migrate/20260320000001_add_index_to_assignments_lti_consumer_key.rb
+++ b/db/migrate/20260320000001_add_index_to_assignments_lti_consumer_key.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddIndexToAssignmentsLtiConsumerKey < ActiveRecord::Migration[8.0]
+  def change
+    add_index :assignments, :lti_consumer_key,
+              unique: true,
+              where: "lti_consumer_key IS NOT NULL",
+              name: "index_assignments_on_lti_consumer_key"
+  end
+end


### PR DESCRIPTION
## Summary

- Adds a partial unique index on `assignments.lti_consumer_key` (`WHERE lti_consumer_key IS NOT NULL`) via a new migration

## What changed and why

LTI 1.1 authentication calls `Assignment.find_by(lti_consumer_key: params[:oauth_consumer_key])` on every LTI launch. The column had no index, so the database performed a sequential scan of the entire `assignments` table for every student LTI login.

The index is:
- **Partial** (`WHERE NOT NULL`): the vast majority of assignments don't use LTI 1.1, so this avoids indexing them and keeps the index small
- **Unique**: `lti_consumer_key` is generated with `SecureRandom.hex(4)` per-assignment and must be unique for OAuth signature validation to work correctly

**Migration file:** `db/migrate/20260320000001_add_index_to_assignments_lti_consumer_key.rb`

```ruby
add_index :assignments, :lti_consumer_key,
          unique: true,
          where: "lti_consumer_key IS NOT NULL",
          name: "index_assignments_on_lti_consumer_key"
```

## How to test

```bash
bundle exec rails db:migrate
# Then verify in psql:
# \d assignments  => should show the new index
bundle exec rspec spec/requests/lti_spec.rb
```

To verify the index is used:
```sql
EXPLAIN ANALYZE SELECT * FROM assignments WHERE lti_consumer_key = 'abc123';
-- Should show: Index Scan using index_assignments_on_lti_consumer_key
```

Closes #7183

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Database index improvements for assignment records to enhance data handling and system performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->