### PR TITLE
fix: use find_by in AssignmentDeadlineVerificationJob to avoid RecordNotFound on deleted assignments

### DIFF
--- a/app/jobs/assignment_deadline_verification_job.rb
+++ b/app/jobs/assignment_deadline_verification_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AssignmentDeadlineVerificationJob < ApplicationJob
+  queue_as :verification
+
+  def perform(assignment_id)
+    assignment = Assignment.find_by(id: assignment_id)
+    return if assignment.nil?
+
+    assignment.assignment_submissions
+              .where(status: :draft)
+              .find_each do |submission|
+      CircuitVerificationJob.perform_later(submission.id)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `AssignmentDeadlineVerificationJob` using `find_by` with an early `return` guard, preventing `ActiveRecord::RecordNotFound` when an assignment is deleted while the job is queued

## What changed and why

This job triggers circuit auto-verification for draft submissions at the assignment deadline. Using `Assignment.find(id)` raises `ActiveRecord::RecordNotFound` if the assignment is deleted before the job runs (e.g. when a teacher deletes an assignment that still has pending auto-grade jobs). This causes Sidekiq to log an error and retry the job indefinitely.

The sibling job `AssignmentDeadlineSubmissionJob` already uses the safe pattern:
```ruby
assignment = Assignment.find_by(id: assignment_id)
return if assignment.nil? || (assignment.status == "closed")
```

This PR applies the same pattern:
```ruby
def perform(assignment_id)
  assignment = Assignment.find_by(id: assignment_id)
  return if assignment.nil?

  assignment.assignment_submissions
            .where(status: :draft)
            .find_each do |submission|
    CircuitVerificationJob.perform_later(submission.id)
  end
end
```

## How to test

```bash
# Unit test: enqueue the job for a non-existent assignment_id
AssignmentDeadlineVerificationJob.perform_now(0)
# Should complete without raising RecordNotFound
```

Closes #7184

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated background job to identify and process draft submissions associated with assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->