### PR TITLE
docs: add VAPID keys setup instructions to SETUP.md

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -83,6 +83,29 @@ The `.env` file only needs to be used if you would like to link to third party s
    1.  Update the `site url` field with the URL of your instance, and update the `callback url` field with `<url>/users/auth/google`, `<url>/users/auth/facebook`, `<url>/users/auth/github` or `<url>/users/auth/gitlab`  respectively.
 3. Configure your `id` and `secret` environment variables in `.env`. If `.env` does not exist, copy the template from `.env.example`.
 4. After adding the environment variables, run `dotenv rails server` to start the application.
+## Web Push Notifications (VAPID Keys)
+
+CircuitVerse uses [Web Push](https://github.com/zaru/webpush) for browser notifications. You need to generate VAPID keys and add them to your `.env` file.
+
+### Generating VAPID Keys
+
+Run the following in your Rails console:
+
+```ruby
+vapid_key = Webpush.generate_key
+puts vapid_key.public_key
+puts vapid_key.private_key
+```
+
+Then add these to your `.env` file:
+
+```
+VAPID_PUBLIC_KEY=<your_public_key>
+VAPID_PRIVATE_KEY=<your_private_key>
+```
+
+> **Note:** Keep your `VAPID_PRIVATE_KEY` secret. Never commit it to version control.
+
 
 ## (Optional) Yosys Installation for Verilog RTL Synthesis
 If you wish to do Verilog RTL Synthesis/create CircuitVerse Verilog Circuits in your local development environment, you need to install the `yosys` binary.

--- a/SETUP.md
+++ b/SETUP.md
@@ -99,7 +99,7 @@ puts vapid_key.private_key
 
 Then add these to your `.env` file:
 
-```
+```dotenv
 VAPID_PUBLIC_KEY=<your_public_key>
 VAPID_PRIVATE_KEY=<your_private_key>
 ```


### PR DESCRIPTION
## Description

This PR adds a new section to `SETUP.md` documenting how to generate and configure VAPID keys required for Web Push notifications in CircuitVerse.

Currently, `SETUP.md` has no mention of VAPID keys, which are required for the push notification feature to work. New contributors setting up the project locally have no guidance on this, leading to broken notification functionality.

## Changes Made

- Added `## Web Push Notifications (VAPID Keys)` section after the Third Party Services section
- Included step-by-step instructions for generating VAPID keys using the Rails console
- Documented the required `.env` variables: `VAPID_PUBLIC_KEY` and `VAPID_PRIVATE_KEY`
- Added a security note to never commit the private key

Fixes #4040

## Type of Change

- [x] Documentation update

## Checklist

- [x] My changes follow the existing documentation style
- [x] I have tested the VAPID key generation steps locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added setup instructions for Web Push Notifications: guidance for generating VAPID public/private keys, configuring them as environment secrets, and explicit security guidance to keep the private key secret and avoid committing it to version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->