### PR TITLE
fix: show 'No circuits found' message when search returns no results

### DIFF
--- a/app/views/users/circuitverse/index.html.erb
+++ b/app/views/users/circuitverse/index.html.erb
@@ -89,6 +89,12 @@
       </div>
       <% else %>
         <%= render partial: "dashboard", locals: { projects: @user_projects } %>
+        <div id="no-results-message" class="col-12" style="display:none;">
+          <div class="search-no-results-image">
+            <%= image_tag "svgs/noProject.svg", alt: "No result image" %>
+            <h6>No circuits found. Try a different keyword.</h6>
+          </div>
+        </div>
       <% end %>
     </div>
     <div id="favourite-circuits-div" class="row center-row circuit-page">
@@ -186,6 +192,8 @@
           // mark matches as visible
           $(match.item.domObj).show();
       })
+      // Show empty state message if no circuits match the search
+      $('#no-results-message').toggle(matches.length === 0);
       // Helper function used for sorting cards
       function getSortIndex(circuitDiv) {
         var title = getTitle(circuitDiv);
@@ -207,6 +215,7 @@
       });
     } else { // if searchQuery is empty -> display everything
       projects.show();
+      $('#no-results-message').hide();
     }
   })
 

--- a/app/views/users/circuitverse/index.html.erb
+++ b/app/views/users/circuitverse/index.html.erb
@@ -92,7 +92,7 @@
         <div id="no-results-message" class="col-12" style="display:none;">
           <div class="search-no-results-image">
             <%= image_tag "svgs/noProject.svg", alt: "No result image" %>
-            <h6>No circuits found. Try a different keyword.</h6>
+            <h6><%= t("users.circuitverse.index.no_circuits_found_try_different_keyword") %></h6>
           </div>
         </div>
       <% end %>
@@ -204,7 +204,7 @@
       // Sort cards
       var dashboards = $('.circuit-page');
       dashboards.each((i, dashboard) => {
-        var circuitCards = $(dashboard).children();
+        var circuitCards = $(dashboard).children('.circuit-card-js');
         circuitCards.detach().sort((a, b) => {
           a = getSortIndex(a);
           b = getSortIndex(b);

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -109,3 +109,7 @@ en:
       almost_x_years:
         one: "1 year" # default was: "almost 1 year"
         other: "%{count} years" # default was: "almost %{count} years"
+  users:
+    circuitverse:
+      index:
+        no_circuits_found_try_different_keyword: "No circuits found. Try a different keyword."


### PR DESCRIPTION
 
Fixes #7197
 
## Describe the changes you have made in this PR
 
When a user searches for a circuit on the My Circuits page using the search bar, the Fuse.js client-side search hides all project cards that don't match. However, when no cards match at all, the page was left completely blank with no feedback to the user.
 
This PR fixes that by:
1. Adding a hidden `#no-results-message` div inside `#my-circuits-div` (after the dashboard partial), using the existing `noProject.svg`and `search-no-results-image` pattern already used in the same file
   for the "no projects" and "no favourites" empty states.
2. Updating the Fuse.js `keyup` handler to show this message when`matches.length === 0`, and hide it when the search is cleared.
 
Only 1 file was changed: `app/views/users/circuitverse/index.html.erb` **9 lines added, 0 lines deleted.**
 

## Code Understanding and AI Usage
 
**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
 
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)
 
**If you used AI assistance:**
 
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions
 
**Explain your implementation approach:**
 
**Problem:**
The Fuse.js search on the My Circuits page hides all circuit cards when searching, but had no logic for when`matches.length === 0`, leaving the page completely blank with no user feedback.
 
**Approach chosen:**
I added a hidden div (`#no-results-message`) that gets shown/hidden bythe existing jQuery Fuse.js `keyup` handler using
`$('#no-results-message').toggle(matches.length === 0)`. This is the simplest possible fix — no new dependencies, no new files, no backend changes needed.
 
**Alternative considered:**
Adding the empty state inside `_dashboard.html.erb` partial, but that would affect all three tabs (My Circuits, Favourites, Collaborators) unnecessarily. Keeping it in `index.html.erb` scoped to `#my-circuits-div` is more precise and surgical.
 
**Key logic added:**
- `$('#no-results-message').toggle(matches.length === 0)` — shows the message when Fuse.js returns zero matches, hides it when results exist
- `$('#no-results-message').hide()` in the `else` block — hides the message when the user clears the search input and all cards reappear
- The div reuses the same `noProject.svg` and `search-no-results-image` CSS class already used elsewhere in the same file for full visual consistency with the rest of the UI
 
---
 
## Checklist before requesting a review
 
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
 
---

 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "No circuits found" message in My Circuits to show when searches return no matches (localized).
* **Bug Fixes**
  * Improved search behavior to correctly show/hide the empty-state message when queries are blank or yield no results.
  * Fixed card sorting to only reorder actual circuit cards, preventing unintended layout changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->