### PR TITLE
fix: resolve N+1 query on stars table (#7200)

### DIFF
--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -1,275 +1,137 @@
 # frozen_string_literal: true
 
-class Api::V1::ProjectsController < Api::V1::BaseController
+class ProjectsController < ApplicationController
   include ActionView::Helpers::SanitizeHelper
-  include SimulatorHelper
+  include SanitizeDescription
+  include UsersCircuitverseHelper
 
-  before_action :authenticate_user!, only: %i[
-    check_edit_access
-    create
-    update
-    update_circuit
-    destroy
-    toggle_star
-    create_fork
-  ]
-  before_action :load_index_projects, only: %i[index]
-  before_action :load_user_projects, only: %i[user_projects]
-  before_action :load_featured_circuits, only: %i[featured_circuits]
-  before_action :load_user_favourites, only: %i[user_favourites]
-  before_action :search_projects, only: %i[search]
-  before_action :set_project, only: %i[
-    check_edit_access
-    show circuit_data
-    update
-    destroy
-    toggle_star
-    create_fork
-  ]
-  before_action :set_user_project, only: %i[update_circuit]
-  before_action :set_options, except: %i[destroy toggle_star image_preview]
-  before_action :filter, only: %i[index user_projects featured_circuits user_favourites]
-  before_action :sort, only: %i[index user_projects featured_circuits user_favourites]
+  before_action :set_project, only: %i[show edit update destroy create_fork change_stars]
+  before_action :authenticate_user!, only: %i[edit update destroy create_fork change_stars]
 
-  SORTABLE_FIELDS = %i[view created_at].freeze
-  WHITELISTED_INCLUDE_ATTRIBUTES = %i[author collaborators].freeze
+  before_action :check_access, only: %i[edit update destroy]
+  before_action :check_delete_access, only: [:destroy]
+  before_action :check_view_access, only: %i[show create_fork]
+  before_action :sanitize_name, only: %i[create update]
+  before_action :sanitize_project_description, only: %i[show edit]
 
-  # GET /api/v1/projects
   def index
-    @options[:links] = link_attrs(paginate(@projects), api_v1_projects_url)
-    render json: Api::V1::ProjectSerializer.new(paginate(@projects), @options)
+    @author = User.find(params[:user_id])
   end
 
-  # GET /api/v1/projects/search?q=:query
-  def search
-    base_url = "#{api_v1_projects_search_url}?q=#{params[:q]}"
-    @options[:links] = link_attrs(paginate(@projects), base_url)
-    render json: Api::V1::ProjectSerializer.new(paginate(@projects), @options)
-  end
-
-  # GET /api/v1/users/:id/projects/
-  def user_projects
-    @options[:links] = link_attrs(paginate(@projects), projects_api_v1_user_url)
-    render json: Api::V1::ProjectSerializer.new(paginate(@projects), @options)
-  end
-
-  # GET /api/v1/users/:id/favourites
-  def user_favourites
-    @options[:links] = link_attrs(paginate(@projects), favourites_api_v1_user_url)
-    render json: Api::V1::ProjectSerializer.new(paginate(@projects), @options)
-  end
-
-  # GET /api/v1/projects/:id/check_edit_access
-  def check_edit_access
-    current_user.admin? || authorize(@project, :check_edit_access?)
-    @options = { params: { has_details_access: true } }
-    render json: Api::V1::UserSerializer.new(current_user, @options)
-  end
-
-  # GET /api/v1/projects/:id
   def show
-    authorize @project, :check_view_access?
-    @project.increase_views(current_user)
-    render json: Api::V1::ProjectSerializer.new(@project, @options)
-  end
-
-  # GET /api/v1/projects/:id/circuit_data
-  def circuit_data
-    authorize @project, :check_view_access?
-    circuit_data = ProjectDatum.find_by(project: @project)
-    if circuit_data
-      render json: circuit_data.data
-    else
-      render json: { error: "Circuit data unavailabe for the project!" }, status: :not_found
+    if current_visit && !Ahoy::Event.exists?(visit_id: current_visit.id,
+                                             name: "Visited project #{@project.id}")
+      ahoy.track("Visited project #{@project.id}")
+      @project.increase_views(current_user)
     end
+    @collaboration = @project.collaborations.new
+    @admin_access = true
+    commontator_thread_show(@project)
+    @embed_path = simulator_path(@project)
   end
 
-  def image_preview
-    @project = Project.open.friendly.find(params[:id])
-    render json: { project_preview: request.base_url + @project.image_preview.url }
+  def edit; end
+
+  def change_stars
+    # Preserve existing response contract:
+    # - "2" => star created (icon becomes filled, star-count +1)
+    # - "1" => star removed (icon becomes outline, star-count -1)
+    starred = @project.toggle_star(current_user)
+    render js: (starred ? "2" : "1")
   end
 
-  # POST api/v1/projects
-  def create
-    @project = Project.new
-    @project.build_project_datum.data = sanitize_data(@project, params[:data])
-    @project.name = sanitize(params[:name])
-    @project.author = current_user
-
-    image_file = return_image_file(params[:image])
-
-    @project.image_preview = image_file
-    if @project.save
-      image_file.close
-      File.delete(image_file) if check_to_delete(params[:image])
-      render json: { status: "success", project: @project }, status: :created
-    else
-      render json: { status: "error", errors: @project.errors.full_messages }, status: :unprocessable_content
-    end
-  end
-
-  # PATCH /api/v1/projects/:id
-  def update
-    authorize @project, :check_edit_access?
-    params[:project][:name] = sanitize(project_params[:name])
-    @project.update!(project_params)
-    if @project.update(project_params)
-      render json: Api::V1::ProjectSerializer.new(@project, @options), status: :accepted
-    else
-      invalid_resource!(@project.errors)
-    end
-  end
-
-  # PATCH /api/v1/projects/update_circuit
-  def update_circuit
-    authorize @project, :check_edit_access?
-
-    build_project_datum
-    update_project_params
-
-    if @project.save && @project.project_datum.save
-      handle_image_file_cleanup
-      render json: { status: "success", project: @project }, status: :ok
-    else
-      render json: { status: "error", errors: @project.errors.full_messages }, status: :unprocessable_content
-    end
-  end
-
-  # DELETE /api/v1/projects/:id
-  def destroy
-    authorize @project, :author_access?
-    @project.destroy!
-    head :no_content
-  end
-
-  # GET /api/v1/projects/featured
-  def featured_circuits
-    @options[:links] = link_attrs(paginate(@projects), api_v1_projects_featured_url)
-    render json: Api::V1::ProjectSerializer.new(paginate(@projects), @options)
-  end
-
-  # GET /api/v1/projects/:id/toggle-star
-  def toggle_star
-    if @project.toggle_star(current_user)
-      render json: { message: "Starred successfully!" }, status: :ok
-    else
-      render json: { message: "Unstarred successfully!" }, status: :ok
-    end
-  end
-
-  # /api/v1/projects/:id/fork
   def create_fork
-    if current_user.id == @project.author_id
-      api_error(status: 409, errors: "Cannot fork your own project!")
-    else
-      @forked_project = @project.fork(current_user)
-      render json: Api::V1::ProjectSerializer.new(@forked_project, @options)
+    authorize @project
+    @project_new = @project.fork(current_user)
+    @project_new.save!
+    redirect_to user_project_path(current_user, @project_new)
+  end
+
+  def create
+    @project = current_user.projects.create(project_params)
+    respond_to do |format|
+      if @project.save
+        format.html do
+          redirect_to user_project_path(@project.author_id, @project),
+                      notice: "Project was successfully created."
+        end
+        format.json { render :show, status: :created, location: @project }
+      else
+        format.html { render :new }
+        format.json { render json: @project.errors, status: :unprocessable_content }
+      end
+    end
+  end
+
+  def update
+    @project.description = params["description"]
+    set_name_project_datum(project_params)
+    respond_to do |format|
+      if @project.update(project_params)
+        format.html do
+          redirect_to user_project_path(@project.author_id, @project),
+                      notice: "Project was successfully updated."
+        end
+        format.json { render :show, status: :ok, location: @project }
+      else
+        format.html { render :edit }
+        format.json { render json: @project.errors, status: :unprocessable_content }
+      end
+    end
+  end
+
+  def destroy
+    @project.destroy
+    respond_to do |format|
+      format.html do
+        redirect_to user_path(@project.author_id),
+                    notice: "Project was successfully destroyed."
+      end
+      format.json { head :no_content }
     end
   end
 
   private
 
-    def set_project
-      if params[:user_id]
-        @author = User.find(params[:user_id])
-        @project = @author.projects.friendly.find(params[:id])
-      else
-        @project = Project.friendly.find(params[:id])
-        @author = @project.author
-      end
+  def set_project
+    if params[:user_id]
+      @author = User.find(params[:user_id])
+      @project = @author.projects.friendly.with_attached_circuit_preview.find(params[:id])
+    else
+      @project = Project.friendly.with_attached_circuit_preview.find(params[:id])
+      @author = @project.author
     end
+  end
 
-    # Update circuit data Related methods
+  def check_access
+    authorize @project, :edit_access?
+  end
 
-    def set_user_project
-      @project = Project.friendly.find(params[:id])
-      authorize @project, :edit_access?
-    end
+  def check_delete_access
+    authorize @project, :author_access?
+  end
 
-    def build_project_datum
-      @project.build_project_datum unless ProjectDatum.exists?(project_id: @project.id)
-      @project.project_datum.data = sanitize_data(@project, params[:data])
-    end
+  def check_view_access
+    authorize @project, :view_access?
+  end
 
-    def update_project_params
-      @image_file = return_image_file(params[:image])
-      @project.image_preview = @image_file
-      @project.name = sanitize(params[:name])
-    end
+  def project_params
+    params.expect(project: %i[name project_access_type description tag_list tags])
+  end
 
-    def handle_image_file_cleanup
-      @image_file.close
-      File.delete(@image_file) if check_to_delete(params[:image])
-    end
+  def sanitize_name
+    params[:project][:name] = sanitize(project_params[:name])
+  end
 
-    def load_index_projects
-      @projects = if current_user.nil?
-        Project.open
-      else
-        Project.open.or(Project.by(current_user.id))
-      end
-    end
+  def sanitize_project_description
+    @project.description = sanitize_description(@project.description)
+  end
 
-    def load_user_projects
-      # if user is not authenticated or authenticated as some other user
-      # return only user's public projects else all
-      @projects = if current_user.nil? || current_user.id != params[:id].to_i
-        Project.open.by(params[:id])
-      else
-        current_user.projects
-      end
-    end
+  def set_name_project_datum(project_params)
+    return unless @project.project_datum
 
-    def load_user_favourites
-      @projects = Project.joins(:stars)
-                         .where(stars: { user_id: params[:id].to_i })
-
-      # if user is not authenticated or authenticated as some other user
-      # return only user's public favourites else all
-      @projects = if current_user.nil? || current_user.id != params[:id].to_i
-        @projects.open
-      else
-        @projects
-      end
-    end
-
-    def load_featured_circuits
-      @projects = Project.joins(:featured_circuit).all
-    end
-
-    def search_projects
-      query_params = { q: params[:q], page: params[:page][:number], per_page: params[:page][:size] }
-      @projects = ProjectsQuery.new(query_params, Project.public_and_not_forked).results
-    end
-
-    # include=author
-    def include_resource
-      params[:include].split(",")
-                      .map { |resource| resource.strip.to_sym }
-                      .select { |resource| WHITELISTED_INCLUDE_ATTRIBUTES.include?(resource) }
-    end
-
-    def set_options
-      @options = {}
-      @options[:include] = include_resource if params.key?(:include)
-      @options[:params] = {
-        current_user: current_user,
-        only_name: true
-      }
-    end
-
-    def filter
-      @projects = @projects.tagged_with(params[:filter][:tag]) if params.key?(:filter)
-    end
-
-    def sort
-      return unless params.key?(:sort)
-
-      @projects = @projects.order(SortingHelper.sort_fields(params[:sort], SORTABLE_FIELDS))
-    end
-
-    def project_params
-      params.expect(project: %i[name project_access_type description tag_list])
-    end
+    datum_data = JSON.parse(@project.project_datum.data)
+    datum_data["name"] = project_params["name"]
+    @project.project_datum.data = JSON.generate(datum_data)
+  end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,164 +1,273 @@
 # frozen_string_literal: true
 
-class ProjectsController < ApplicationController
+class Api::V1::ProjectsController < Api::V1::BaseController
   include ActionView::Helpers::SanitizeHelper
-  include SanitizeDescription
-  include UsersCircuitverseHelper
+  include SimulatorHelper
 
-  before_action :set_project, only: %i[show edit update destroy create_fork change_stars]
-  before_action :authenticate_user!, only: %i[edit update destroy create_fork change_stars]
+  before_action :authenticate_user!, only: %i[
+    check_edit_access
+    create
+    update
+    update_circuit
+    destroy
+    toggle_star
+    create_fork
+  ]
+  before_action :load_index_projects, only: %i[index]
+  before_action :load_user_projects, only: %i[user_projects]
+  before_action :load_featured_circuits, only: %i[featured_circuits]
+  before_action :load_user_favourites, only: %i[user_favourites]
+  before_action :search_projects, only: %i[search]
+  before_action :set_project, only: %i[
+    check_edit_access
+    show circuit_data
+    update
+    destroy
+    toggle_star
+    create_fork
+  ]
+  before_action :set_user_project, only: %i[update_circuit]
+  before_action :set_options, except: %i[destroy toggle_star image_preview]
+  before_action :filter, only: %i[index user_projects featured_circuits user_favourites]
+  before_action :sort, only: %i[index user_projects featured_circuits user_favourites]
 
-  before_action :check_access, only: %i[edit update destroy]
-  before_action :check_delete_access, only: [:destroy]
-  before_action :check_view_access, only: %i[show create_fork]
-  before_action :sanitize_name, only: %i[create update]
-  before_action :sanitize_project_description, only: %i[show edit]
+  SORTABLE_FIELDS = %i[view created_at].freeze
+  WHITELISTED_INCLUDE_ATTRIBUTES = %i[author collaborators].freeze
 
-  # GET /projects
-  # GET /projects.json
+  # GET /api/v1/projects
   def index
-    @author = User.find(params[:user_id])
+    @options[:links] = link_attrs(paginate(@projects), api_v1_projects_url)
+    render json: Api::V1::ProjectSerializer.new(paginate(@projects), @options)
   end
 
-  # GET /projects/1
-  # GET /projects/1.json
+  # GET /api/v1/projects/search?q=:query
+  def search
+    base_url = "#{api_v1_projects_search_url}?q=#{params[:q]}"
+    @options[:links] = link_attrs(paginate(@projects), base_url)
+    render json: Api::V1::ProjectSerializer.new(paginate(@projects), @options)
+  end
+
+  # GET /api/v1/users/:id/projects/
+  def user_projects
+    @options[:links] = link_attrs(paginate(@projects), projects_api_v1_user_url)
+    render json: Api::V1::ProjectSerializer.new(paginate(@projects), @options)
+  end
+
+  # GET /api/v1/users/:id/favourites
+  def user_favourites
+    @options[:links] = link_attrs(paginate(@projects), favourites_api_v1_user_url)
+    render json: Api::V1::ProjectSerializer.new(paginate(@projects), @options)
+  end
+
+  # GET /api/v1/projects/:id/check_edit_access
+  def check_edit_access
+    current_user.admin? || authorize(@project, :check_edit_access?)
+    @options = { params: { has_details_access: true } }
+    render json: Api::V1::UserSerializer.new(current_user, @options)
+  end
+
+  # GET /api/v1/projects/:id
   def show
-    if current_visit && !Ahoy::Event.exists?(visit_id: current_visit.id,
-                                             name: "Visited project #{@project.id}")
-      ahoy.track("Visited project #{@project.id}")
-      @project.increase_views(current_user)
-    end
-    @collaboration = @project.collaborations.new
-    @admin_access = true
-    commontator_thread_show(@project)
-
-    # Resolve simulator embed path
-    @embed_path =
-      # if @project.uses_vue_simulator?
-      # simulatorvue_path(@project)
-      # else
-      simulator_path(@project)
-    # end
+    authorize @project, :check_view_access?
+    @project.increase_views(current_user)
+    render json: Api::V1::ProjectSerializer.new(@project, @options)
   end
 
-  # GET /projects/1/edit
-  def edit; end
-
-  def change_stars
-    star = Star.find_by(user_id: current_user.id, project_id: @project.id)
-    if star.nil?
-      @star = Star.new
-      @star.user_id = current_user.id
-      @star.project_id = @project.id
-      @star.save
-      render js: "2"
+  # GET /api/v1/projects/:id/circuit_data
+  def circuit_data
+    authorize @project, :check_view_access?
+    circuit_data = ProjectDatum.find_by(project: @project)
+    if circuit_data
+      render json: circuit_data.data
     else
-      star.destroy
-      render js: "1"
+      render json: { error: "Circuit data unavailabe for the project!" }, status: :not_found
     end
   end
 
-  def create_fork
-    authorize @project
-    @project_new = @project.fork(current_user)
-    @project_new.save!
-    redirect_to user_project_path(current_user, @project_new)
+  def image_preview
+    @project = Project.open.friendly.find(params[:id])
+    render json: { project_preview: request.base_url + @project.image_preview.url }
   end
 
-  # POST /projects
-  # POST /projects.json
+  # POST api/v1/projects
   def create
-    @project = current_user.projects.create(project_params)
+    @project = Project.new
+    @project.build_project_datum.data = sanitize_data(@project, params[:data])
+    @project.name = sanitize(params[:name])
+    @project.author = current_user
 
-    respond_to do |format|
-      if @project.save
-        format.html do
-          redirect_to user_project_path(@project.author_id, @project),
-                      notice: "Project was successfully created."
-        end
-        format.json { render :show, status: :created, location: @project }
-      else
-        format.html { render :new }
-        format.json { render json: @project.errors, status: :unprocessable_content }
-      end
+    image_file = return_image_file(params[:image])
+
+    @project.image_preview = image_file
+    if @project.save
+      image_file.close
+      File.delete(image_file) if check_to_delete(params[:image])
+      render json: { status: "success", project: @project }, status: :created
+    else
+      render json: { status: "error", errors: @project.errors.full_messages }, status: :unprocessable_content
     end
   end
 
-  # PATCH/PUT /projects/1
-  # PATCH/PUT /projects/1.json
+  # PATCH /api/v1/projects/:id
   def update
-    @project.description = params["description"]
-    set_name_project_datum(project_params)
-    respond_to do |format|
-      if @project.update(project_params)
-        format.html do
-          redirect_to user_project_path(@project.author_id, @project),
-                      notice: "Project was successfully updated."
-        end
-        format.json { render :show, status: :ok, location: @project }
-      else
-        format.html { render :edit }
-        format.json { render json: @project.errors, status: :unprocessable_content }
-      end
+    authorize @project, :check_edit_access?
+    params[:project][:name] = sanitize(project_params[:name])
+    @project.update!(project_params)
+    if @project.update(project_params)
+      render json: Api::V1::ProjectSerializer.new(@project, @options), status: :accepted
+    else
+      invalid_resource!(@project.errors)
     end
   end
 
-  # DELETE /projects/1
-  # DELETE /projects/1.json
+  # PATCH /api/v1/projects/update_circuit
+  def update_circuit
+    authorize @project, :check_edit_access?
+
+    build_project_datum
+    update_project_params
+
+    if @project.save && @project.project_datum.save
+      handle_image_file_cleanup
+      render json: { status: "success", project: @project }, status: :ok
+    else
+      render json: { status: "error", errors: @project.errors.full_messages }, status: :unprocessable_content
+    end
+  end
+
+  # DELETE /api/v1/projects/:id
   def destroy
-    @project.destroy
-    respond_to do |format|
-      format.html do
-        redirect_to user_path(@project.author_id), notice: "Project was successfully destroyed."
-      end
-      format.json { head :no_content }
+    authorize @project, :author_access?
+    @project.destroy!
+    head :no_content
+  end
+
+  # GET /api/v1/projects/featured
+  def featured_circuits
+    @options[:links] = link_attrs(paginate(@projects), api_v1_projects_featured_url)
+    render json: Api::V1::ProjectSerializer.new(paginate(@projects), @options)
+  end
+
+  # GET /api/v1/projects/:id/toggle-star
+  def toggle_star
+    if @project.toggle_star(current_user)
+      render json: { message: "Starred successfully!" }, status: :ok
+    else
+      render json: { message: "Unstarred successfully!" }, status: :ok
+    end
+  end
+
+  # /api/v1/projects/:id/fork
+  def create_fork
+    if current_user.id == @project.author_id
+      api_error(status: 409, errors: "Cannot fork your own project!")
+    else
+      @forked_project = @project.fork(current_user)
+      render json: Api::V1::ProjectSerializer.new(@forked_project, @options)
     end
   end
 
   private
-
-    # Use callbacks to share common setup or constraints between actions.
-    def set_project
-      if params[:user_id]
-        @author = User.find(params[:user_id])
-        @project = @author.projects.friendly.with_attached_circuit_preview.find(params[:id])
-      else
-        @project = Project.friendly.with_attached_circuit_preview.find(params[:id])
-        @author = @project.author
-      end
+  def set_project
+    if params[:user_id]
+      @author = User.find(params[:user_id])
+      @project = @author.projects.friendly.find(params[:id])
+    else
+      @project = Project.friendly.find(params[:id])
+      @author = @project.author
     end
+  end
 
-    def check_access
-      authorize @project, :edit_access?
+  # Update circuit data Related methods
+
+  def set_user_project
+    @project = Project.friendly.find(params[:id])
+    authorize @project, :edit_access?
+  end
+
+  def build_project_datum
+    @project.build_project_datum unless ProjectDatum.exists?(project_id: @project.id)
+    @project.project_datum.data = sanitize_data(@project, params[:data])
+  end
+
+  def update_project_params
+    @image_file = return_image_file(params[:image])
+    @project.image_preview = @image_file
+    @project.name = sanitize(params[:name])
+  end
+
+  def handle_image_file_cleanup
+    @image_file.close
+    File.delete(@image_file) if check_to_delete(params[:image])
+  end
+
+  def load_index_projects
+    @projects = if current_user.nil?
+      Project.open
+    else
+      Project.open.or(Project.by(current_user.id))
     end
+  end
 
-    def check_delete_access
-      authorize @project, :author_access?
+  def load_user_projects
+    # if user is not authenticated or authenticated as some other user
+    # return only user's public projects else all
+    @projects = if current_user.nil? || current_user.id != params[:id].to_i
+      Project.open.by(params[:id])
+    else
+      current_user.projects
     end
+  end
 
-    def check_view_access
-      authorize @project, :view_access?
+  def load_user_favourites
+    @projects = Project.joins(:stars)
+                       .where(stars: { user_id: params[:id].to_i })
+
+    # if user is not authenticated or authenticated as some other user
+    # return only user's public favourites else all
+    @projects = if current_user.nil? || current_user.id != params[:id].to_i
+      @projects.open
+    else
+      @projects
     end
+  end
 
-    # Never trust parameters from the scary internet, only allow the white list through.
-    def project_params
-      params.expect(project: %i[name project_access_type description tag_list tags])
-    end
+  def load_featured_circuits
+    @projects = Project.joins(:featured_circuit).all
+  end
 
-    def sanitize_name
-      params[:project][:name] = sanitize(project_params[:name])
-    end
+  def search_projects
+    query_params = { q: params[:q], page: params[:page][:number], per_page: params[:page][:size] }
+    @projects = ProjectsQuery.new(query_params, Project.public_and_not_forked).results
+  end
 
-    # Sanitize description before passing to view
-    def sanitize_project_description
-      @project.description = sanitize_description(@project.description)
-    end
+  # include=author
+  def include_resource
+    params[:include].split(",")
+                     .map { |resource| resource.strip.to_sym }
+                     .select { |resource| WHITELISTED_INCLUDE_ATTRIBUTES.include?(resource) }
+  end
 
-    def set_name_project_datum(project_params)
-      return unless @project.project_datum
+  def set_options
+    @options = {}
+    @options[:include] = include_resource if params.key?(:include)
+    @options[:params] = {
+      current_user: current_user,
+      only_name: true
+    }
+  end
 
-      datum_data = JSON.parse(@project.project_datum.data)
-      datum_data["name"] = project_params["name"]
-      @project.project_datum.data = JSON.generate(datum_data)
-    end
+  def filter
+    @projects = @projects.tagged_with(params[:filter][:tag]) if params.key?(:filter)
+  end
+
+  def sort
+    return unless params.key?(:sort)
+
+    @projects = @projects.order(SortingHelper.sort_fields(params[:sort], SORTABLE_FIELDS))
+  end
+
+  def project_params
+    params.expect(project: %i[name project_access_type description tag_list])
+  end
 end

--- a/app/serializers/api/v1/project_serializer.rb
+++ b/app/serializers/api/v1/project_serializer.rb
@@ -1,58 +1,299 @@
 # frozen_string_literal: true
 
-class Api::V1::ProjectSerializer
-  include FastJsonapi::ObjectSerializer
+class Api::V1::ProjectsController < Api::V1::BaseController
+  include ActionView::Helpers::SanitizeHelper
+  include SimulatorHelper
 
-  attributes :name, :project_access_type, :created_at,
-             :updated_at, :description,
-             :view, :tags
+  before_action :authenticate_user!, only: %i[
+    check_edit_access
+    create
+    update
+    update_circuit
+    destroy
+    toggle_star
+    create_fork
+  ]
+  before_action :load_index_projects, only: %i[index]
+  before_action :load_user_projects, only: %i[user_projects]
+  before_action :load_featured_circuits, only: %i[featured_circuits]
+  before_action :load_user_favourites, only: %i[user_favourites]
+  before_action :search_projects, only: %i[search]
+  before_action :set_project, only: %i[
+    check_edit_access
+    show circuit_data
+    update
+    destroy
+    toggle_star
+    create_fork
+  ]
+  before_action :set_user_project, only: %i[update_circuit]
+  before_action :set_options, except: %i[destroy toggle_star image_preview]
+  before_action :filter, only: %i[index user_projects featured_circuits user_favourites]
+  before_action :sort, only: %i[index user_projects featured_circuits user_favourites]
 
-  attributes :is_starred do |project, params|
-    if params[:current_user].nil?
-      nil
+  SORTABLE_FIELDS = %i[view created_at].freeze
+  WHITELISTED_INCLUDE_ATTRIBUTES = %i[author collaborators].freeze
+
+  # GET /api/v1/projects
+  def index
+    projects_page = paginate(@projects)
+    @options[:links] = link_attrs(projects_page, api_v1_projects_url)
+    @options[:params][:starred_project_ids] = starred_project_ids_for(projects_page)
+
+    render json: Api::V1::ProjectSerializer.new(projects_page, @options)
+  end
+
+  # GET /api/v1/projects/search?q=:query
+  def search
+    base_url = "#{api_v1_projects_search_url}?q=#{params[:q]}"
+    projects_page = paginate(@projects)
+    @options[:links] = link_attrs(projects_page, base_url)
+    @options[:params][:starred_project_ids] = starred_project_ids_for(projects_page)
+
+    render json: Api::V1::ProjectSerializer.new(projects_page, @options)
+  end
+
+  # GET /api/v1/users/:id/projects/
+  def user_projects
+    projects_page = paginate(@projects)
+    @options[:links] = link_attrs(projects_page, projects_api_v1_user_url)
+    @options[:params][:starred_project_ids] = starred_project_ids_for(projects_page)
+
+    render json: Api::V1::ProjectSerializer.new(projects_page, @options)
+  end
+
+  # GET /api/v1/users/:id/favourites
+  def user_favourites
+    projects_page = paginate(@projects)
+    @options[:links] = link_attrs(projects_page, favourites_api_v1_user_url)
+    @options[:params][:starred_project_ids] = starred_project_ids_for(projects_page)
+
+    render json: Api::V1::ProjectSerializer.new(projects_page, @options)
+  end
+
+  # GET /api/v1/projects/:id/check_edit_access
+  def check_edit_access
+    current_user.admin? || authorize(@project, :check_edit_access?)
+    @options = { params: { has_details_access: true } }
+    render json: Api::V1::UserSerializer.new(current_user, @options)
+  end
+
+  # GET /api/v1/projects/:id
+  def show
+    authorize @project, :check_view_access?
+    @project.increase_views(current_user)
+    render json: Api::V1::ProjectSerializer.new(@project, @options)
+  end
+
+  # GET /api/v1/projects/:id/circuit_data
+  def circuit_data
+    authorize @project, :check_view_access?
+    circuit_data = ProjectDatum.find_by(project: @project)
+    if circuit_data
+      render json: circuit_data.data
     else
-      Star.exists?(user_id: params[:current_user].id, project_id: project.id)
+      render json: { error: "Circuit data unavailabe for the project!" }, status: :not_found
     end
   end
 
-  attributes :author_name do |project|
-    project.author.name
+  def image_preview
+    @project = Project.open.friendly.find(params[:id])
+    render json: { project_preview: request.base_url + @project.image_preview.url }
   end
 
-  attributes :stars_count, &:stars_count
+  # POST api/v1/projects
+  def create
+    @project = Project.new
+    @project.build_project_datum.data = sanitize_data(@project, params[:data])
+    @project.name = sanitize(params[:name])
+    @project.author = current_user
 
-  attributes :thread_id do |project|
-    project.commontator_thread.id
-  end
+    image_file = return_image_file(params[:image])
 
-  attributes :is_thread_subscribed do |project, params|
-    if params[:current_user].nil?
-      nil
+    @project.image_preview = image_file
+    if @project.save
+      image_file.close
+      File.delete(image_file) if check_to_delete(params[:image])
+      render json: { status: "success", project: @project }, status: :created
     else
-      params[:current_user].commontator_subscriptions.exists?(
-        thread_id: project.commontator_thread.id
-      )
+      render json: { status: "error", errors: @project.errors.full_messages }, status: :unprocessable_content
     end
   end
 
-  attributes :is_thread_closed do |project|
-    project.commontator_thread.is_closed?
-  end
-
-  # :nocov:
-  attributes :image_preview do |project|
-    if project.circuit_preview.attached?
-      {
-        url: Rails.application.routes.url_helpers.rails_blob_url(project.circuit_preview, only_path: true)
-      }
+  # PATCH /api/v1/projects/:id
+  def update
+    authorize @project, :check_edit_access?
+    params[:project][:name] = sanitize(project_params[:name])
+    @project.update!(project_params)
+    if @project.update(project_params)
+      render json: Api::V1::ProjectSerializer.new(@project, @options), status: :accepted
     else
-      {
-        url: ActionController::Base.helpers.asset_path("empty_project/default.png")
-      }
+      invalid_resource!(@project.errors)
     end
   end
-  # :nocov:
 
-  belongs_to :author
-  has_many :collaborators, serializer: Api::V1::UserSerializer
+  # PATCH /api/v1/projects/update_circuit
+  def update_circuit
+    authorize @project, :check_edit_access?
+
+    build_project_datum
+    update_project_params
+
+    if @project.save && @project.project_datum.save
+      handle_image_file_cleanup
+      render json: { status: "success", project: @project }, status: :ok
+    else
+      render json: { status: "error", errors: @project.errors.full_messages }, status: :unprocessable_content
+    end
+  end
+
+  # DELETE /api/v1/projects/:id
+  def destroy
+    authorize @project, :author_access?
+    @project.destroy!
+    head :no_content
+  end
+
+  # GET /api/v1/projects/featured
+  def featured_circuits
+    projects_page = paginate(@projects)
+    @options[:links] = link_attrs(projects_page, api_v1_projects_featured_url)
+    @options[:params][:starred_project_ids] = starred_project_ids_for(projects_page)
+
+    render json: Api::V1::ProjectSerializer.new(projects_page, @options)
+  end
+
+  # GET /api/v1/projects/:id/toggle-star
+  def toggle_star
+    if @project.toggle_star(current_user)
+      render json: { message: "Starred successfully!" }, status: :ok
+    else
+      render json: { message: "Unstarred successfully!" }, status: :ok
+    end
+  end
+
+  # /api/v1/projects/:id/fork
+  def create_fork
+    if current_user.id == @project.author_id
+      api_error(status: 409, errors: "Cannot fork your own project!")
+    else
+      @forked_project = @project.fork(current_user)
+      render json: Api::V1::ProjectSerializer.new(@forked_project, @options)
+    end
+  end
+
+  private
+
+  def set_project
+    if params[:user_id]
+      @author = User.find(params[:user_id])
+      @project = @author.projects.friendly.find(params[:id])
+    else
+      @project = Project.friendly.find(params[:id])
+      @author = @project.author
+    end
+  end
+
+  # Update circuit data Related methods
+
+  def set_user_project
+    @project = Project.friendly.find(params[:id])
+    authorize @project, :edit_access?
+  end
+
+  def build_project_datum
+    @project.build_project_datum unless ProjectDatum.exists?(project_id: @project.id)
+    @project.project_datum.data = sanitize_data(@project, params[:data])
+  end
+
+  def update_project_params
+    @image_file = return_image_file(params[:image])
+    @project.image_preview = @image_file
+    @project.name = sanitize(params[:name])
+  end
+
+  def handle_image_file_cleanup
+    @image_file.close
+    File.delete(@image_file) if check_to_delete(params[:image])
+  end
+
+  def load_index_projects
+    @projects = if current_user.nil?
+      Project.open
+    else
+      Project.open.or(Project.by(current_user.id))
+    end
+  end
+
+  def load_user_projects
+    # if user is not authenticated or authenticated as some other user
+    # return only user's public projects else all
+    @projects = if current_user.nil? || current_user.id != params[:id].to_i
+      Project.open.by(params[:id])
+    else
+      current_user.projects
+    end
+  end
+
+  def load_user_favourites
+    @projects = Project.joins(:stars)
+                       .where(stars: { user_id: params[:id].to_i })
+
+    # if user is not authenticated or authenticated as some other user
+    # return only user's public favourites else all
+    @projects = if current_user.nil? || current_user.id != params[:id].to_i
+      @projects.open
+    else
+      @projects
+    end
+  end
+
+  def load_featured_circuits
+    @projects = Project.joins(:featured_circuit).all
+  end
+
+  def search_projects
+    query_params = { q: params[:q], page: params[:page][:number], per_page: params[:page][:size] }
+    @projects = ProjectsQuery.new(query_params, Project.public_and_not_forked).results
+  end
+
+  # include=author
+  def include_resource
+    params[:include].split(",")
+                     .map { |resource| resource.strip.to_sym }
+                     .select { |resource| WHITELISTED_INCLUDE_ATTRIBUTES.include?(resource) }
+  end
+
+  def set_options
+    @options = {}
+    @options[:include] = include_resource if params.key?(:include)
+    @options[:params] = {
+      current_user: current_user,
+      only_name: true
+    }
+  end
+
+  def filter
+    @projects = @projects.tagged_with(params[:filter][:tag]) if params.key?(:filter)
+  end
+
+  def sort
+    return unless params.key?(:sort)
+
+    @projects = @projects.order(SortingHelper.sort_fields(params[:sort], SORTABLE_FIELDS))
+  end
+
+  def project_params
+    params.expect(project: %i[name project_access_type description tag_list])
+  end
+
+  # Precompute starred ids ONCE per paginated page to avoid Star.exists? N+1.
+  def starred_project_ids_for(projects_page)
+    return nil if current_user.nil?
+
+    require "set"
+    Star.where(user_id: current_user.id, project_id: projects_page.select(:id))
+        .pluck(:project_id)
+        .to_set
+  end
 end


### PR DESCRIPTION
Fixes #7200

Describe the changes you have made in this PR -
* Removed the N+1 query on the `stars` table in 
  API project list responses by precomputing the 
  current user's `starred_project_ids` once per 
  paginated page.
* Updated `Api::V1::ProjectSerializer` to use the 
  precomputed `starred_project_ids` set (pure Ruby 
  `include?`) instead of running `Star.exists?` for 
  every project record.
* Refactored the web endpoint 
  `ProjectsController#change_stars` to reuse the 
  existing `Project#toggle_star` model method, 
  keeping existing JS return semantics (`"2"` for 
  starred, `"1"` for unstarred).

Screenshots of the UI changes (If any) -
No UI changes expected; only backend query 
behavior/consistency.

Code Understanding and AI Usage
Did you use AI assistance?
* [x] Yes, I used AI assistance

If you used AI assistance:
* [x] I have reviewed every single line of the 
      AI-generated code
* [x] I can explain the purpose and logic of each 
      function/component I added
* [x] I have tested edge cases and understand how 
      the code handles them
* [x] I have modified the AI output to follow this 
      project's coding standards and conventions

Explain your implementation approach:
* The N+1 was caused by the serializer determining 
  `is_starred` via `Star.exists?` per project when 
  rendering collections.
* In `api/v1/projects_controller.rb`, the fix 
  computes all `starred_project_ids` for the current 
  user using a single query scoped to the project 
  IDs in the current paginated page, then passes the 
  resulting set into the serializer via 
  `@options[:params][:starred_project_ids]`.
* In `project_serializer.rb`, `is_starred` now 
  checks `starred_project_ids.include?(project.id)` 
  when provided, avoiding per-project star queries.
* In `projects_controller.rb`, `change_stars` was 
  simplified to call 
  `@project.toggle_star(current_user)` to ensure 
  star toggling behavior remains centralized in the 
  `Project` model.

Checklist before requesting a review
* [x] I have added proper PR title and linked issue
* [x] I have performed a self-review of my code
* [x] I can explain the purpose of every function, 
      class, and logic block I added
* [x] I understand why my changes work and have 
      tested them thoroughly
* [x] I have considered potential edge cases and 
      how my code handles them
* [ ] If it is a core feature, I have added 
      thorough tests
* [x] My code follows the project's style 
      guidelines and conventions