### PR TITLE
Fix spacing issue in assignments-submain-heading margin-top

### DIFF
--- a/app/assets/stylesheets/assignments.scss
+++ b/app/assets/stylesheets/assignments.scss
@@ -1,6 +1,6 @@
 //newassignment-editassignment
 .assignments-submain-heading {
-  margin-top: 0;
+  margin-top: 20px;
 }
 
 .assignments-noedit-grade-field {


### PR DESCRIPTION
Fixes #5541

#### Describe the changes you have made in this PR -
Fixed the spacing issue in the Assignment section by changing the 
margin-top value of .assignments-submain-heading from 0 to 20px. 
This adds proper spacing between the deadline and grading scale 
placeholder sections, improving the visual layout of the edit 
assignment page.

### Screenshots of the UI changes (If any) -
CSS change made in app/assets/stylesheets/assignments.scss
Line 3: margin-top changed from 0 to 20px

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted spacing for improved visual organization in the assignments section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->