### PR TITLE
Fix: Handle Recaptcha API failures gracefully (502 / invalid JSON)  #7211

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -70,15 +70,26 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   private
+   
 
+  #
     def check_captcha
-      return unless Flipper.enabled?(:recaptcha) && !verify_recaptcha
+  return unless Flipper.enabled?(:recaptcha)
 
-      self.resource = resource_class.new sign_up_params
-      resource.validate # Look for any other validation errors besides reCAPTCHA
-      set_minimum_password_length
-      respond_with_navigational(resource) { render :new }
-    end
+  begin
+    return if verify_recaptcha
+  rescue JSON::ParserError, Recaptcha::RecaptchaError => e
+    Rails.logger.error("[Recaptcha Error] #{e.class}: #{e.message}")
+
+    # Fail-open: allow request if captcha service fails
+    return true
+  end
+
+  self.resource = resource_class.new sign_up_params
+  resource.validate # Look for any other validation errors besides reCAPTCHA
+  set_minimum_password_length
+  respond_with_navigational(resource) { render :new }
+end
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_account_update_params


### PR DESCRIPTION
### Issue

`verify_recaptcha` may raise `JSON::ParserError` or `Recaptcha::RecaptchaError` when the Recaptcha API returns a non-JSON response (e.g., 502 HTML error page).

This currently causes the registration flow to crash.

### Fix

* Wrapped `verify_recaptcha` call in `check_captcha` with exception handling
* Logs errors for debugging
* Uses a fail-open strategy to allow user registration when Recaptcha service is unavailable

### Rationale

Recaptcha is an external dependency and may fail unpredictably. This change ensures:

* No user-facing crashes
* Better resilience of the signup flow

### Scope

Minimal change — only modifies `check_captcha` method.

### Result

* Prevents JSON parsing crashes
* Maintains existing validation behavior
* Improves system robustness


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced reCAPTCHA verification error handling in the user registration process. The system now gracefully manages verification failures with detailed error logging, enabling users to successfully complete registration even if verification encounters technical issues.

* **Chores**
  * Optimized reCAPTCHA feature flag control and verification workflow management for improved system flexibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->