### PR TITLE
feat: LTI 1.3 OIDC launch flow — GSoC 2026 POC

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -287,7 +287,11 @@ GEM
       logger
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
-    ffi (1.17.2)
+    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x64-mingw-ucrt)
+    ffi (1.17.2-x86_64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
       rake
@@ -314,10 +318,13 @@ GEM
     glob (0.4.1)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    google-protobuf (4.32.0)
+    google-protobuf (4.32.0-aarch64-linux-gnu)
       bigdecimal
       rake (>= 13)
     google-protobuf (4.32.0-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.0-x64-mingw-ucrt)
       bigdecimal
       rake (>= 13)
     google-protobuf (4.32.0-x86_64-darwin)
@@ -479,6 +486,8 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
+    nokogiri (1.19.1-aarch64-linux-gnu)
+      racc (~> 1.4)
     nokogiri (1.19.1-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.19.1-x64-mingw-ucrt)
@@ -640,7 +649,11 @@ GEM
       racc
     percy-capybara (5.0.0)
       capybara (>= 3)
-    pg (1.6.1)
+    pg (1.6.1-aarch64-linux)
+    pg (1.6.1-arm64-darwin)
+    pg (1.6.1-x64-mingw-ucrt)
+    pg (1.6.1-x86_64-darwin)
+    pg (1.6.1-x86_64-linux)
     pg_search (2.3.7)
       activerecord (>= 6.1)
       activesupport (>= 6.1)
@@ -1011,6 +1024,7 @@ GEM
     zeitwerk (2.7.3)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23

--- a/README_LTI13.md
+++ b/README_LTI13.md
@@ -1,0 +1,169 @@
+# LTI 1.3 OIDC Launch Flow — CircuitVerse POC
+
+> GSoC 2026 POC — Option B: Integrated into CircuitVerse alongside existing LTI 1.1
+
+## What This Implements
+
+This adds **LTI 1.3 OIDC third-party login** to CircuitVerse as a Proof of Concept. When launched from a Learning Management System (LMS) that supports LTI 1.3, CircuitVerse:
+
+1. Receives an OIDC login initiation request
+2. Redirects the user's browser to the platform's authorization endpoint
+3. Receives a signed JWT (id_token) via form POST
+4. Verifies the JWT signature against the platform's JWKS
+5. Renders the decoded claims for verification
+
+The existing **LTI 1.1 implementation is completely untouched** — both versions coexist.
+
+---
+
+## Prerequisites
+
+- Rails development environment (Docker recommended)
+- OpenSSL (for key generation)
+- [ngrok](https://ngrok.com/) (for external testing with saLTIre)
+
+---
+
+## Setup
+
+### 1. Run Migrations
+
+```bash
+# Docker
+docker compose exec web bundle exec rails db:migrate
+
+# Native
+bundle exec rails db:migrate
+```
+
+This creates:
+- `lti_platforms` table (stores LTI 1.3 platform registrations)
+- `lti_deployment_id` column on `assignments` (for future deployment tracking)
+
+### 2. Generate RSA Key Pair
+
+```bash
+openssl genrsa -out tmp/lti_private_key.pem 2048
+```
+
+### 3. Add to Rails Credentials
+
+```bash
+EDITOR="code --wait" rails credentials:edit
+```
+
+Add:
+```yaml
+lti_tool_private_key: |
+  -----BEGIN RSA PRIVATE KEY-----
+  [paste contents of tmp/lti_private_key.pem]
+  -----END RSA PRIVATE KEY-----
+
+lti_tool_kid: "circuitverse-lti-key-1"
+```
+
+### 4. Seed saLTIre Platform
+
+```ruby
+# In rails console
+LtiPlatform.create!(
+  issuer:        "https://saltire.lti.app",
+  client_id:     "saltire.lti.app",
+  auth_url:      "https://saltire.lti.app/platform/auth",
+  token_url:     "https://saltire.lti.app/platform/token",
+  jwks_url:      "https://saltire.lti.app/platform/jwks",
+  deployment_id: "1"
+)
+```
+
+### 5. Start ngrok and Configure saLTIre
+
+```bash
+ngrok http 3000
+```
+
+At https://saltire.lti.app/platform configure:
+
+| Field | Value |
+|---|---|
+| OIDC Login Initiation URL | `https://YOUR_NGROK/lti/v1p3/oidc/login` |
+| Launch / Redirect URL | `https://YOUR_NGROK/lti/v1p3/oidc/callback` |
+| JWKS URL | `https://YOUR_NGROK/lti/v1p3/jwks` |
+| Client ID | `saltire.lti.app` |
+
+Click **Launch** — you should see the decoded JWT claims page.
+
+---
+
+## Endpoint Reference
+
+| Route | Method | Purpose |
+|---|---|---|
+| `/lti/launch` | GET/POST | **Existing** LTI 1.1 launch (untouched) |
+| `/lti/v1p3/jwks` | GET | Serves tool RSA public key in JWK format |
+| `/lti/v1p3/oidc/login` | POST | OIDC login initiation — validates issuer, redirects to platform auth |
+| `/lti/v1p3/oidc/callback` | POST | Receives JWT id_token, verifies signature, renders decoded claims |
+
+---
+
+## Gems Used
+
+| Gem | Version | Purpose |
+|---|---|---|
+| `jwt` | 2.10.2 | JWT decode, verify, encode (already in Gemfile) |
+| `Net::HTTP` | stdlib | Fetch platform JWKS, AGS token requests |
+| `OpenSSL` | stdlib | RSA key operations |
+| `SecureRandom` | stdlib | State/nonce generation |
+
+**No new gems were added.** Everything uses existing dependencies.
+
+---
+
+## Files Added
+
+| File | Purpose |
+|---|---|
+| `app/controllers/lti/v1p3/launches_controller.rb` | OIDC flow controller |
+| `app/models/lti_platform.rb` | Platform registration model |
+| `app/views/lti/v1p3/launches/launch_success.html.erb` | Decoded claims view |
+| `db/migrate/*_add_lti_deployment_id_to_assignments.rb` | Schema migration |
+| `db/migrate/*_create_lti_platforms.rb` | Platform table migration |
+| `README_LTI13.md` | This file |
+
+## Files Modified
+
+| File | Change |
+|---|---|
+| `config/routes.rb` | Added 3 routes inside existing `scope 'lti'` block |
+
+## Files NOT Modified
+
+- `app/controllers/lti_controller.rb` — LTI 1.1 untouched
+- `app/services/lti_score_submission.rb` — Grade passback untouched
+- `spec/requests/lti_spec.rb` — All existing tests pass unchanged
+
+---
+
+## How Existing LTI 1.1 Is Unaffected
+
+The new LTI 1.3 routes are namespaced under `/lti/v1p3/`, completely independent of the existing `/lti/launch` route. The existing controller, service, views, helper, and tests are never touched.
+
+---
+
+## Production Considerations
+
+For a production deployment beyond this POC:
+
+1. **Session Storage**: Replace cookie-based sessions with Redis for nonce/state storage (prevents replay attacks at scale)
+2. **Platform Registration UI**: Add an admin interface for registering LTI platforms (currently seeded via console)
+3. **JWKS Caching**: Cache platform JWKS responses with automatic refresh (avoid fetching on every launch)
+4. **User Provisioning**: Auto-create CircuitVerse accounts from LTI claims or match by email
+5. **Assignment Linking**: Map LTI resource links to CircuitVerse assignments via `lti_deployment_id`
+6. **AGS Integration**: Use `projects.lis_result_sourced_id` to store lineitem URLs for LTI 1.3 grade passback
+7. **Rate Limiting**: Rate-limit the `/lti/v1p3/jwks` endpoint
+
+---
+
+## Screenshots
+
+_Add screenshots of successful saLTIre launch here_

--- a/README_LTI13.md
+++ b/README_LTI13.md
@@ -164,6 +164,4 @@ For a production deployment beyond this POC:
 
 ---
 
-## Screenshots
 
-_Add screenshots of successful saLTIre launch here_

--- a/app/controllers/lti/v1p3/launches_controller.rb
+++ b/app/controllers/lti/v1p3/launches_controller.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+require "net/http"
+require "json"
+require "openssl"
+
+module Lti
+  module V1p3
+    class LaunchesController < ApplicationController
+      skip_before_action :verify_authenticity_token,
+                         only: %i[oidc_login oidc_callback]
+      after_action :allow_iframe_lti, only: [:oidc_callback]
+
+      # GET /lti/v1p3/jwks
+      # Serves the tool's RSA public key so platforms can
+      # verify JWT signatures on client assertions.
+      def jwks
+        render json: { keys: [build_jwk] }
+      end
+
+      # POST /lti/v1p3/oidc/login
+      # Receives OIDC login initiation from platform.
+      # Validates the issuer, generates state + nonce,
+      # stores both in session, redirects to platform
+      # authorization endpoint.
+      def oidc_login
+        iss      = params[:iss]
+        platform = LtiPlatform.find_by(issuer: iss)
+
+        unless platform
+          render plain: "Unknown platform: #{iss}",
+                 status: :unauthorized and return
+        end
+
+        state = SecureRandom.hex(24)
+        nonce = SecureRandom.hex(24)
+
+        cookie_options = {
+          same_site: :none,
+          secure:    true,
+          httponly:  true,
+          expires:   10.minutes
+        }
+
+        cookies.signed[:lti_v1p3_state]       = cookie_options.merge(value: state)
+        cookies.signed[:lti_v1p3_nonce]       = cookie_options.merge(value: nonce)
+        cookies.signed[:lti_v1p3_platform_id] = cookie_options.merge(value: platform.id.to_s)
+
+        auth_params = {
+          scope:            "openid",
+          response_type:    "id_token",
+          response_mode:    "form_post",
+          prompt:           "none",
+          client_id:        platform.client_id,
+          redirect_uri:     v1p3_oidc_callback_url,
+          login_hint:       params[:login_hint],
+          lti_message_hint: params[:lti_message_hint],
+          state:            state,
+          nonce:            nonce
+        }.compact
+
+        redirect_to "#{platform.auth_url}?#{auth_params.to_query}",
+                    allow_other_host: true
+      end
+
+      # POST /lti/v1p3/oidc/callback
+      # Receives JWT id_token from platform.
+      # Validates state, decodes + verifies JWT,
+      # validates nonce, sets session, renders claims.
+      def oidc_callback
+        id_token       = params[:id_token]
+        returned_state = params[:state]
+        stored_state   = cookies.signed[:lti_v1p3_state]
+        stored_nonce   = cookies.signed[:lti_v1p3_nonce]
+        platform_id    = cookies.signed[:lti_v1p3_platform_id]
+
+        cookies.delete(:lti_v1p3_state)
+        cookies.delete(:lti_v1p3_nonce)
+        cookies.delete(:lti_v1p3_platform_id)
+
+        unless returned_state.present? &&
+               returned_state == stored_state
+          render plain: "State mismatch — possible CSRF",
+                 status: :unauthorized and return
+        end
+
+        platform = LtiPlatform.find_by(id: platform_id)
+        unless platform
+          render plain: "Platform not found",
+                 status: :unauthorized and return
+        end
+
+        claims = decode_and_verify(id_token, platform)
+        unless claims
+          render plain: "JWT verification failed",
+                 status: :unauthorized and return
+        end
+
+        unless claims["nonce"] == stored_nonce
+          render plain: "Nonce mismatch",
+                 status: :unauthorized and return
+        end
+
+        @claims = claims
+        render :launch_success, layout: false
+      end
+
+      private
+
+      def decode_and_verify(id_token, platform)
+        # Step 1: decode header without verification to
+        # get kid for JWKS lookup
+        _payload, header = JWT.decode(id_token, nil, false)
+        kid = header["kid"]
+
+        # Step 2: fetch platform JWKS and find matching key
+        jwks_keys = fetch_platform_jwks(platform.jwks_url)
+        pub_key   = find_public_key(jwks_keys, kid)
+        return nil unless pub_key
+
+        # Step 3: decode and verify fully
+        payload, _header = JWT.decode(
+          id_token,
+          pub_key,
+          true,
+          algorithms: ["RS256"],
+          verify_iat: true
+        )
+        payload
+      rescue JWT::DecodeError => e
+        Rails.logger.warn("LTI 1.3 JWT decode failed: #{e.message}")
+        nil
+      end
+
+      def fetch_platform_jwks(jwks_url)
+        uri      = URI.parse(jwks_url)
+        response = Net::HTTP.get_response(uri)
+        JSON.parse(response.body)["keys"]
+      rescue StandardError => e
+        Rails.logger.error("Failed to fetch JWKS from #{jwks_url}: #{e.message}")
+        []
+      end
+
+      def find_public_key(jwks_keys, kid)
+        key_data = if kid.present?
+                     jwks_keys.find { |k| k["kid"] == kid }
+                   else
+                     jwks_keys.first
+                   end
+        return nil unless key_data
+
+        jwk = JWT::JWK.import(key_data)
+        jwk.public_key
+      rescue StandardError => e
+        Rails.logger.error("JWK import failed: #{e.message}")
+        nil
+      end
+
+      def build_jwk
+        private_key_pem =
+          Rails.application.credentials.lti_tool_private_key
+        raise "LTI private key not configured in credentials" \
+          unless private_key_pem.present?
+
+        private_key = OpenSSL::PKey::RSA.new(private_key_pem)
+        pub_key     = private_key.public_key
+        kid         = Rails.application.credentials.lti_tool_kid ||
+                      "circuitverse-lti-key-1"
+
+        {
+          kty: "RSA",
+          use: "sig",
+          alg: "RS256",
+          kid: kid,
+          n: Base64.urlsafe_encode64(
+               pub_key.n.to_s(2), padding: false),
+          e: Base64.urlsafe_encode64(
+               pub_key.e.to_s(2), padding: false)
+        }
+      end
+
+      def allow_iframe_lti
+        response.headers.delete("X-Frame-Options")
+        response.headers["Content-Security-Policy"] =
+          "frame-ancestors 'self' https://saltire.lti.app"
+      end
+    end
+  end
+end

--- a/app/models/lti_platform.rb
+++ b/app/models/lti_platform.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class LtiPlatform < ApplicationRecord
+  validates :issuer, :client_id, :auth_url,
+            :token_url, :jwks_url, presence: true
+  validates :issuer, uniqueness: { scope: :client_id,
+    message: "already registered for this client_id" }
+
+  def self.find_by_launch_params(iss, client_id)
+    find_by(issuer: iss, client_id: client_id)
+  end
+end

--- a/app/views/lti/v1p3/launches/launch_success.html.erb
+++ b/app/views/lti/v1p3/launches/launch_success.html.erb
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>LTI 1.3 Launch — CircuitVerse</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont,
+                   "Segoe UI", sans-serif;
+      background: #f6f8fa;
+      padding: 2rem;
+    }
+    .card {
+      background: white;
+      border: 1px solid #d0d7de;
+      border-radius: 8px;
+      padding: 1.5rem;
+      max-width: 800px;
+      margin: 0 auto;
+    }
+    .badge {
+      display: inline-block;
+      background: #2da44e;
+      color: white;
+      padding: 0.3rem 0.8rem;
+      border-radius: 2rem;
+      font-size: 0.85rem;
+      font-weight: 600;
+      margin-bottom: 1rem;
+    }
+    h1 { font-size: 1.4rem; margin-bottom: 1.5rem;
+         color: #24292f; }
+    .meta {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+      margin-bottom: 1.5rem;
+    }
+    .meta-item {
+      background: #f6f8fa;
+      padding: 0.75rem;
+      border-radius: 6px;
+      border: 1px solid #d0d7de;
+    }
+    .meta-item label {
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: #57606a;
+      text-transform: uppercase;
+      display: block;
+      margin-bottom: 0.25rem;
+    }
+    .meta-item span { font-size: 0.9rem; color: #24292f; }
+    h2 { font-size: 1rem; margin-bottom: 0.75rem;
+         color: #24292f; }
+    pre {
+      background: #f6f8fa;
+      border: 1px solid #d0d7de;
+      border-radius: 6px;
+      padding: 1rem;
+      font-size: 0.8rem;
+      overflow-x: auto;
+      white-space: pre-wrap;
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="badge">LTI 1.3 Launch Successful</div>
+    <h1>CircuitVerse — LTI 1.3 POC</h1>
+
+    <div class="meta">
+      <div class="meta-item">
+        <label>User</label>
+        <span>
+          <%= @claims["email"] ||
+              @claims["name"] ||
+              @claims["sub"] %>
+        </span>
+      </div>
+      <div class="meta-item">
+        <label>Issuer</label>
+        <span><%= @claims["iss"] %></span>
+      </div>
+      <div class="meta-item">
+        <label>Resource Link</label>
+        <span>
+          <%= @claims.dig(
+            "https://purl.imsglobal.org/spec/lti/claim/resource_link",
+            "id") || "not present" %>
+        </span>
+      </div>
+      <div class="meta-item">
+        <label>Roles</label>
+        <span>
+          <% roles = @claims[
+            "https://purl.imsglobal.org/spec/lti/claim/roles"
+          ] || [] %>
+          <%= roles.map { |r| r.split("/").last }.join(", ") %>
+        </span>
+      </div>
+    </div>
+
+    <h2>Full Decoded JWT Claims</h2>
+    <pre><%= JSON.pretty_generate(@claims) %></pre>
+  </div>
+</body>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -132,6 +132,13 @@ Rails.application.routes.draw do
   # lti
   scope "lti"  do
     match 'launch', to: 'lti#launch', via: [:get, :post]
+
+    # LTI 1.3 OIDC launch flow (alongside existing LTI 1.1)
+    namespace :v1p3, module: 'lti/v1p3' do
+      get  'jwks',          to: 'launches#jwks'
+      post 'oidc/login',    to: 'launches#oidc_login',    as: :oidc_login
+      post 'oidc/callback', to: 'launches#oidc_callback', as: :oidc_callback
+    end
   end
 
   mount Commontator::Engine => "/commontator"

--- a/db/migrate/20260326040000_add_lti_deployment_id_to_assignments.rb
+++ b/db/migrate/20260326040000_add_lti_deployment_id_to_assignments.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddLtiDeploymentIdToAssignments < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_column :assignments, :lti_deployment_id, :string, null: true
+    add_index  :assignments, :lti_deployment_id, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20260326040001_create_lti_platforms.rb
+++ b/db/migrate/20260326040001_create_lti_platforms.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreateLtiPlatforms < ActiveRecord::Migration[8.0]
+  def change
+    create_table :lti_platforms do |t|
+      t.string :issuer,        null: false
+      t.string :client_id,     null: false
+      t.string :auth_url,      null: false
+      t.string :token_url,     null: false
+      t.string :jwks_url,      null: false
+      t.string :deployment_id
+      t.timestamps
+    end
+    # Index added inside create_table transaction is safe for new tables
+    add_index :lti_platforms, [:issuer, :client_id],
+              unique: true,
+              name: "index_lti_platforms_on_issuer_and_client_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_31_010356) do
+ActiveRecord::Schema[8.0].define(version: 2026_03_26_040001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -104,7 +104,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_31_010356) do
     t.string "lti_consumer_key"
     t.string "lti_shared_secret"
     t.jsonb "feature_restrictions", default: {}
+    t.string "lti_deployment_id"
     t.index ["group_id"], name: "index_assignments_on_group_id"
+    t.index ["lti_deployment_id"], name: "index_assignments_on_lti_deployment_id"
   end
 
   create_table "collaborations", force: :cascade do |t|
@@ -285,6 +287,18 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_31_010356) do
     t.text "data"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "lti_platforms", force: :cascade do |t|
+    t.string "issuer", null: false
+    t.string "client_id", null: false
+    t.string "auth_url", null: false
+    t.string "token_url", null: false
+    t.string "jwks_url", null: false
+    t.string "deployment_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["issuer", "client_id"], name: "index_lti_platforms_on_issuer_and_client_id", unique: true
   end
 
   create_table "mailkick_opt_outs", force: :cascade do |t|


### PR DESCRIPTION
## Summary
Adds LTI 1.3 OIDC launch flow alongside the existing LTI 1.1 
implementation as a GSoC 2026 proof of concept.

## What's New
- `GET  /lti/v1p3/jwks` — serves tool RSA public key
- `POST /lti/v1p3/oidc/login` — OIDC login initiation
- `POST /lti/v1p3/oidc/callback` — JWT verification + claims render
- `LtiPlatform` model for storing platform registrations
- Zero new gems — uses jwt 2.10.2 already in Gemfile

## What's Untouched
- `app/controllers/lti_controller.rb` — LTI 1.1 unchanged
- `app/services/lti_score_submission.rb` — grade passback unchanged
- `spec/requests/lti_spec.rb` — all 5 existing tests pass

## Tested With
saLTIre platform emulator — successful OIDC launch confirmed 
with full decoded JWT claims including AGS grade passback endpoint.

## Screenshots
<img width="1470" height="956" alt="Screenshot 2026-03-26 at 11 11 24 AM" src="https://github.com/user-attachments/assets/648cd36d-7df2-4f38-b6b2-b138f5810c26" />


## Related
GSoC 2026 application — Assignment Suite & Classroom Workflow 
Enhancement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LTI 1.3 OIDC third-party login support for educational platform integrations
  * Implemented secure authentication verification for platform connections

* **Documentation**
  * Added comprehensive setup guide for LTI 1.3 configuration and deployment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->