### PR TITLE
Add model-level validation for assignment deadline

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -19,7 +19,18 @@ class Assignment < ApplicationRecord
   has_many :grades, dependent: :destroy
 
   has_noticed_notifications model_name: "NoticedNotification", dependent: :destroy
+  
+  validate :deadline_cannot_be_in_the_past
 
+  private
+  def deadline_cannot_be_in_the_past
+    return if deadline.blank?
+
+    if deadline < Time.current
+      errors.add(:deadline, "cannot be in the past")
+    end  
+  end
+  
   def notify_recipient
     group.group_members.each do |group_member|
       NewAssignmentNotification.with(assignment: self).deliver_later(group_member.user)

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -20,9 +20,10 @@ class Assignment < ApplicationRecord
 
   has_noticed_notifications model_name: "NoticedNotification", dependent: :destroy
   
-  validate :deadline_cannot_be_in_the_past
+  validate :deadline_cannot_be_in_the_past, if: :deadline_changed?
 
   private
+  
   def deadline_cannot_be_in_the_past
     return if deadline.blank?
 


### PR DESCRIPTION
This PR adds a model-level validation to ensure assignment deadlines cannot be set in the past.

## Changes:
- Introduced `deadline_cannot_be_in_the_past` validation in Assignment model
- Ensures validation is applied consistently across create and update flows

## Why:
Previously, validation was handled at the controller level, which can lead to duplication and inconsistencies. Moving this logic to the model ensures a single source of truth and aligns with Rails best practices.

This improves maintainability and ensures correctness across all entry points.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prevents assignment deadlines from being set in the past when a deadline is changed.
  * Leaves blank deadlines untouched and only validates when the deadline value is modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->