### PR TITLE
Fix TypeError when page param is not a hash in paginate

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 nodejs 22.13.0
-ruby 3.2.2
+ruby 3.4.4
 yarn 1.22.19

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 nodejs 22.13.0
-ruby 3.4.4
+ruby 3.2.2
 yarn 1.22.19

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -65,11 +65,18 @@ class Api::V1::BaseController < ActionController::API
   end
 
   def paginate(resource)
-    page_params = params.to_unsafe_h["page"]
-    page_params = {} unless page_params.is_a?(Hash)
+    page_param = params.to_unsafe_h["page"]
+
+    page_number, per_page =
+      if page_param.is_a?(Hash)
+        [page_param["number"], page_param["size"]]
+      else
+        [page_param, nil]
+      end
+
     resource.paginate(
-      page: (page_params["number"] || 1).to_i,
-      per_page: (page_params["size"] || DEFAULT_PER_PAGE).to_i
+      page: (page_number || 1).to_i,
+      per_page: (per_page || DEFAULT_PER_PAGE).to_i
     )
   end
 

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -65,9 +65,11 @@ class Api::V1::BaseController < ActionController::API
   end
 
   def paginate(resource)
+    page_params = params.to_unsafe_h["page"]
+    page_params = {} unless page_params.is_a?(Hash)
     resource.paginate(
-      page: (params.to_unsafe_h.dig("page", "number") || 1).to_i,
-      per_page: (params.to_unsafe_h.dig("page", "size") || DEFAULT_PER_PAGE).to_i
+      page: (page_params["number"] || 1).to_i,
+      per_page: (page_params["size"] || DEFAULT_PER_PAGE).to_i
     )
   end
 


### PR DESCRIPTION
Fixes #7236

#### Describe the changes you have made in this PR -

This PR fixes a TypeError caused by calling `.dig` on `params[:page]` when it is a String instead of a Hash.

Previously, the code assumed that `params[:page]` would always be a nested hash (e.g., `page[number]=2`). However, when a request is made with `page=2`, `params[:page]` becomes a String, causing `.dig` to raise a TypeError.

This fix ensures that `params[:page]` is treated as a Hash before accessing nested keys. If it is not a Hash, it safely defaults to an empty hash, preventing crashes and maintaining expected pagination behavior.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The issue occurs because `params[:page]` can be either a Hash or a String depending on how the request is structured. When using nested parameters like `page[number]=2`, it is a Hash, but when using `page=2`, it becomes a String.

The original implementation used `.dig("page", "number")`, which assumes `page` is always a Hash. This caused a TypeError when `page` was a String.

To fix this, I first extract `page_params` and ensure it is a Hash. If it is not, I default it to an empty Hash. This allows safe access to `"number"` and `"size"` without raising errors.

Alternative approaches considered:
- Using safe navigation or conditional checks inline
- Handling invalid formats by raising an error

I chose this approach because it is simple, defensive, and maintains backward compatibility by gracefully handling unexpected input instead of breaking the API.

Key logic:
- Normalize `params[:page]` into a Hash
- Safely access `"number"` and `"size"`
- Default to fallback values when missing

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced API pagination handling to properly support different input parameter formats while maintaining consistent default page sizing behavior across requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->