### PR TITLE
fix: add Hindi localization for Recent Circuits section

### DIFF
--- a/config/locales/views/explore/hi.yml
+++ b/config/locales/views/explore/hi.yml
@@ -1,1 +1,7 @@
 hi:
+  explore:
+    tabs:
+      recent: "हाल के सर्किट"
+    sections:
+      recent:
+        heading: "हाल के सर्किट"


### PR DESCRIPTION
### Description
Fixes #[3552]

**Root Cause:**
The Hindi localization file for the explore page (`config/locales/views/explore/hi.yml`) was completely empty, causing the `i18n` system to fall back to English for the "Recent Circuits" tab and heading.

**Fix Explanation:**
Added the proper Hindi translation ("हाल के सर्किट") for both the `tabs.recent` and `sections.recent.heading` keys under the `explore` namespace in `hi.yml`.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Translation/Localization update

### Before / After
*Before:* When switching to Hindi, the explorer tabs displayed "Recent Circuits" in English.
*After:* The text correctly converts to "हाल के सर्किट".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Added Hindi language translations for the Explore section, including labels for recent items navigation and section headings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->