### PR TITLE
fix(tests): restore test suite after Devise confirmable tightening (CVE-2026-32700)

### DIFF
--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     name   { Faker::Name.name }
     locale { "en" }
     admin  { false }
+    confirmed_at { Time.current }
 
     trait :admin do
       admin { true }

--- a/spec/system/signup_spec.rb
+++ b/spec/system/signup_spec.rb
@@ -59,6 +59,8 @@ describe "Sign up", type: :system do
     fill_in "Password", with: "secret"
     click_button "Sign up"
 
-    expect(page).to have_text("Welcome! You have signed up successfully.")
+    # With devise :confirmable enabled, users must confirm their email before logging in.
+    # Devise shows a confirmation notice instead of an immediate welcome message.
+    expect(page).to have_text("A message with a confirmation link has been sent to your email address.")
   end
 end


### PR DESCRIPTION

Fixes #7265 

#### Describe the changes you have made in this PR -
Commit 9e277d0 commented out allow_unconfirmed_access_for = 30.days to address CVE-2026-32700 (Devise confirmable race condition on email change). This was the right security call, but it silently broke 300+ tests because factory-created users have no confirmed_at timestamp, Devise now rejects their authentication entirely.

Two changes:

1. **spec/factories/user.rb**:  Added confirmed_at { Time.current } to the base user factory. Tests should never depend on the unconfirmed-access grace period; users in specs should be explicitly confirmed.

2. **spec/system/signup_spec.rb**: Updated the expected flash message in the sign-up system test. Before the CVE fix, the grace period meant users were signed in immediately after registration, showing "Welcome! You have signed up successfully.". With confirmable properly enforced, the correct response is the confirmation email notice. The old expectation was only passing because of the loophole.


### Screenshots of the UI changes (If any) -
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The root cause was a mismatch between what the security fix expected (confirmed users) and what the test setup provided (unconfirmed factory users). Rather than weakening the security fix, I made the test infrastructure match it.

I considered re-enabling allow_unconfirmed_access_for in the test environment only, but that would complicate the security fix and make tests diverge from production behaviour. Setting confirmed_at directly in the factory is simpler and more honest, it says "this test user is a valid, confirmed account" without touching Devise configuration at all.

The signup spec change documents real app behaviour: with confirmable on, registration requires email confirmation. The previous expectation was testing the side-effect of a security loophole, not the intended flow.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated user factory to create confirmed test users by default
  * Modified signup test expectations to align with email confirmation flow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->