### PR TITLE
fix: resolve statement timeouts and n+1 on avo project index pages

### DIFF
--- a/app/avo/resources/project.rb
+++ b/app/avo/resources/project.rb
@@ -8,6 +8,15 @@ class Avo::Resources::Project < Avo::BaseResource
     query: -> { query.text_search(params[:q]) }
   }
 
+  # Exclude heavy columns on index to prevent statement timeouts
+  self.index_query = lambda {
+    query.select(
+      :id, :name, :author_id, :forked_project_id, :project_access_type,
+      :assignment_id, :project_submission, :image_preview, :view,
+      :slug, :stars_count, :created_at, :updated_at
+    )
+  }
+
   # rubocop:disable Metrics/MethodLength
   def fields
     field :id, as: :id, link_to_record: true
@@ -27,11 +36,11 @@ class Avo::Resources::Project < Avo::BaseResource
     field :image_preview, as: :external_image, hide_on: %i[edit new] do
       record.image_preview.url if record.image_preview.present?
     end
-    field :description, as: :textarea
+    field :description, as: :textarea, hide_on: %i[index]
     field :view, as: :number, sortable: true
     field :slug, as: :text, readonly: true, help: "Auto-generated from name"
-    field :lis_result_sourced_id, as: :text
-    field :version, as: :text
+    field :lis_result_sourced_id, as: :text, hide_on: %i[index]
+    field :version, as: :text, hide_on: %i[index]
     field :stars_count, as: :number, readonly: true, sortable: true
 
     field :forks, as: :has_many
@@ -42,10 +51,10 @@ class Avo::Resources::Project < Avo::BaseResource
     field :taggings, as: :has_many
     field :tags, as: :has_many
     field :tag_list, as: :tags
-    field :circuit_preview, as: :file
+    field :circuit_preview, as: :file, hide_on: %i[index]
 
     field :featured_circuit, as: :has_one
-    field :grade, as: :has_one
+    field :grade, as: :has_one, hide_on: %i[index]
     field :project_datum, as: :has_one
     field :contest_winner, as: :has_one
     field :submissions, as: :has_many

--- a/app/avo/resources/project_datum.rb
+++ b/app/avo/resources/project_datum.rb
@@ -4,11 +4,14 @@ class Avo::Resources::ProjectDatum < Avo::BaseResource
   self.title = :id
   self.includes = %i[project]
   self.model_class = ::ProjectDatum
+  self.index_query = lambda {
+    query.select(:id, :project_id, :created_at, :updated_at)
+  }
 
   def fields
-    field :id, as: :id, link_to_resource: true
+    field :id, as: :id, link_to_record: true
     field :project, as: :belongs_to, required: true, searchable: true
-    field :data, as: :textarea, readonly: true
+    field :data, as: :textarea, readonly: true, hide_on: %i[index]
 
     field :created_at, as: :date_time, readonly: true, sortable: true
     field :updated_at, as: :date_time, readonly: true


### PR DESCRIPTION


Fixes #7329 , #7327 ,  #7322

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -

Picked up two statement timeout errors and one N+1 query flagged by Sentry on the Avo admin project index pages.

**CIRCUITVERSE-CORE-11W** — `Avo::ProjectDataController#index` was doing  `SELECT *` on the `project_data` table which includes a `data TEXT` column storing full circuit JSON (can be hundreds of KB per row). Fetching 24 of these at once was consistently hitting the statement timeout in production.

**CIRCUITVERSE-CORE-121** — `Avo::ProjectsController#index` had the same issue with `description TEXT` being fetched on every index load, plus a N+1 on `grades` since it wasn't included in the eager load.

### Screenshots of the UI changes (If any) -
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem was straightforward once I looked at the SQL being generated Avo's default behaviour is SELECT * which pulls every column including large TEXT blobs. Avo v3 provides `self.index_query` specifically to override the query scope for the index action without affecting show/edit pages. Paired with `hide_on: %i[index]` on the field definitions so the UI is consistent 
with what's actually being queried.

Considered just increasing the statement_timeout but that would be masking the problem. Also considered adding indexes but the existing PK and project_id indexes are sufficient the real issue was data volume being transferred, not query planning.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized admin panel performance through refined data retrieval queries for faster list page loading
  * Streamlined project and data list views by removing non-essential fields to improve visual clarity
  * Enhanced navigation with improved linking behavior in project data records
  * Improved overall admin interface responsiveness and usability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->