### PR TITLE
chore: add auto labeler workflow (#7258)

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,42 @@
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.md'
+          - 'docs/**'
+
+javascript:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.js'
+          - '**/*.jsx'
+          - '**/*.ts'
+          - '**/*.tsx'
+
+ruby:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.rb'
+          - 'Gemfile'
+          - 'Gemfile.lock'
+
+docker:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'Dockerfile'
+          - 'docker-compose*.yml'
+          - '.docker/**'
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'package.json'
+          - 'package-lock.json'
+          - 'yarn.lock'
+          - 'Gemfile'
+          - 'Gemfile.lock'
+
+infra:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/workflows/**'
+          - '.github/dependabot.yml'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -24,6 +24,7 @@ docker:
       - any-glob-to-any-file:
           - 'Dockerfile'
           - 'docker-compose*.yml'
+          - 'docker-compose*.yaml'
           - '.docker/**'
 
 dependencies:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,19 @@
+name: Auto Label Pull Requests
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Label pull request
+        uses: actions/labeler@v5
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
Fixes #7258

#### Describe the changes you have made in this PR -

Added a GitHub Actions auto-labeler workflow for pull requests.

Changes made:

* Added `.github/workflows/labeler.yml`
* Added `.github/labeler.yml`
* Added label rules for documentation, JavaScript, Ruby, Docker, dependencies, and infra-related file changes
* Used existing repository labels only

### Screenshots of the UI changes (If any) -

No UI changes. This PR only adds GitHub Actions workflow/configuration files.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**

* [x] No, I wrote all the code myself
* [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**

* [x] I have reviewed every single line of the AI-generated code
* [x] I can explain the purpose and logic of each function/component I added
* [x] I have tested edge cases and understand how the code handles them
* [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

This PR solves the issue by adding an automatic pull request labeling workflow. The workflow uses GitHub Actions to check changed files in a pull request and apply matching existing labels.

I chose a configuration-based approach using `actions/labeler` because it keeps the solution simple, maintainable, and focused on repository automation without changing application code.

The workflow file `.github/workflows/labeler.yml` runs when a pull request is opened, synchronized, or reopened.

The configuration file `.github/labeler.yml` defines which labels should be applied based on changed file paths. For example:

* Markdown/docs changes receive the `documentation` label
* JavaScript file changes receive the `javascript` label
* Ruby file changes receive the `ruby` label
* Docker-related files receive the `docker` label
* Dependency files receive the `dependencies` label
* GitHub workflow/config changes receive the `infra` label

---

## Checklist before requesting a review

* [x] I have added proper PR title and linked to the issue
* [x] I have performed a self-review of my code
* [x] I can explain the purpose of every function, class, and logic block I added
* [x] I understand why my changes work and have tested them thoroughly
* [x] I have considered potential edge cases and how my code handles them
* [ ] If it is a core feature, I have added thorough tests
* [x] My code follows the project's style guidelines and conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Configured automated PR labeling rules to tag changes to documentation, JavaScript/TypeScript, Ruby, Docker, dependencies, and infra.
  * Added a workflow to automatically apply those labels on pull request events.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CircuitVerse/CircuitVerse/pull/7376?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->