### PR TITLE
fix: tag filtering conflict with pg_search ordering

### DIFF
--- a/app/lib/adapters/pg_adapter.rb
+++ b/app/lib/adapters/pg_adapter.rb
@@ -87,7 +87,10 @@ module Adapters
         tags = extract_tags(query_params[:tag])
         return relation if tags.empty?
 
-        relation.joins(:tags).where(tags: { name: tags }).distinct
+        relation.where(
+          id: Project.joins(:tags)
+                     .where(tags: { name: tags })
+        )
       end
 
       def apply_user_filters(relation, query_params)

--- a/spec/lib/adapters/pg_adapter_spec.rb
+++ b/spec/lib/adapters/pg_adapter_spec.rb
@@ -62,23 +62,18 @@ RSpec.describe Adapters::PgAdapter do
 
     context "with tag filters" do
       let(:query_params) { { tag: "electronics,circuit", page: 1 } }
-      let(:tag_filtered_results) do
-        instance_double(ActiveRecord::Relation).tap do |results|
-          allow(results).to receive_messages(includes: results, paginate: paginated_results)
-        end
-      end
+      let(:tag_subquery) { double }
 
       before do
-        allow(mock_results).to receive(:joins).with(:tags).and_return(mock_results)
-        allow(mock_results).to receive_messages(where: mock_results, distinct: tag_filtered_results)
+        allow(Project).to receive(:joins).with(:tags).and_return(tag_subquery)
+        allow(tag_subquery).to receive(:where).with(tags: { name: %w[electronics circuit] }).and_return(tag_subquery)
+        allow(mock_results).to receive(:where).with(id: tag_subquery).and_return(mock_results)
       end
 
-      it "filters by tags" do
+      it "filters using a subquery to avoid DISTINCT conflict with pg_search ordering" do
         adapter.search_project(project_relation, query_params)
 
-        expect(mock_results).to have_received(:joins).with(:tags)
-        expect(mock_results).to have_received(:where).with(tags: { name: %w[electronics circuit] })
-        expect(mock_results).to have_received(:distinct)
+        expect(mock_results).to have_received(:where).with(id: tag_subquery)
       end
     end
   end


### PR DESCRIPTION
Fixes #7389 
<!-- Add issue number above --> 

This PR targets the sentry issue where earlier the tag filtering used joins(:tags) with distinct directly on the existing relation.
When combined with pg_search, PostgreSQL raised: `PG::InvalidColumnReference:for SELECT DISTINCT, ORDER BY expressions must appear in select list` 

The issue occurred because pg_search adds ranking (pg_search_rank) to ORDER BY, which conflicted with DISTINCT.

#### Describe the changes you have made in this PR -

Now this PR uses a subquery that fetches matching project IDs. The main search relation now filters using where(id: ...) instead of applying distinct directly. Search ranking and ordering from pg_search remain unchanged. 
Eliminates PostgreSQL DISTINCT + ORDER BY conflicts while preserving expected search behavior.

### Screenshots of the UI changes (If any) -
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized project tag filtering to improve query performance and efficiency.
* **Tests**
  * Updated project tag filter tests to align with the new query approach.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CircuitVerse/CircuitVerse/pull/7402?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->