### PR TITLE
Fix #7197: Show 'No circuits found' message

### DIFF
--- a/app/views/users/circuitverse/index.html.erb
+++ b/app/views/users/circuitverse/index.html.erb
@@ -123,6 +123,16 @@
         <%= render partial: "dashboard", locals: { projects: @collaborated_projects } %>
       <% end %>
     </div>
+    <div id="search-no-results" class="search-no-results-container" style="display:none;">
+  <div class="row center-row">
+    <div class="col-12">
+      <div class="search-no-results-image">
+        <%= image_tag "svgs/noResult.svg", alt: "No result image" %>
+        <h6><%= t("users.circuitverse.index.no_search_results") %></h6>
+      </div>
+    </div>
+  </div>
+</div>
 
   </div>
 </div>
@@ -178,6 +188,7 @@
     if(searchQuery) {
       // Mark everything as hidden initially
       projects.hide();
+      $('#search-no-results').hide();
       // Find matches
       var matches = fuse.search(searchQuery);
       var matchMap = {}
@@ -186,6 +197,9 @@
           // mark matches as visible
           $(match.item.domObj).show();
       })
+      if(matches.length === 0){
+        $('#search-no-results').show();
+      }
       // Helper function used for sorting cards
       function getSortIndex(circuitDiv) {
         var title = getTitle(circuitDiv);
@@ -207,6 +221,7 @@
       });
     } else { // if searchQuery is empty -> display everything
       projects.show();
+      $('#search-no-results').hide();
     }
   })
 
@@ -218,20 +233,24 @@
     $('#collaborator-circuits-div').hide();
     var circuitTabs = ['favourite-circuits', 'my-circuits', 'collaborator-circuits'];
     $('.users-circuits-tab').on('click', function (e) {
-      if(!$(this).hasClass("active")) {
-        var id = this.id;
-        $(this).addClass("active");
-        circuitTabs.forEach(element => {
-          var div = `#${element}-div`;
-          if(element == id) {
-            $(div).css("display", "flex");
-          }
-          else {
-            $('#' + element).removeClass("active");
-            $(div).css("display", "none");
-          }
-        });
-      }});
+  if(!$(this).hasClass("active")) {
+    var id = this.id;
+    $(this).addClass("active");
+    circuitTabs.forEach(element => {
+      var div = `#${element}-div`;
+      if(element == id) {
+        $(div).css("display", "flex");
+      }
+      else {
+        $('#' + element).removeClass("active");
+        $(div).css("display", "none");
+      }
+    });
+    // Reset search state on tab switch
+    $('.users-circuits-search').val('');
+    projects.show();
+    $('#search-no-results').hide();
+  }});
     $('.previewButton').on('click', function (e) {
         e.preventDefault()
         let project = $(e.currentTarget).data('currentproject').id;

--- a/app/views/users/circuitverse/index.html.erb
+++ b/app/views/users/circuitverse/index.html.erb
@@ -197,8 +197,12 @@
           // mark matches as visible
           $(match.item.domObj).show();
       })
-      if(matches.length === 0){
-        $('#search-no-results').show();
+      if(matches.length === 0) {
+        const activeTab = $('.users-circuits-tab.active').attr('id');
+        const activeDiv = $(`#${activeTab}-div`);
+        if(activeDiv.find('.circuit-card-js').length > 0) {
+          $('#search-no-results').show();
+        }
       }
       // Helper function used for sorting cards
       function getSortIndex(circuitDiv) {

--- a/config/locales/views/users/ar.yml
+++ b/config/locales/views/users/ar.yml
@@ -49,6 +49,7 @@ ar:
         no_user_projects: "لا يملك %{name} أي مشاريع."
         no_favourites_heading_html: "ليس لديك أي مفضلة. أنشئ %{simulator_new_url}"
         not_a_collaborator: "أنت لست متعاوناً مع أي مشروع."
+        no_search_results: "لم يتم العثور على دوائر"
       search:
         no_results: "لم يتم العثور على نتائج"
     mailer:

--- a/config/locales/views/users/bn.yml
+++ b/config/locales/views/users/bn.yml
@@ -49,6 +49,7 @@ bn:
         no_user_favourites: "%{name} -এর কোনো প্রিয় সার্কিট নেই।"
         not_a_collaborator: "আপনি কোনো প্রকল্পের সহযোগী নন।"
         user_not_a_collaborator: "%{name} কোনো প্রকল্পের সহযোগী নয়।"
+        no_search_results: "কোনো সার্কিট পাওয়া যায়নি"
       search:
         no_results: "কোন ফলাফল পাওয়া যায়নি"
     mailer:

--- a/config/locales/views/users/de.yml
+++ b/config/locales/views/users/de.yml
@@ -52,6 +52,7 @@ de:
         no_user_favourites: "%{name} hat keine Favoriten."
         not_a_collaborator: "Sie sind kein Mitarbeiter eines Projekts."
         user_not_a_collaborator: "%{name} ist kein Mitarbeiter eines Projekts."
+        no_search_results: "Keine Schaltkreise gefunden"
       search:
         no_results: "Keine Ergebnisse gefunden"
     mailer:

--- a/config/locales/views/users/en.yml
+++ b/config/locales/views/users/en.yml
@@ -52,6 +52,7 @@ en:
         no_user_favourites: "%{name} doesn't have any favourites."
         not_a_collaborator: "You are not a collaborator of any project."
         user_not_a_collaborator: "%{name} is not a collaborator of any project."
+        no_search_results: "No circuits found"
       search:
         no_results: "No Results Found"
     mailer:

--- a/config/locales/views/users/es.yml
+++ b/config/locales/views/users/es.yml
@@ -52,6 +52,7 @@ es:
         no_user_favourites: "%{name} no tiene ningún favorito."
         not_a_collaborator: "No eres un colaborador de ningún proyecto."
         user_not_a_collaborator: "%{name} no es un colaborador de ningún proyecto."
+        no_search_results: "No se encontraron circuitos"
       search:
         no_results: "No se encontraron resultados"
     mailer:

--- a/config/locales/views/users/fr.yml
+++ b/config/locales/views/users/fr.yml
@@ -52,6 +52,7 @@ fr:
         no_user_favourites: "%{name} n'a aucun favori."
         not_a_collaborator: "Vous n'êtes pas un collaborateur d'aucun projet."
         user_not_a_collaborator: "%{name} n'est pas un collaborateur d'aucun projet."
+        no_search_results: "Aucun circuit trouvé"
       search:
         no_results: "Aucun résultat trouvé"
     mailer:

--- a/config/locales/views/users/hi.yml
+++ b/config/locales/views/users/hi.yml
@@ -49,6 +49,7 @@ hi:
         no_user_favourites: "%{name} के द्वारा पसंद की गयी कोई परियोजना नहीं है।"
         not_a_collaborator: "आप किसी परियोजना के सहयोगी नहीं हैं।"
         user_not_a_collaborator: "%{name} किसी भी परियोजना के सहयोगी नहीं है।"
+        no_search_results: "कोई सर्किट नहीं मिला"
       search:
         no_results: "कोई परिणाम नहीं मिला"
     mailer:

--- a/config/locales/views/users/ja.yml
+++ b/config/locales/views/users/ja.yml
@@ -52,6 +52,7 @@ ja:
         no_user_favourites: "%{name} にはお気に入りがありません。"
         not_a_collaborator: "あなたはどのプロジェクトの共同編集者でもありません。"
         user_not_a_collaborator: "%{name} はどのプロジェクトの共同作業者でもありません。"
+        no_search_results: "回路が見つかりません"
       search:
         no_results: "結果が見つかりませんでした"
     mailer:

--- a/config/locales/views/users/mr.yml
+++ b/config/locales/views/users/mr.yml
@@ -48,6 +48,7 @@ mr:
         no_user_favourites: "%{name} ला आवडलेले कोणतेही प्रकल्प नाहीत."
         not_a_collaborator: "तुम्ही प्रकल्प सहयोगी नाही."
         user_not_a_collaborator: "%{name} कोणत्याही प्रकल्पासाठी योगदानकर्ता नाही."
+        no_search_results: "कोणतेही सर्किट आढळले नाही"
       search:
         no_results: "कोणताही परिणाम आढळला नाही"
     mailer:

--- a/config/locales/views/users/ne.yml
+++ b/config/locales/views/users/ne.yml
@@ -49,6 +49,7 @@ ne:
         no_user_favourites: "%{name}सँग कुनै मनपर्ने छैन।"
         not_a_collaborator: "तपाईं कुनै परियोजनाको सहयोगी हुनुहुन्न।"
         user_not_a_collaborator: "%{name} कुनै परियोजनाको सहयोगी होइन।"
+        no_search_results: "कुनै सर्किट फेला परेन"
       search:
         no_results: "कुनै परिणाम फेला परेन"
     mailer:


### PR DESCRIPTION
#7197 

#### Describe the changes you have made in this PR -
On the user profile page (`/users/:id`), when a user searched for a circuit with no matching results, the page showed a completely blank area. This PR fixes that by displaying a "No circuits found" message with the `noResult.svg` illustration.

Changes made:
- Added a hidden `#search-no-results` div inside `users-circuits-container` with `noResult.svg` and a "No circuits found" message
- Updated the Fuse.js `keyup` handler to show the message when `matches.length === 0`, hide it when search starts, and hide it when search is cleared
- Added reset logic on tab switch so the no-results message is hidden and search bar is cleared when switching between My Circuits / Favourite Circuits / Collaborated Circuits tabs
- Added `no_search_results: "No circuits found"` translation key to `config/locales/views/users/en.yml`

### Screenshots of the UI changes (If any) -
before
<img width="1780" height="638" alt="image" src="https://github.com/user-attachments/assets/f25bb045-e149-46ee-b08a-86d3e2cc356c" />
after
<img width="1580" height="756" alt="image" src="https://github.com/user-attachments/assets/4368b709-4ea9-44dc-9ea6-4fb6b63267d2" />


---

## Code Understanding and AI Usage
**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The problem was that the Fuse.js keyup handler hid all `.circuit-card-js` elements when searching but showed nothing when zero matches were returned, leaving a blank area.

The fix adds a hidden `#search-no-results` div (using the existing `search-no-results-container` and `search-no-results-image` CSS classes already used by the global search page) that is toggled via jQuery based on `matches.length === 0`. The same `noResult.svg` illustration used on the global search page is reused here for visual consistency. The tab switching handler was also updated to reset the search state (clear input, show all circuits, hide no-results message) so the message does not persist incorrectly when switching tabs.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a localized "No circuits found" message displayed when a circuits search returns no results (multiple languages supported).
  * Introduced a hidden no-results indicator that appears only when a search yields zero matches and the circuits tab is active.

* **Bug Fixes**
  * Search UI now resets on tab switches: clears query, restores project lists, and hides the no-results message.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CircuitVerse/CircuitVerse/pull/7423?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->