### PR TITLE
Fix/imgur upload error

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@ GITHUB_CLIENT_ID=<github-client-id>
 GITHUB_CLIENT_SECRET=<github-client-secret>
 GITLAB_CLIENT_ID=<gitlab-client-id>
 GITLAB_CLIENT_SECRET=<gitlab-client-secret>
+IMGUR_CLIENT_ID=<imgur-client-id>
 SLACK_ISSUE_HOOK_URL=<Slack-hook-url>
 BUGSNAG_API_KEY=''
 RECAPTCHA_SITE_KEY=<google-recaptcha-site-key>

--- a/app/views/editor/_index.html.erb
+++ b/app/views/editor/_index.html.erb
@@ -1,6 +1,6 @@
 <script>
   window.circuitverseConfig = {
-    imgurClientId: '<%= ENV['IMGUR_CLIENT_ID'] %>'
+    imgurClientId: <%= ENV.fetch('IMGUR_CLIENT_ID', '').to_json %>
   };
 </script>
 <textarea id="trumbowyg"> <%= content %> </textarea>
@@ -46,7 +46,7 @@
     });
   });
 </script>
-
+<script type="text/javascript">
   $.fn.cleanHtml = function () {
       var html = $('#trumbowyg').trumbowyg('html');
       return html && html.replace(/(<br>|\s|<div><br><\/div>|&nbsp;)*$/, '');

--- a/app/views/editor/_index.html.erb
+++ b/app/views/editor/_index.html.erb
@@ -1,9 +1,13 @@
+<script>
+  window.circuitverseConfig = {
+    imgurClientId: '<%= ENV['IMGUR_CLIENT_ID'] %>'
+  };
+</script>
 <textarea id="trumbowyg"> <%= content %> </textarea>
-
 <script type="text/javascript">
   $(document).ready(function() {
     $('#trumbowyg').trumbowyg({
-      svgPath: "https://cdnjs.cloudflare.com/ajax/libs/Trumbowyg/2.20.0/ui/icons.svg",
+      svgPath: 'https://cdnjs.cloudflare.com/ajax/libs/Trumbowyg/2.20.0/ui/icons.svg',
       btnsDef: {
         image: {
           dropdown: ['insertImage', 'upload'],
@@ -30,7 +34,7 @@
           serverPath: 'https://api.imgur.com/3/image',
           fileFieldName: 'image',
           headers: {
-            'Authorization': 'Client-ID 9a33b3b370f1054'
+            'Authorization': 'Client-ID ' + window.circuitverseConfig.imgurClientId
           },
           urlPropertyName: 'data.link',
         },
@@ -41,6 +45,8 @@
       }
     });
   });
+</script>
+
   $.fn.cleanHtml = function () {
       var html = $('#trumbowyg').trumbowyg('html');
       return html && html.replace(/(<br>|\s|<div><br><\/div>|&nbsp;)*$/, '');

--- a/app/views/editor/_index.html.erb
+++ b/app/views/editor/_index.html.erb
@@ -10,7 +10,7 @@
       svgPath: 'https://cdnjs.cloudflare.com/ajax/libs/Trumbowyg/2.20.0/ui/icons.svg',
       btnsDef: {
         image: {
-          dropdown: ['insertImage', 'upload'],
+          dropdown: window.circuitverseConfig.imgurClientId ? ['insertImage', 'upload'] : ['insertImage'],
           ico: 'insertImage'
         }
       },
@@ -30,14 +30,14 @@
         ['fullscreen']
       ],
       plugins: {
-        upload: {
+        upload: window.circuitverseConfig.imgurClientId ? {
           serverPath: 'https://api.imgur.com/3/image',
           fileFieldName: 'image',
           headers: {
             'Authorization': 'Client-ID ' + window.circuitverseConfig.imgurClientId
           },
           urlPropertyName: 'data.link',
-        },
+        } : undefined,
         resizimg: {
           minSize: 64,
           step: 16,

--- a/simulator/src/modules/ImageAnnotation.js
+++ b/simulator/src/modules/ImageAnnotation.js
@@ -123,7 +123,7 @@ export default class ImageAnnotation extends CircuitElement {
     async uploadImage() {
         var file = await promptFile("image/*", false);
         var apiUrl = 'https://api.imgur.com/3/image';
-        var apiKey = process.env.IMGUR_CLIENT_ID;
+        var apiKey = window.circuitverseConfig ? window.circuitverseConfig.imgurClientId : null;
 
         if (!apiKey) {
             console.error('Error: IMGUR_CLIENT_ID is not defined in the environment variables.');
@@ -150,11 +150,12 @@ export default class ImageAnnotation extends CircuitElement {
         // Response contains stringified JSON
         // Image URL available at response.data.link
         showMessage('Uploading Image');
-        try {
-            var response = await $.ajax(settings);
-            showMessage('Image Uploaded');
-            this.imageUrl = JSON.parse(response).data.link;
-            this.loadImage();
+        var response = await $.ajax(settings);
+        showMessage('Image Uploaded');
+        this.imageUrl = JSON.parse(response).data.link;
+        this.loadImage();
+    }
+
         } catch (error) {
             console.error('Imgur upload failed:', error);
             showMessage('Error uploading image to Imgur. Check console for details.');

--- a/simulator/src/modules/ImageAnnotation.js
+++ b/simulator/src/modules/ImageAnnotation.js
@@ -121,41 +121,40 @@ export default class ImageAnnotation extends CircuitElement {
     }
 
     async uploadImage() {
-        var file = await promptFile("image/*", false);
-        var apiUrl = 'https://api.imgur.com/3/image';
-        var apiKey = window.circuitverseConfig ? window.circuitverseConfig.imgurClientId : null;
+        try {
+            var file = await promptFile("image/*", false);
+            var apiUrl = 'https://api.imgur.com/3/image';
+            var apiKey = window.circuitverseConfig ? window.circuitverseConfig.imgurClientId : null;
 
-        if (!apiKey) {
-            console.error('Error: IMGUR_CLIENT_ID is not defined in the environment variables.');
-            showMessage('Error: Imgur API key not configured. Please contact an administrator.');
-            return;
-        }
+            if (!apiKey) {
+                console.error('Error: IMGUR_CLIENT_ID is not defined in the environment variables.');
+                showMessage('Error: Imgur API key not configured. Please contact an administrator.');
+                return;
+            }
 
-        var settings = {
-            crossDomain: true,
-            processData: false,
-            contentType: false,
-            type: 'POST',
-            url: apiUrl,
-            headers: {
-            Authorization: 'Client-ID ' + apiKey,
-            Accept: 'application/json',
-            },
-            mimeType: 'multipart/form-data',
-        };
-        var formData = new FormData();
-        formData.append('image', file);
-        settings.data = formData;
+            var settings = {
+                crossDomain: true,
+                processData: false,
+                contentType: false,
+                type: 'POST',
+                url: apiUrl,
+                headers: {
+                Authorization: 'Client-ID ' + apiKey,
+                Accept: 'application/json',
+                },
+                mimeType: 'multipart/form-data',
+            };
+            var formData = new FormData();
+            formData.append('image', file);
+            settings.data = formData;
 
-        // Response contains stringified JSON
-        // Image URL available at response.data.link
-        showMessage('Uploading Image');
-        var response = await $.ajax(settings);
-        showMessage('Image Uploaded');
-        this.imageUrl = JSON.parse(response).data.link;
-        this.loadImage();
-    }
-
+            // Response contains stringified JSON
+            // Image URL available at response.data.link
+            showMessage('Uploading Image');
+            var response = await $.ajax(settings);
+            showMessage('Image Uploaded');
+            this.imageUrl = JSON.parse(response).data.link;
+            this.loadImage();
         } catch (error) {
             console.error('Imgur upload failed:', error);
             showMessage('Error uploading image to Imgur. Check console for details.');

--- a/simulator/src/modules/ImageAnnotation.js
+++ b/simulator/src/modules/ImageAnnotation.js
@@ -123,6 +123,9 @@ export default class ImageAnnotation extends CircuitElement {
     async uploadImage() {
         try {
             var file = await promptFile("image/*", false);
+            if (!file) {
+                return; // User cancelled
+            }
             var apiUrl = 'https://api.imgur.com/3/image';
             var apiKey = window.circuitverseConfig ? window.circuitverseConfig.imgurClientId : null;
 
@@ -139,7 +142,7 @@ export default class ImageAnnotation extends CircuitElement {
                 type: 'POST',
                 url: apiUrl,
                 headers: {
-                Authorization: 'Client-ID ' + apiKey,
+                Authorization: `Client-ID ${apiKey}`,
                 Accept: 'application/json',
                 },
                 mimeType: 'multipart/form-data',

--- a/simulator/src/modules/ImageAnnotation.js
+++ b/simulator/src/modules/ImageAnnotation.js
@@ -123,7 +123,14 @@ export default class ImageAnnotation extends CircuitElement {
     async uploadImage() {
         var file = await promptFile("image/*", false);
         var apiUrl = 'https://api.imgur.com/3/image';
-        var apiKey = '9a33b3b370f1054';
+        var apiKey = process.env.IMGUR_CLIENT_ID;
+
+        if (!apiKey) {
+            console.error('Error: IMGUR_CLIENT_ID is not defined in the environment variables.');
+            showMessage('Error: Imgur API key not configured. Please contact an administrator.');
+            return;
+        }
+
         var settings = {
             crossDomain: true,
             processData: false,
@@ -143,10 +150,15 @@ export default class ImageAnnotation extends CircuitElement {
         // Response contains stringified JSON
         // Image URL available at response.data.link
         showMessage('Uploading Image');
-        var response = await $.ajax(settings);
-        showMessage('Image Uploaded');
-        this.imageUrl = JSON.parse(response).data.link;
-        this.loadImage();
+        try {
+            var response = await $.ajax(settings);
+            showMessage('Image Uploaded');
+            this.imageUrl = JSON.parse(response).data.link;
+            this.loadImage();
+        } catch (error) {
+            console.error('Imgur upload failed:', error);
+            showMessage('Error uploading image to Imgur. Check console for details.');
+        }
     }
 
     async loadImage() {


### PR DESCRIPTION
## Summary
This PR fixes a critical issue where the Imgur API Client-ID was hardcoded in multiple locations, causing 400 Bad Request errors and posing a security risk. It refactors the configuration to use environment variables injected via Rails.

## Changes
- **Backend (Rails):** Updated `app/views/editor/_index.html.erb` to inject `IMGUR_CLIENT_ID` from the environment into a global `window.circuitverseConfig` object. This ensures the API key is loaded dynamically and securely.
- **Frontend (Simulator):** Updated `simulator/src/modules/ImageAnnotation.js` to consume the key from `window.circuitverseConfig` instead of `process.env`. Added a check to warn the user if the `IMGUR_CLIENT_ID` is not configured.
- **Robustness:** Enhanced error handling in the simulator's upload logic with a `try/catch` block, providing user-friendly messages for upload failures.

## Motivation
Hardcoded credentials are a security vulnerability and lead to rigid configuration. This change aligns CircuitVerse with professional standards for environment-based configuration, improving security, maintainability, and user experience.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (improves code structure and security)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Image uploads now use a configurable Imgur client ID so editor and simulator behave consistently.
  * Editor embeds the configured client ID at runtime and surfaces when configuration is missing.
* **Bug Fixes**
  * Upload failures now show clear user-facing error messages and prevent uncaught errors/crashes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CircuitVerse/CircuitVerse/pull/7424?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->