### PR TITLE
Fix/no circuit found

### DIFF
--- a/app/views/users/circuitverse/index.html.erb
+++ b/app/views/users/circuitverse/index.html.erb
@@ -197,12 +197,11 @@
           // mark matches as visible
           $(match.item.domObj).show();
       })
-      if(matches.length === 0) {
-        const activeTab = $('.users-circuits-tab.active').attr('id');
-        const activeDiv = $(`#${activeTab}-div`);
-        if(activeDiv.find('.circuit-card-js').length > 0) {
-          $('#search-no-results').show();
-        }
+      const activeTab = $('.users-circuits-tab.active').attr('id');
+      const activeDiv = $(`#${activeTab}-div`);
+      const activeCards = activeDiv.find('.circuit-card-js');
+      if(activeCards.length > 0 && activeCards.filter(':visible').length === 0) {
+        $('#search-no-results').show();
       }
       // Helper function used for sorting cards
       function getSortIndex(circuitDiv) {

--- a/config/locales/views/users/ar.yml
+++ b/config/locales/views/users/ar.yml
@@ -49,7 +49,6 @@ ar:
         no_user_projects: "لا يملك %{name} أي مشاريع."
         no_favourites_heading_html: "ليس لديك أي مفضلة. أنشئ %{simulator_new_url}"
         not_a_collaborator: "أنت لست متعاوناً مع أي مشروع."
-        no_search_results: "لم يتم العثور على دوائر"
       search:
         no_results: "لم يتم العثور على نتائج"
     mailer:

--- a/config/locales/views/users/bn.yml
+++ b/config/locales/views/users/bn.yml
@@ -49,7 +49,6 @@ bn:
         no_user_favourites: "%{name} -এর কোনো প্রিয় সার্কিট নেই।"
         not_a_collaborator: "আপনি কোনো প্রকল্পের সহযোগী নন।"
         user_not_a_collaborator: "%{name} কোনো প্রকল্পের সহযোগী নয়।"
-        no_search_results: "কোনো সার্কিট পাওয়া যায়নি"
       search:
         no_results: "কোন ফলাফল পাওয়া যায়নি"
     mailer:

--- a/config/locales/views/users/de.yml
+++ b/config/locales/views/users/de.yml
@@ -52,7 +52,6 @@ de:
         no_user_favourites: "%{name} hat keine Favoriten."
         not_a_collaborator: "Sie sind kein Mitarbeiter eines Projekts."
         user_not_a_collaborator: "%{name} ist kein Mitarbeiter eines Projekts."
-        no_search_results: "Keine Schaltkreise gefunden"
       search:
         no_results: "Keine Ergebnisse gefunden"
     mailer:

--- a/config/locales/views/users/es.yml
+++ b/config/locales/views/users/es.yml
@@ -52,7 +52,6 @@ es:
         no_user_favourites: "%{name} no tiene ningún favorito."
         not_a_collaborator: "No eres un colaborador de ningún proyecto."
         user_not_a_collaborator: "%{name} no es un colaborador de ningún proyecto."
-        no_search_results: "No se encontraron circuitos"
       search:
         no_results: "No se encontraron resultados"
     mailer:

--- a/config/locales/views/users/fr.yml
+++ b/config/locales/views/users/fr.yml
@@ -52,7 +52,6 @@ fr:
         no_user_favourites: "%{name} n'a aucun favori."
         not_a_collaborator: "Vous n'êtes pas un collaborateur d'aucun projet."
         user_not_a_collaborator: "%{name} n'est pas un collaborateur d'aucun projet."
-        no_search_results: "Aucun circuit trouvé"
       search:
         no_results: "Aucun résultat trouvé"
     mailer:

--- a/config/locales/views/users/ja.yml
+++ b/config/locales/views/users/ja.yml
@@ -52,7 +52,6 @@ ja:
         no_user_favourites: "%{name} にはお気に入りがありません。"
         not_a_collaborator: "あなたはどのプロジェクトの共同編集者でもありません。"
         user_not_a_collaborator: "%{name} はどのプロジェクトの共同作業者でもありません。"
-        no_search_results: "回路が見つかりません"
       search:
         no_results: "結果が見つかりませんでした"
     mailer:

--- a/config/locales/views/users/mr.yml
+++ b/config/locales/views/users/mr.yml
@@ -48,7 +48,6 @@ mr:
         no_user_favourites: "%{name} ला आवडलेले कोणतेही प्रकल्प नाहीत."
         not_a_collaborator: "तुम्ही प्रकल्प सहयोगी नाही."
         user_not_a_collaborator: "%{name} कोणत्याही प्रकल्पासाठी योगदानकर्ता नाही."
-        no_search_results: "कोणतेही सर्किट आढळले नाही"
       search:
         no_results: "कोणताही परिणाम आढळला नाही"
     mailer:

--- a/config/locales/views/users/ne.yml
+++ b/config/locales/views/users/ne.yml
@@ -49,7 +49,6 @@ ne:
         no_user_favourites: "%{name}सँग कुनै मनपर्ने छैन।"
         not_a_collaborator: "तपाईं कुनै परियोजनाको सहयोगी हुनुहुन्न।"
         user_not_a_collaborator: "%{name} कुनै परियोजनाको सहयोगी होइन।"
-        no_search_results: "कुनै सर्किट फेला परेन"
       search:
         no_results: "कुनै परिणाम फेला परेन"
     mailer:


### PR DESCRIPTION

Fixes #7428

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

This PR fixes an edge case in the user profile circuits search empty state.

Previously, the search no-results message was shown only when Fuse.js returned zero matches globally. Since Fuse indexes circuit cards from all tabs, a query could match a circuit in a hidden tab while showing no results in the currently active tab. In that case, the active tab appeared blank and the “No circuits found” message was not displayed.

Changes made:
- Updated the no-results condition to check the currently active tab instead of relying only on global Fuse.js matches.
- Added logic to find the active circuits tab and its circuit cards.
- Show the “No circuits found” message when the active tab has circuit cards but none are visible after filtering.
- Kept the existing guard that prevents the search empty state from appearing on tabs that already have their own server-rendered empty state.

### Screenshots of the UI changes (If any) -
<!-- Do not add code diff here -->

No visual design changes. This PR only fixes when the existing “No circuits found” empty state is displayed.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The issue was caused by checking `matches.length === 0`, where `matches` contains Fuse.js results from all circuit cards across all tabs. This does not always represent what the user sees in the currently active tab.

For example, if the user is on “My Circuits” and searches for a circuit that exists only in “Favourite Circuits”, Fuse returns a match globally, so the old condition does not show the no-results message. However, the active tab still has no visible matching cards, so the UI appears blank.

This PR changes the condition to inspect the active tab directly:
- Get the active tab from `.users-circuits-tab.active`.
- Find the matching tab content div using the tab id.
- Find circuit cards inside that active tab.
- Show the no-results message only when the active tab has cards but none are visible after search filtering.

I chose this approach because it keeps the existing Fuse.js search behavior unchanged and only fixes the display condition for the empty state. This is a small, targeted change with minimal impact on the rest of the profile page search logic.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed search functionality to correctly display "no results" message only when the currently selected tab has no visible results, improving search feedback accuracy.

* **Localization**
  * Updated translation structure across all supported languages to ensure consistent "no results" messaging in search.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CircuitVerse/CircuitVerse/pull/7429?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->