### PR TITLE
Fix Vue simulator payload storage and API parsing

### DIFF
--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -78,7 +78,12 @@ class Api::V1::ProjectsController < Api::V1::BaseController
     authorize @project, :check_view_access?
     circuit_data = ProjectDatum.find_by(project: @project)
     if circuit_data
-      render json: circuit_data.data
+      parsed_data = begin
+                      Oj.safe_load(circuit_data.data)
+                    rescue StandardError
+                      circuit_data.data
+                    end
+      render json: parsed_data
     else
       render json: { error: "Circuit data unavailabe for the project!" }, status: :not_found
     end

--- a/app/helpers/simulator_helper.rb
+++ b/app/helpers/simulator_helper.rb
@@ -32,11 +32,11 @@ module SimulatorHelper
   end
 
   def sanitize_data(project, data)
-    return data if project&.assignment_id.blank? || data.blank?
+    return (data.is_a?(String) ? data : data.to_json) if project&.assignment_id.blank? || data.blank?
 
-    data = Oj.safe_load(data)
+    data_hash = data.is_a?(String) ? Oj.safe_load(data) : data
     saved_restricted_elements = Oj.safe_load(project.assignment.restrictions)
-    scopes = data["scopes"] || []
+    scopes = data_hash["scopes"] || []
 
     parsed_scopes = scopes.each_with_object([]) do |scope, new_scopes|
       restricted_elements_used = []
@@ -49,7 +49,7 @@ module SimulatorHelper
       new_scopes.push(scope)
     end
 
-    data["scopes"] = parsed_scopes
-    data.to_json
+    data_hash["scopes"] = parsed_scopes
+    data_hash.to_json
   end
 end


### PR DESCRIPTION
# Fix: Vue Simulator Payload Storage and API Parsing
Resolves #7444

This PR fixes the data formatting and parsing bug that caused Vue Simulator projects to load incorrectly due to heavily escaped strings being returned by the API.

## Changes Made
1. **`app/helpers/simulator_helper.rb`**: Updated the `sanitize_data` method to ensure that incoming `Hash` payloads are automatically converted into valid JSON strings via `.to_json` before being saved to the database.
2. **`app/controllers/api/v1/projects_controller.rb`**: Adjusted the `circuit_data` method to parse the stored database string using `Oj.safe_load(circuit_data.data)`. This forces Rails to render a pure JSON object in the response instead of an escaped string.

## Visual Demonstration (Terminal Test)

> [!NOTE]  
> To accurately validate the fix locally without a full Docker/Rails setup, a pure Ruby script (`test_bug.rb`) was used to emulate the exact Controller and ActiveRecord flows. This allowed us to visually compare the data arriving before and after the refactor!

### Bug Simulation Output (Before vs After)

```text
=== SAVING DATA FROM VUE SIMULATOR (Hash payload) ===
BEFORE (sanitize_data output): {"scopes"=>[{"a"=>1}]}
AFTER (sanitize_data output): "{\"scopes\":[{\"a\":1}]}"

=== FETCHING DATA (API Response) ===
DB contains corrupted ruby string: "{\"scopes\"=>[{\"a\"=>1}]}"
API response BEFORE fix: "{\"scopes\"=>[{\"a\"=>1}]}"
API response AFTER fix (on corrupted data): "{\"scopes\"=>[{\"a\"=>1}]}"

=== If saved properly using AFTER fix ===
DB contains valid JSON string: "{\"scopes\":[{\"a\":1}]}"
API response AFTER fix (on valid JSON data): {"scopes":[{"a":1}]}
```

### What does this test prove?
1. In the **SAVING DATA** step, you can see that the `BEFORE` execution was saving Ruby hash rockets (`=>`) to the database. With the `AFTER` additions, a properly formatted JSON string (`:`) is returned and saved cleanly.
2. In the **FETCHING DATA** step, the `BEFORE fix` API response would send a massive, escaped string to the Vue application, which perfectly matches the reported issue. In the final test (`AFTER fix`), we guarantee that the API yields the exact pure object expected by the Vue frontend: `{"scopes":[{"a":1}]}`.

These modifications will completely resolve the error for all newly saved projects originating from the Vue simulator.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of circuit data parsing with fallback handling for invalid input.
  * Enhanced data normalization and scope processing for more reliable simulation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->