### PR TITLE
Fix project loading crash due to unhandled layout_id

### DIFF
--- a/simulator/src/subcircuit.js
+++ b/simulator/src/subcircuit.js
@@ -349,6 +349,7 @@ export default class SubCircuit extends CircuitElement {
             ];
         }
         for (var i = 0; i < this.inputNodes.length; i++) {
+            if (!this.inputNodes[i]) continue;
             if (temp_map_inp.hasOwnProperty(this.inputNodes[i].layout_id)) {
                 temp_map_inp[this.inputNodes[i].layout_id][1] = this.inputNodes[
                     i
@@ -414,6 +415,7 @@ export default class SubCircuit extends CircuitElement {
             ];
         }
         for (var i = 0; i < this.outputNodes.length; i++) {
+            if (!this.outputNodes[i]) continue;
             if (temp_map_out.hasOwnProperty(this.outputNodes[i].layout_id)) {
                 temp_map_out[
                     this.outputNodes[i].layout_id


### PR DESCRIPTION
# Fix: Project Loading Error (Layout ID Undefined)
Resolves #7261

This documentation details the root cause and resolution of a critical bug where projects failed to load in the CircuitVerse simulator, resulting in an infinite loading state or a red screen when attempting fullscreen.

## Problem Overview

The issue was reported on GitHub in [Issue #7261](https://github.com/CircuitVerse/CircuitVerse/issues/7261).

- **Symptoms:** When trying to open certain projects, the user experiences an infinite loading state in the simulator (represented by a spinning blue square). The interface becomes unresponsive.
- **Browser Console:** Throws the following blocking error:
  `Uncaught TypeError: can't access property "layout_id" of undefined`
- **Affected File:** The error primarily points to the call inside the `reset()` method in the `subcircuit.js` file (line 352).

> [!CAUTION]
> The failure is located in the initial reset cycle (`reset()`) of a subcircuit (`SubCircuit`). It propagates a null error that completely halts the rendering and simulation process handled by `engine.js`.

## Root Cause Analysis

The data structure for `SubCircuit` maintains arrays for the components connected to it, such as `inputNodes` and `outputNodes`.
During loading or resetting, the simulator compares and synchronizes the subcircuit interfaces using an identifier stored in a temporary map:
```javascript
if (temp_map_inp.hasOwnProperty(this.inputNodes[i].layout_id)) { ... }
```

The crash occurred because a node inside the `inputNodes` array existed logically in the array (accounted for in `.length`), but its object had not been instantiated or was resolving to `undefined`. When JavaScript attempted to access `.layout_id` on this undefined object, it threw an exception that prematurely aborted the entire initialization load.

## Solution Adopted

The most robust solution involves defensive programming: anticipating possible "holes" or missing nodes in the list when iterating over it during the `reset()` process.

The following change was applied analogously to both the standard simulation environment and the Vue-based port:

### Modified Files

#### [MODIFY] `simulator/src/subcircuit.js`
#### [MODIFY] `cv-frontend-vue/src/simulator/src/subcircuit.ts`

### Code Diff

The modification adds an `if (!this.inputNodes[i]) continue;` clause inside the respective *reset* blocks. The same safety layer was preemptively adopted for the `outputNodes` loops.

```diff
  for (var i = 0; i < this.inputNodes.length; i++) {
+     if (!this.inputNodes[i]) continue;
      if (temp_map_inp.hasOwnProperty(this.inputNodes[i].layout_id)) {
          temp_map_inp[this.inputNodes[i].layout_id][1] = this.inputNodes[i];
      } else {
```

> [!TIP]
> **Why is this safe?** 
> Skipping the iteration safely discards the faulty element (`undefined`). Right after this search loop, the `reset()` function internally recreates the entire `inputNodes` array using only the remaining valid items. In this way, "ghost" nodes are naturally weeded out and handled by garbage collection, allowing the initialization process to proceed cleanly and intact.

## Validation and Verification

Following the corrections, the validation to ensure the changes were successful consisted of:

- **Test Performed:** Accessed the [simulation page of the failing project](https://circuitverse.org/users/201266/projects/kompjuter) for confirmation.
- **Expected Result:** The simulator successfully loads the previously broken project. No infinite loading loops or red screens are observed. The browser console indicates a successful load without the `layout_id of undefined` exception.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved stability of subcircuit operations by gracefully handling edge cases with missing node references during reset operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->