### PR TITLE
Migrate pagination view component#5827

### DIFF
--- a/app/components/contest/index_page_component.html.erb
+++ b/app/components/contest/index_page_component.html.erb
@@ -29,7 +29,8 @@
   </div>
 
   <div class="container pagination-cont">
-    <%= helpers.will_paginate contests, renderer: PaginateRenderer %>
+    <%= render Pagination::PaginationComponent.new(collection: contests,
+                                                   renderer: PaginateRenderer) %>
   </div>
 
   <% if contests.empty? %>

--- a/app/components/contest/index_page_component.html.erb
+++ b/app/components/contest/index_page_component.html.erb
@@ -29,8 +29,8 @@
   </div>
 
   <div class="container pagination-cont">
-    <%= render Pagination::PaginationComponent.new(collection: contests,
-                                                   renderer: PaginateRenderer) %>
+    <%= render ::Pagination::PaginationComponent.new(collection: contests,
+                                                     renderer: PaginateRenderer) %>
   </div>
 
   <% if contests.empty? %>

--- a/app/components/pagination.rb
+++ b/app/components/pagination.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module Pagination
+end

--- a/app/components/pagination/pagination_component.html.erb
+++ b/app/components/pagination/pagination_component.html.erb
@@ -1,0 +1,1 @@
+<%= helpers.will_paginate(collection, **options) %>

--- a/app/components/pagination/pagination_component.rb
+++ b/app/components/pagination/pagination_component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Pagination
+  class PaginationComponent < ViewComponent::Base
+    def initialize(collection:, **options)
+      super()
+      @collection = collection
+      @options = options
+    end
+
+    private
+
+      attr_reader :collection, :options
+  end
+end

--- a/app/views/admin/contests/index.html.erb
+++ b/app/views/admin/contests/index.html.erb
@@ -81,7 +81,8 @@
     <% end %>
   </div>
   <div class="container pagination-cont">
-    <%= will_paginate @contests, renderer: PaginateRenderer %>
+    <%= render Pagination::PaginationComponent.new(collection: @contests,
+                                                   renderer: PaginateRenderer) %>
   </div>
   <% if @contests.empty? %>
     <div class="col-12 row center-row d-flex justify-content-center">

--- a/app/views/commontator/comments/_show.html.erb
+++ b/app/views/commontator/comments/_show.html.erb
@@ -99,13 +99,13 @@
 
 <div id="commontator-comment-<%= comment.id %>-pagination" class="pagination">
   <div id="commontator-comment-<%= comment.id %>-will-paginate" class="will-paginate">
-    <%= will_paginate nested_children,
-                      renderer: Commontator::LinkRenderer,
-                      name: t('commontator.comment.status.reply_pages'),
-                      remote: true,
-                      params: { controller: 'commontator/comments',
-                                action: 'show',
-                                id: comment.id } %>
+    <%= render Pagination::PaginationComponent.new(collection: nested_children,
+                                                   renderer: Commontator::LinkRenderer,
+                                                   name: t('commontator.comment.status.reply_pages'),
+                                                   remote: true,
+                                                   params: { controller: 'commontator/comments',
+                                                             action: 'show',
+                                                             id: comment.id }) %>
   </div>
 </div>
 <%= render partial: 'commontator/comments/delete_comment_confirmation_modal' %>

--- a/app/views/commontator/threads/_show.html.erb
+++ b/app/views/commontator/threads/_show.html.erb
@@ -84,17 +84,14 @@
   <div id="commontator-thread-<%= thread.id %>-pagination" class="pagination">
 
     <div id="commontator-thread-<%= thread.id %>-will-paginate" class="will-paginate">
-      <%=
-        name = t('commontator.thread.status.pages') \
-          if [ :i, :b ].include?(thread.config.comment_reply_style)
-        will_paginate comments,
-                      renderer: Commontator::LinkRenderer,
-                      name: name,
-                      remote: true,
-                      params: { controller: 'commontator/threads',
-                                action: 'show',
-                                id: thread.id }
-      %>
+      <% name = t('commontator.thread.status.pages') if [:i, :b].include?(thread.config.comment_reply_style) %>
+      <%= render Pagination::PaginationComponent.new(collection: comments,
+                                                     renderer: Commontator::LinkRenderer,
+                                                     name: name,
+                                                     remote: true,
+                                                     params: { controller: 'commontator/threads',
+                                                               action: 'show',
+                                                               id: thread.id }) %>
     </div>
   </div>
 

--- a/app/views/contests/show.html.erb
+++ b/app/views/contests/show.html.erb
@@ -112,7 +112,8 @@
   </div>
 
   <div class="container pagination-cont">
-    <%= will_paginate @submissions, renderer: PaginateRenderer %>
+    <%= render Pagination::PaginationComponent.new(collection: @submissions,
+                                                   renderer: PaginateRenderer) %>
   </div>
 
   <%= render Contest::PreviewModalComponent.new %>

--- a/app/views/projects/search.html.erb
+++ b/app/views/projects/search.html.erb
@@ -18,7 +18,9 @@
       <% end %>
     </div>
     <% unless @results.empty? %>
-      <%= will_paginate(@results, renderer: SearchPaginateRenderer, page_links: false) %>
+      <%= render Pagination::PaginationComponent.new(collection: @results,
+                                                     renderer: SearchPaginateRenderer,
+                                                     page_links: false) %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/users/circuitverse/search.html.erb
+++ b/app/views/users/circuitverse/search.html.erb
@@ -17,7 +17,9 @@
       <% end %>
     </div>
     <% unless @results.empty? %>
-      <%= will_paginate(@results, renderer: SearchPaginateRenderer, page_links: false) %>
+      <%= render Pagination::PaginationComponent.new(collection: @results,
+                                                     renderer: SearchPaginateRenderer,
+                                                     page_links: false) %>
     <% end %>
   </div>
 <% end %>

--- a/spec/components/pagination_component_spec.rb
+++ b/spec/components/pagination_component_spec.rb
@@ -10,20 +10,24 @@ RSpec.describe Pagination::PaginationComponent, type: :component do
   end
 
   it "renders pagination for a paginated collection" do
-    render_inline(described_class.new(collection: collection, renderer: PaginateRenderer))
+    with_request_url "/search" do
+      render_inline(described_class.new(collection: collection, renderer: PaginateRenderer))
 
-    expect(page).to have_css(".pagination.justify-content-center")
-    expect(page).to have_css(".page-item.active", text: "2")
+      expect(page).to have_css(".pagination.justify-content-center")
+      expect(page).to have_css(".page-item.active", text: "2")
+    end
   end
 
   it "passes options to will_paginate" do
-    render_inline(described_class.new(collection: collection,
-                                      renderer: SearchPaginateRenderer,
-                                      page_links: false))
+    with_request_url "/search" do
+      render_inline(described_class.new(collection: collection,
+                                        renderer: SearchPaginateRenderer,
+                                        page_links: false))
 
-    expect(page).to have_css(".pagination")
-    expect(page).to have_css(".page-link", text: "Previous")
-    expect(page).to have_css(".page-link", text: "Next")
-    expect(page).to have_no_css(".page-item.active")
+      expect(page).to have_css(".pagination")
+      expect(page).to have_css(".page-link", text: "Previous")
+      expect(page).to have_css(".page-link", text: "Next")
+      expect(page).to have_no_css(".page-item.active")
+    end
   end
 end

--- a/spec/components/pagination_component_spec.rb
+++ b/spec/components/pagination_component_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Pagination::PaginationComponent, type: :component do
+  let(:collection) do
+    WillPaginate::Collection.create(2, 2, 5) do |pager|
+      pager.replace(%w[third fourth])
+    end
+  end
+
+  it "renders pagination for a paginated collection" do
+    render_inline(described_class.new(collection: collection, renderer: PaginateRenderer))
+
+    expect(page).to have_css(".pagination.justify-content-center")
+    expect(page).to have_css(".page-item.active", text: "2")
+  end
+
+  it "passes options to will_paginate" do
+    render_inline(described_class.new(collection: collection,
+                                      renderer: SearchPaginateRenderer,
+                                      page_links: false))
+
+    expect(page).to have_css(".pagination")
+    expect(page).to have_css(".page-link", text: "Previous")
+    expect(page).to have_css(".page-link", text: "Next")
+    expect(page).to have_no_css(".page-item.active")
+  end
+end


### PR DESCRIPTION
Fixes #5827

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Migrated pagination rendering to a small shared ViewComponent:

- Added `Pagination::PaginationComponent`, which delegates to `will_paginate` with the provided collection and options (no behavior change).
- Added `app/components/pagination.rb` declaring the `Pagination` module so Zeitwerk resolves the namespace reliably when the component is referenced from within another ViewComponent (e.g. `Contest::IndexPageComponent`). The component is referenced as `::Pagination::PaginationComponent` to force root-namespace resolution.
- Replaced direct `will_paginate` helper calls in the contest, search, and commontator views with the new component.
- Updated `Contest::IndexPageComponent` to render pagination through the shared component instead of calling the helper internally.
- Added a focused component spec for `Pagination::PaginationComponent`, using `with_request_url` so `will_paginate` can generate links in the component test context.

All existing renderers (`PaginateRenderer`, `SearchPaginateRenderer`, the commontator renderer) and their options (e.g. `page_links: false`, remote params) are passed through unchanged, so the generated markup is identical.

### Screenshots of the UI changes (If any) -

This is a behavior-preserving refactor — no intentional UI changes. The change was validated locally in Docker (`http://localhost:3000`): the affected pages render without errors. On the default seed database the pagination controls are not shown because each list has fewer items than `per_page`, which is the correct single-page behavior. The contest-show and commontator pages could not be exercised with real pagination because the seed database does not create contests or commented projects.

<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The goal was to remove duplicated `will_paginate` call sites and centralize them behind a single reusable ViewComponent without changing any visible behavior.

We kept the component intentionally thin: it accepts a paginated `collection:` plus arbitrary `**options` and forwards them directly to `will_paginate`. The existing renderers remain fully responsible for the generated markup, which is why search pagination (`page_links: false`), the contest Bootstrap renderer, and commontator's remote pagination all continue working with the same options as before.

One detail worth noting: when the component is rendered from inside another ViewComponent (`Contest::IndexPageComponent`), Ruby's constant lookup resolves `Pagination` through the enclosing namespace first, which fails unless the root namespace is explicitly declared. We addressed this by adding `app/components/pagination.rb` (`module Pagination; end`) and referencing the component as `::Pagination::PaginationComponent`.

Validation performed locally:
- `bundle exec rspec spec/components/pagination_component_spec.rb` → **2 examples, 0 failures**
- `bundle exec rubocop` on the changed Ruby files → **no offenses detected**
- Pages `/search`, `/contests`, and `/admins/contests` render without errors

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Migrated pagination system from a helper-based approach to a component-based architecture. Applied across contest listings, comment threads, and search results pages. Pagination behavior and appearance remain unchanged for end-users.

* **Tests**
  * Added comprehensive tests for the new pagination component, including scenarios with and without page links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->