### PR TITLE
fix: cache contest submission count

### DIFF
--- a/app/components/contest/card_component.html.erb
+++ b/app/components/contest/card_component.html.erb
@@ -25,7 +25,7 @@
       <div class="contest-container-details-entries">
         <%= helpers.image_tag(helpers.image_path("svgs/user.svg"), alt: t("contest.contest_container.entries_alt"), class: "entries-image") %>
         <span>
-          <%= @contest.submissions.count %> <%= t("contest.contest_container.entries") %>
+          <%= @contest.submissions_count %> <%= t("contest.contest_container.entries") %>
         </span>
       </div>
       <div class="contest-container-details-description">

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Submission < ApplicationRecord
-  belongs_to :contest
+  belongs_to :contest, counter_cache: true
   belongs_to :project
   belongs_to :user
   has_many :submission_votes, dependent: :destroy

--- a/db/migrate/20260525230000_add_submissions_count_to_contests.rb
+++ b/db/migrate/20260525230000_add_submissions_count_to_contests.rb
@@ -1,0 +1,5 @@
+class AddSubmissionsCountToContests < ActiveRecord::Migration[7.0]
+  def change
+    add_column :contests, :submissions_count, :integer, default: 0, null: false
+  end
+end

--- a/db/migrate/20260525230001_backfill_contest_submissions_count.rb
+++ b/db/migrate/20260525230001_backfill_contest_submissions_count.rb
@@ -1,0 +1,20 @@
+class BackfillContestSubmissionsCount < ActiveRecord::Migration[7.0]
+  def up
+    execute "LOCK TABLE submissions IN SHARE MODE"
+
+    execute <<~SQL.squish
+      UPDATE contests
+      SET submissions_count = counts.submission_count
+      FROM (
+        SELECT contest_id, COUNT(*) AS submission_count
+        FROM submissions
+        GROUP BY contest_id
+      ) AS counts
+      WHERE counts.contest_id = contests.id
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, "Counter cache backfills cannot be reversed safely"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_22_202006) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_25_230001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -173,6 +173,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_22_202006) do
     t.integer "status", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "submissions_count", default: 0, null: false
     t.index ["status"], name: "index_contests_on_status_live_unique", unique: true, where: "(status = 0)"
   end
 

--- a/spec/components/contest/card_component_spec.rb
+++ b/spec/components/contest/card_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Contest::CardComponent, type: :component do
     contest = create(:contest, :completed)
     create_list(:submission, 3, contest: contest)
 
-    render_inline described_class.new(contest: contest)
+    render_inline described_class.new(contest: contest.reload)
 
     expect(page).to have_link("Contest ##{contest.id}")
     expect(page).to have_text("3 Entries")

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Submission, type: :model do
   describe "associations" do
     it { is_expected.to belong_to(:user) }
     it { is_expected.to belong_to(:project) }
-    it { is_expected.to belong_to(:contest) }
+    it { is_expected.to belong_to(:contest).counter_cache(true) }
     it { is_expected.to have_many(:submission_votes) }
     it { is_expected.to have_one(:contest_winner) }
   end


### PR DESCRIPTION
## Summary
- add a counter cache for contest submissions
- render contest cards from the cached submissions count to avoid repeated COUNT queries
- backfill existing contest counters and update specs

Closes #7421

## Tests
- ruby -c app/models/submission.rb
- ruby -c db/migrate/20260525230000_add_submissions_count_to_contests.rb
- ruby -c db/migrate/20260525230001_backfill_contest_submissions_count.rb
- ruby -c spec/models/submission_spec.rb
- ruby -c spec/components/contest/card_component_spec.rb
- git diff --check

Could not run targeted RSpec locally because this machine has system Ruby 2.6 and lacks the locked Bundler 2.5.3 / project Ruby 4.0.2 toolchain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **Performance**
  * Improved contest “Entries” counting to reduce database load and speed up contest card rendering.

* **Bug Fixes**
  * Updated the completed contest display to reliably show the correct persisted entry count.

* **Data & Reliability**
  * Added and populated a stored submissions counter for contests so existing records stay accurate.

* **Tests**
  * Strengthened specs to verify contest/submission counter behavior and adjusted component expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->