### PR TITLE
fix: handle missing project preview image

### DIFF
--- a/app/helpers/simulator_helper.rb
+++ b/app/helpers/simulator_helper.rb
@@ -2,7 +2,7 @@
 
 module SimulatorHelper
   def return_image_file(data_url)
-    str = data_url[("data:image/jpeg;base64,".length)..]
+    str = data_url.to_s[("data:image/jpeg;base64,".length)..]
     if str.to_s.empty?
       path = Rails.public_path.join("images/default.png")
       image_file = File.open(path, "rb") # rubocop:disable Style/FileOpen
@@ -16,7 +16,7 @@ module SimulatorHelper
   end
 
   def parse_image_data_url(data_url)
-    str = data_url[("data:image/jpeg;base64,".length)..]
+    str = data_url.to_s[("data:image/jpeg;base64,".length)..]
     if str.to_s.empty?
       image_file = nil
     else
@@ -28,7 +28,7 @@ module SimulatorHelper
   end
 
   def check_to_delete(data_url)
-    !data_url[("data:image/jpeg;base64,".length)..].to_s.empty?
+    !data_url.to_s[("data:image/jpeg;base64,".length)..].to_s.empty?
   end
 
   def sanitize_data(project, data)

--- a/spec/requests/api/v1/projects_controller/create_spec.rb
+++ b/spec/requests/api/v1/projects_controller/create_spec.rb
@@ -50,6 +50,21 @@ RSpec.describe Api::V1::ProjectsController, "#create", type: :request do
       end
     end
 
+    context "when image is missing" do
+      it "creates project with default image" do
+        expect do
+          token = get_auth_token(user)
+          post "/api/v1/projects",
+               headers: { Authorization: "Token #{token}" },
+               params: { name: "Test Name" }, as: :json
+        end.to change(Project, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+        created_project = Project.order(:created_at).last
+        expect(created_project.image_preview.path.split("/")[-1]).to eq("default.png")
+      end
+    end
+
     context "when there is image data", :skip_windows do
       it "creates project with its own image file" do
         expect do


### PR DESCRIPTION
## Summary
- treat missing project preview image data like an empty image
- keep default preview assignment for project creation when `image` is omitted
- add request coverage for omitted image params

Closes #7172

## Tests
- ruby -c app/helpers/simulator_helper.rb
- ruby -c spec/requests/api/v1/projects_controller/create_spec.rb
- git diff --check

Could not run targeted RSpec locally because this machine has system Ruby 2.6 and lacks the locked Bundler 4.0.10 / project Ruby 4.0.2 toolchain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of image data handling in simulator functionality.

* **Tests**
  * Added test coverage for API project creation when image parameter is missing, confirming default image usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->