### PR TITLE
fix: handle invalid contest page params

### DIFF
--- a/app/controllers/contests_controller.rb
+++ b/app/controllers/contests_controller.rb
@@ -8,7 +8,7 @@ class ContestsController < ApplicationController
 
   def index
     @contests = Contest.order(id: :desc)
-                       .paginate(page: params[:page])
+                       .paginate(page: page_number)
                        .limit(Contest.per_page)
 
     respond_to do |format|
@@ -22,7 +22,7 @@ class ContestsController < ApplicationController
     @user_submission = @contest.submissions.where(user_id: current_user&.id)
     @submissions     = @contest.submissions
                                .where.not(user_id: current_user&.id)
-                               .paginate(page: params[:page])
+                               .paginate(page: page_number)
                                .limit(6)
 
     return unless @contest.completed? && Submission.exists?(contest_id: @contest.id)
@@ -52,5 +52,9 @@ class ContestsController < ApplicationController
 
     def set_user_count
       @user_count = Rails.cache.fetch("users/total_count", expires_in: 10.minutes) { User.count }
+    end
+
+    def page_number
+      params[:page].to_s.match?(/\A[1-9]\d*\z/) ? params[:page] : 1
     end
 end

--- a/spec/controllers/contest_controller_spec.rb
+++ b/spec/controllers/contest_controller_spec.rb
@@ -16,11 +16,21 @@ RSpec.describe ContestsController, type: :controller do
       get :index
       expect(response).to be_successful
     end
+
+    it "returns a success response for an invalid page param" do
+      get :index, params: { page: "JJJ2QQQ" }
+      expect(response).to be_successful
+    end
   end
 
   describe "GET #show" do
     it "returns a success response" do
       get :show, params: { id: contest.to_param }
+      expect(response).to be_successful
+    end
+
+    it "returns a success response for an invalid page param" do
+      get :show, params: { id: contest.to_param, page: "JJJ2QQQ" }
       expect(response).to be_successful
     end
   end


### PR DESCRIPTION
## Summary
- fall back to page 1 when contest pagination receives a non-positive or non-numeric `page` param
- apply the same guard to contest index and submissions pagination on contest show
- add controller specs for invalid page params

Closes #7419

## Tests
- ruby -c app/controllers/contests_controller.rb
- ruby -c spec/controllers/contest_controller_spec.rb
- git diff --check

Could not run targeted RSpec locally because this machine has system Ruby 2.6 and lacks the locked Bundler 4.0.10 / project Ruby 4.0.2 toolchain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pagination robustness by implementing input validation for page parameters. Invalid page values—such as non-numeric entries, negative numbers, and other malformed data—now gracefully default to the first page, ensuring stable behavior across paginated content views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->