### PR TITLE
fix: use valid circuit preview mime type

### DIFF
--- a/app/controllers/simulator_controller.rb
+++ b/app/controllers/simulator_controller.rb
@@ -213,7 +213,7 @@ class SimulatorController < ApplicationController
       @project.circuit_preview.attach(
         io: image_file,
         filename: "preview_#{Time.zone.now.to_f.to_s.sub('.', '')}.jpeg",
-        content_type: "img/jpeg"
+        content_type: "image/jpeg"
       )
     end
 end

--- a/spec/controllers/simulator_controller_spec.rb
+++ b/spec/controllers/simulator_controller_spec.rb
@@ -37,6 +37,7 @@ describe SimulatorController, type: :request do
             end.to change(Project, :count).by(1)
             created_project = Project.order(:created_at).last
             expect(created_project.circuit_preview.blob.filename.to_s).to start_with("preview_")
+            expect(created_project.circuit_preview.blob.content_type).to eq("image/jpeg")
             expect(created_project.image_preview.file.filename).to start_with("preview_")
           end
         end


### PR DESCRIPTION
## Summary
- use the valid `image/jpeg` MIME type when attaching circuit previews
- add a request spec assertion for the attached preview blob content type

Closes #7541

## Checks
- `git diff --check`
- `grep "img/jpeg" app spec db lib` (0 matches)

## Not run
- `bundle exec rspec spec/controllers/simulator_controller_spec.rb` blocked locally: missing Bundler 4.0.10 for Gemfile.lock; shell has macOS Ruby 2.6.10 with Bundler 1.17.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed circuit preview image format metadata to use the correct file type label, ensuring previews are properly recognized and processed by the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->