### PR TITLE
fix: eager load contest submission authors

### DIFF
--- a/app/controllers/contests_controller.rb
+++ b/app/controllers/contests_controller.rb
@@ -19,8 +19,11 @@ class ContestsController < ApplicationController
   end
 
   def show
-    @user_submission = @contest.submissions.where(user_id: current_user&.id)
+    @user_submission = @contest.submissions
+                               .includes(project: :author)
+                               .where(user_id: current_user&.id)
     @submissions     = @contest.submissions
+                               .includes(project: :author)
                                .where.not(user_id: current_user&.id)
                                .paginate(page: params[:page])
                                .limit(6)
@@ -28,7 +31,7 @@ class ContestsController < ApplicationController
     return unless @contest.completed? && Submission.exists?(contest_id: @contest.id)
 
     if (contest_winner = ContestWinner.find_by(contest_id: @contest.id))
-      @winner = contest_winner.submission
+      @winner = Submission.includes(project: :author).find(contest_winner.submission_id)
     end
   end
 

--- a/spec/requests/contests_show_queries_spec.rb
+++ b/spec/requests/contests_show_queries_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Contests#show queries", type: :request do
+  it "eager loads project authors for submission cards" do
+    contest = create(:contest, :live)
+    viewer  = create(:user)
+
+    create_list(:submission, 3, contest: contest)
+
+    sign_in viewer
+
+    users_queries = []
+    callback = lambda do |_name, _start, _finish, _id, payload|
+      sql = payload[:sql]
+      next unless sql.match?(/SELECT .*"users"/)
+      next if payload[:name].in?(%w[SCHEMA TRANSACTION])
+
+      users_queries << sql
+    end
+    subscriber = ActiveSupport::Notifications.subscribe("sql.active_record", &callback)
+
+    begin
+      get contest_path(contest)
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber)
+    end
+
+    expect(response).to have_http_status(:ok)
+    expect(users_queries.grep(/WHERE "users"\."id" =/).size).to be <= 1
+  end
+end


### PR DESCRIPTION
## Summary
- eager load submission projects and project authors on contest show pages
- eager load the winning submission author before rendering the submission card
- add a request spec that tracks users table selects and guards against per-submission author lookups

Closes #7542

## Notes
- #7535 is closed and changed contest submission counters; this PR does not touch counter-cache or submissions_count files.
- No open PR currently references #7542.

## Tests
- ruby -c app/controllers/contests_controller.rb
- ruby -c spec/requests/contests_show_queries_spec.rb
- git diff --check

Could not run targeted RSpec locally because this machine has system Ruby 2.6.10 and only Bundler 1.17.2, while the repo requires Ruby 4.0.2 and Bundler 4.0.10.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved page load times on the contests display page through enhanced query optimization.

* **Tests**
  * Added automated tests to verify efficient database query behavior when viewing contests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->