### PR TITLE
fix: correct invalid MIME type for circuit preview attachment

### DIFF
--- a/app/controllers/simulator_controller.rb
+++ b/app/controllers/simulator_controller.rb
@@ -213,7 +213,7 @@ class SimulatorController < ApplicationController
       @project.circuit_preview.attach(
         io: image_file,
         filename: "preview_#{Time.zone.now.to_f.to_s.sub('.', '')}.jpeg",
-        content_type: "img/jpeg"
+        content_type: "image/jpeg"
       )
     end
 end


### PR DESCRIPTION
### Description

Fixes the invalid MIME type used when attaching circuit previews to ActiveStorage. `attach_circuit_preview` passed `"img/jpeg"` as the `content_type`, which is not a valid MIME type — the correct type is `"image/jpeg"`.

This matches the correct MIME type used elsewhere in the codebase (`simulator_helper.rb` uses `data:image/jpeg;base64,` and `migrate_image_preview_task.rb:42` uses `image/jpeg`).

While ActiveStorage may correct this before storing in S3, fixing it ensures consistency and avoids potential issues with Content-Type headers, CDN caching, and downstream MIME type validation.

Fixes #7541

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the MIME type metadata for circuit preview uploads so previews are properly identified as `image/jpeg`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->