### PR TITLE
fix: update concurrent-ruby, faraday, and oj for security advisories

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -226,7 +226,7 @@ gem 'devise_saml_authenticatable'
 
 gem 'activerecord_cursor_paginate'
 
-gem 'concurrent-ruby', '1.3.6'
+gem "concurrent-ruby", ">= 1.3.7"
 gem 'mutex_m'
 
 gem "observer", "~> 0.1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,7 +228,7 @@ GEM
       rails (>= 6.0)
       sprockets-rails
       will_paginate
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     countries (5.7.2)
       unaccent (~> 0.3)
@@ -288,7 +288,7 @@ GEM
       railties (>= 6.1.0)
     faker (3.8.0)
       i18n (>= 1.8.11, < 2)
-    faraday (2.14.2)
+    faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
@@ -394,7 +394,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
-    json (2.19.9)
+    json (2.20.0)
     json-schema (6.2.0)
       addressable (~> 2.8)
       bigdecimal (>= 3.1, < 5)
@@ -527,7 +527,7 @@ GEM
       snaky_hash (~> 2.0, >= 2.0.5)
       version_gem (~> 1.1, >= 1.1.11)
     observer (0.1.2)
-    oj (3.17.1)
+    oj (3.17.3)
       bigdecimal (>= 3.0)
       ostruct (>= 0.2)
     omniauth (2.1.4)
@@ -1061,7 +1061,7 @@ DEPENDENCIES
   carrierwave (~> 3.1)
   coffee-rails (~> 5.0)
   commontator (~> 7.0.0)
-  concurrent-ruby (= 1.3.6)
+  concurrent-ruby (>= 1.3.7)
   country_select (~> 8.0)
   coveralls_reborn (~> 0.29.0)
   database_consistency


### PR DESCRIPTION
Fixes #7552

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -

Updated concurrent-ruby , faraday , oj to the patched version

Verified that bundle exec bundler-audit --update completes successfully after the dependency updates.

### Screenshots of the UI changes (If any) -
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
This PR resolves security vulnerabilities reported by bundler-audit by updating the affected dependencies to their minimum patched versions. A targeted dependency update approach was chosen to minimize unrelated dependency changes and reduce the risk of regressions. No application code was modified.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `concurrent-ruby` gem dependency version constraint to allow version 1.3.7 and later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->