### PR TITLE
fix(notifications): resolve abnormal footer movement issue (#4535)

### DIFF
--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -1,6 +1,3 @@
-.footer-empty-div {
-  height: 250px;
-}
 
 .footer-container-fluid {
   background-color: $footer-dark-grey;

--- a/app/component/footer_component.html.erb
+++ b/app/component/footer_component.html.erb
@@ -1,5 +1,4 @@
-<div class="container footer-empty-div">
-</div>
+
 <div class="container-fluid footer-container-fluid">
   <div class="container footer-container">
     <div class="row">

--- a/app/views/users/noticed_notifications/index.html.erb
+++ b/app/views/users/noticed_notifications/index.html.erb
@@ -17,7 +17,7 @@
       </div>
     <% end %>
   </div>
-  <div id="all-notifications-div" class="d-flex flex-column bd-highlight mb-10 mt-3 notifications_container">
+  <div id="all-notifications-div" class="d-flex flex-column bd-highlight mb-3 mt-3 notifications_container">
     <% @notifications.each do |notification| %>
       <%= link_to mark_as_read_path(id: current_user, notification_id: notification.id), method: :post, class: "mb-2 mt-2 notification" do %>
         <div class="d-flex align-items-center notification-div">


### PR DESCRIPTION
Fixes #4535

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -
Resolved the abnormal footer movement on the Notifications page by removing the legacy `250px` spacer `div` from `footer_component` that was breaking the modern flexbox layout. Also corrected a typo in the `index.html.erb` container classes (`mb-10` to `mb-3`) to ensure consistent heights across tabs, preventing the scroll position from jumping.

### Screenshots of the UI changes (If any) -
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
I used AI to help trace the root cause of the CSS bug. We discovered that a legacy `height: 250px` div (`.footer-empty-div`) was forcing the footer to behave incorrectly in the modern flexbox grid (`d-flex flex-column min-vh-100`). By removing this dead code, the `flex-grow-1` on the `<main>` tag is now able to correctly push the footer to the bottom of the viewport. We also corrected the bootstrap spacing classes on the tabs.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
