### PR TITLE
Feat/clear all notifications

### DIFF
--- a/app/components/about/team_section_card_component.html.erb
+++ b/app/components/about/team_section_card_component.html.erb
@@ -1,0 +1,8 @@
+<div class="team-member-container team-link">
+  <div class="team-underline">
+    <a target="_blank" href="<%= member[:link] %>">
+      <%= image_tag member[:img], class: "about-contributor-image", alt: "User Image" %>
+      <p class="team-footer <%= 'underline' if underline %>"><%= member[:name] %></p>
+    </a>
+  </div>
+</div>

--- a/app/components/about/team_section_card_component.html.erb
+++ b/app/components/about/team_section_card_component.html.erb
@@ -1,6 +1,6 @@
 <div class="team-member-container team-link">
   <div class="team-underline">
-    <a target="_blank" href="<%= member[:link] %>">
+    <a target="_blank" href="<%= member[:link] %>" aria-label="<%= member[:name] %>">
       <%= image_tag member[:img], class: "about-contributor-image", alt: "User Image" %>
       <p class="team-footer <%= 'underline' if underline %>"><%= member[:name] %></p>
     </a>

--- a/app/components/about/team_section_card_component.rb
+++ b/app/components/about/team_section_card_component.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class About::TeamSectionCardComponent < ViewComponent::Base
+  def initialize(member:, underline: false)
+    super()
+    @member = member
+    @underline = underline
+  end
+
+  private
+
+    attr_reader :member, :underline
+end

--- a/app/controllers/users/noticed_notifications_controller.rb
+++ b/app/controllers/users/noticed_notifications_controller.rb
@@ -27,6 +27,11 @@ class Users::NoticedNotificationsController < ApplicationController
     redirect_back_or_to(root_path)
   end
 
+  def clear_all
+    NoticedNotification.where(recipient: current_user).destroy_all
+    redirect_to notifications_path(current_user), notice: t("notifications.cleared_all")
+  end
+
   private
 
     def redirect_path_for(answer) # rubocop:disable Metrics/MethodLength

--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -40,11 +40,7 @@
     </div>
     <div class="row center-row teams-section ">
         <% @cores.each do |member| %>
-        <div class="team-member-container team-link ">
-          <div class="team-underline">
-            <a target="_blank" href="<%= member[:link] %>"><%= image_tag member[:img], class: "about-contributor-image" %><p class="team-footer "><%= member[:name] %></p></a>
-          </div>
-        </div>
+        <%= render(About::TeamSectionCardComponent.new(member: member)) %>
         <% end %>
         <br><br>
     </div>
@@ -60,11 +56,7 @@
     </div>
     <div class="row center-row teams-section">
         <% @mentors.each do |member| %>
-        <div class="team-member-container team-link">
-          <div class="team-underline">
-            <a target="_blank" href="<%= member[:link] %>"><%= image_tag member[:img], class: "about-contributor-image" %><p class="team-footer"><%= member[:name] %></p></a>
-          </div>
-        </div>
+        <%= render(About::TeamSectionCardComponent.new(member: member)) %>
         <% end %>
         <br><br>
     </div>
@@ -81,11 +73,7 @@
     </div>
     <div class="row center-row teams-section">
         <% @issues_triaging.each do |member| %>
-        <div class="team-member-container team-link">
-          <div class="team-underline">
-            <a target="_blank" href="<%= member[:link] %>"><%= image_tag member[:img],alt: "User Image", class: "about-contributor-image" %><p class="team-footer"><%= member[:name] %></p></a>
-          </div>
-        </div>
+        <%= render(About::TeamSectionCardComponent.new(member: member)) %>
         <% end %>
         <br><br>
     </div>
@@ -102,11 +90,7 @@
     </div>
     <div class="row center-row teams-section">
         <% @alumni.each do |member| %>
-        <div class="team-member-container team-link">
-          <div class="team-underline">
-            <a target="_blank" href="<%= member[:link] %>"><%= image_tag member[:img], class: "about-contributor-image " %><p class="team-footer underline"><%= member[:name] %></p></a>
-          </div>
-        </div>
+        <%= render(About::TeamSectionCardComponent.new(member: member, underline: true)) %>
         <% end %>
         <br><br>
     </div>

--- a/app/views/users/noticed_notifications/index.html.erb
+++ b/app/views/users/noticed_notifications/index.html.erb
@@ -19,7 +19,9 @@
       <% end %>
       <% if @notifications.count.positive? %>
         <div class="ms-3">
-          <%= link_to t("users.notifications.clear_all_button"), clear_all_notifications_url(current_user), method: :delete, data: { confirm: t("users.notifications.clear_all_confirm") }, class: "anchor-text text-danger" %>
+          <a href="#" data-bs-toggle="modal" data-bs-target="#clearAllNotificationsModal" class="anchor-text text-danger">
+            <%= t("users.notifications.clear_all_button") %>
+          </a>
         </div>
       <% end %>
     </div>
@@ -76,5 +78,24 @@
         </div>
       </div>
     <% end %>
+  </div>
+</div>
+
+<div id="clearAllNotificationsModal" class="modal fade" role="dialog">
+  <div class="modal-dialog primary-modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header secondary-modal-header">
+        <h4 class="modal-title"><%= t("users.notifications.clear_all_button") %></h4>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="close"></button>
+      </div>
+      <div class="modal-body">
+        <p><%= t("users.notifications.clear_all_confirm") %></p>
+      </div>
+      <div class="modal-footer">
+        <%= link_to clear_all_notifications_url(current_user), method: :delete, class: "btn primary-delete-button" do %>
+          <%= t("users.notifications.clear_all_button") %>
+        <% end %>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/views/users/noticed_notifications/index.html.erb
+++ b/app/views/users/noticed_notifications/index.html.erb
@@ -19,7 +19,7 @@
       <% end %>
       <% if @notifications.count.positive? %>
         <div class="ms-3">
-          <a href="#" data-bs-toggle="modal" data-bs-target="#clearAllNotificationsModal" class="anchor-text text-danger">
+          <a href="#" data-bs-toggle="modal" data-bs-target="#clearAllNotificationsModal" class="anchor-text text-danger" aria-label="<%= t("users.notifications.clear_all_button") %>">
             <%= t("users.notifications.clear_all_button") %>
           </a>
         </div>
@@ -85,7 +85,7 @@
   <div class="modal-dialog primary-modal-dialog">
     <div class="modal-content">
       <div class="modal-header secondary-modal-header">
-        <h4 class="modal-title"><%= t("users.notifications.clear_all_button") %></h4>
+        <h4 class="modal-title" aria-label="<%= t("users.notifications.clear_all_button") %>"><%= t("users.notifications.clear_all_button") %></h4>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="close"></button>
       </div>
       <div class="modal-body">

--- a/app/views/users/noticed_notifications/index.html.erb
+++ b/app/views/users/noticed_notifications/index.html.erb
@@ -11,11 +11,18 @@
       <span id="all-notifications" class="active notifications-tab" data-action="click->notifications#activeAllNotifications"><%= t("users.notifications.all") %></span>
       <span id="unread-notifications" class="notifications-tab" data-action="click->notifications#activeUnreadNotifications"><%= t("users.notifications.unread") %></span>
     </div>
-    <% if @unread.count.positive? %>
-      <div>
-        <%= link_to t("users.notifications.mark_as_read_button"), mark_all_as_read_url(current_user), method: :patch, class: "anchor-text" %>
-      </div>
-    <% end %>
+    <div class="d-flex align-items-center">
+      <% if @unread.count.positive? %>
+        <div>
+          <%= link_to t("users.notifications.mark_as_read_button"), mark_all_as_read_url(current_user), method: :patch, class: "anchor-text" %>
+        </div>
+      <% end %>
+      <% if @notifications.count.positive? %>
+        <div class="ms-3">
+          <%= link_to t("users.notifications.clear_all_button"), clear_all_notifications_url(current_user), method: :delete, data: { confirm: t("users.notifications.clear_all_confirm") }, class: "anchor-text text-danger" %>
+        </div>
+      <% end %>
+    </div>
   </div>
   <div id="all-notifications-div" class="d-flex flex-column bd-highlight mb-10 mt-3 notifications_container">
     <% @notifications.each do |notification| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,7 @@
 en:
   notifications:
     not_found: "Notification not found"
+    cleared_all: "Successfully cleared all notifications."
   edit: "Edit"
   show: "Show"
   delete: "Delete"

--- a/config/locales/views/users/en.yml
+++ b/config/locales/views/users/en.yml
@@ -91,6 +91,8 @@ en:
       all: "All"
       unread: "Unread"
       mark_as_read_button: "Mark all as read"
+      clear_all_button: "Clear all"
+      clear_all_confirm: "Are you sure you want to clear all notifications?"
       no_notifications: "You do not have any notifications!"
       no_unread_notifications: "You do not have any unread notifications!"
       see_all: "See All"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,6 +96,7 @@ Rails.application.routes.draw do
     get "/educational_institute/typeahead/:query" => "users/circuitverse#typeahead_educational_institute"
     get "/:id/notifications", to: "users/noticed_notifications#index", as: "notifications"
     patch "/:id/notifications/mark_all_as_read", to: "users/noticed_notifications#mark_all_as_read", as: "mark_all_as_read"
+    delete "/:id/notifications/clear_all", to: "users/noticed_notifications#clear_all", as: "clear_all_notifications"
     patch "/:id/notifications/read_all_notifications", to: "users/noticed_notifications#read_all_notifications", as: "read_all_notifications"
     post "/:id/notifications/mark_as_read/:notification_id", to: "users/noticed_notifications#mark_as_read", as: "mark_as_read"
   end


### PR DESCRIPTION
Fixes #3328

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -
Added a "Clear all" button to the notifications page that allows users to destroy all their notifications at once. 

Changes include:
- A new `delete` route `/:id/notifications/clear_all` mapped to a new controller action.
- A `clear_all` method in `NoticedNotificationsController` that fetches and destroys all notifications for the current user.
- A UI update to `app/views/users/noticed_notifications/index.html.erb` to render a red "Clear all" button next to "Mark all as read" conditionally when notifications exist.
- Implemented a CircuitVerse-styled **Bootstrap Modal** for confirmation before destroying notifications to prevent accidental clicks and improve the UX.
- Added i18n localizations for the button text, confirmation modal, and success flash banner.

### Screenshots of the UI changes -
<img width="2880" height="1796" alt="image" src="https://github.com/user-attachments/assets/666dda3a-b7d4-4baa-abb1-ba34e8e0bef7" />
<img width="2880" height="1782" alt="image" src="https://github.com/user-attachments/assets/7cf6b4e7-6647-47b2-bfad-2502a3aace61" />
<img width="1440" height="898" alt="Screenshot 2026-07-04 at 12 31 26 AM" src="https://github.com/user-attachments/assets/9e9e3194-6674-4581-ae59-eecdac96c30c" />

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The goal was to provide a mechanism to hard-delete all notifications rather than just updating their `read_at` timestamp. I chose to implement this in the `users/noticed_notifications_controller.rb` by adding a dedicated `clear_all` action. This action scopes the deletion to `recipient: current_user` to ensure users can only ever delete their own notifications. 

For the frontend, I placed the button directly beside the "Mark all as read" button in `index.html.erb` for UI consistency. To ensure a premium user experience and prevent accidental deletions, I opted to use a native Bootstrap Modal for the confirmation step instead of a basic browser alert, carefully styling it to match CircuitVerse's existing modal components. Finally, I ensured all new strings were properly added to the `en.yml` localization files rather than hardcoding them into the view.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “clear all notifications” action with a confirmation modal and a success message after completion.
  * Introduced a reusable team member card component to render About page team profiles consistently.
* **Bug Fixes**
  * Updated notification controls so bulk actions display only when they apply (e.g., show “mark all as read” only with unread items).
  * Kept the alumni entries’ special underline styling on the About page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->