### PR TITLE
feat: add eye buttons to password reset form and fix layout (#2951)

### DIFF
--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -28,8 +28,8 @@
             </h6>
             <div class="input-group form-input">
               <%= f.password_field :password, autofocus: true, autocomplete: "off", class: "form-control users-password-input" %>
-              <button type="button" class="input-group-addon ms-3 mt-2 border-0 bg-transparent" onclick="togglePassword(this)" aria-label="Toggle password visibility">
-                <i class="far fa-eye-slash password-icon" aria-hidden="true" id="toggle-icon"></i>
+              <button type="button" class="input-group-addon ms-3 mt-2 border-0 bg-transparent" onclick="togglePassword(this)" aria-label="<%= t('toggle_password_visibility') %>">
+                <i class="far fa-eye-slash password-icon" aria-hidden="true"></i>
               </button>
             </div>
           </div>
@@ -37,8 +37,8 @@
             <h6><%= f.label :password_confirmation %></h6>
             <div class="input-group form-input">
               <%= f.password_field :password_confirmation, autocomplete: "off", class: "form-control users-password-input #{'is-invalid' if resource.errors[:password_confirmation].any?}" %>
-              <button type="button" class="input-group-addon ms-3 mt-2 border-0 bg-transparent" onclick="togglePassword(this)" aria-label="Toggle password visibility">
-                <i class="far fa-eye-slash password-icon" aria-hidden="true" id="toggle-icon-confirmation"></i>
+              <button type="button" class="input-group-addon ms-3 mt-2 border-0 bg-transparent" onclick="togglePassword(this)" aria-label="<%= t('toggle_password_visibility') %>">
+                <i class="far fa-eye-slash password-icon" aria-hidden="true"></i>
               </button>
               <% if resource.errors[:password_confirmation].any? %>
                 <div class="invalid-feedback">

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -26,14 +26,20 @@
                 <%= t("users.minimum_password_length", minimum_password_length: @minimum_password_length) %>
               <% end %>
             </h6>
-            <div class="input-group">
-              <%= f.password_field :password, autofocus: true, autocomplete: "off", class: "form-control form-input" %>
+            <div class="input-group form-input">
+              <%= f.password_field :password, autofocus: true, autocomplete: "off", class: "form-control users-password-input" %>
+              <div class="input-group-addon ms-3 mt-2" onclick="togglePassword()">
+                <i class="far fa-eye-slash password-icon" aria-hidden="true" id="toggle-icon"></i>
+              </div>
             </div>
           </div>
           <div class="field mb-3">
             <h6><%= f.label :password_confirmation %></h6>
-            <div class="input-group">
-              <%= f.password_field :password_confirmation, autocomplete: "off", class: "form-control form-input #{'is-invalid' if resource.errors[:password_confirmation].any?}" %>
+            <div class="input-group form-input">
+              <%= f.password_field :password_confirmation, autocomplete: "off", class: "form-control users-password-input #{'is-invalid' if resource.errors[:password_confirmation].any?}" %>
+              <div class="input-group-addon ms-3 mt-2" onclick="togglePassword()">
+                <i class="far fa-eye-slash password-icon" aria-hidden="true" id="toggle-icon-confirmation"></i>
+              </div>
               <% if resource.errors[:password_confirmation].any? %>
                 <div class="invalid-feedback">
                   <%= resource.errors[:password_confirmation].first %>
@@ -42,9 +48,9 @@
             </div>
           </div>
           <div class="field mb-3">
-            <div class="d-flex align-items-center">
-              <%= f.submit t("users.passwords.change_password"), class: "btn primary-button users-primary-button" %>
-              <%= link_to t("users.passwords.link_to_login_page"), new_user_session_path, class: "anchor-text ms-3" %>
+            <div class="d-flex flex-column align-items-start">
+              <%= f.submit t("users.passwords.change_password"), class: "btn primary-button users-primary-button mb-3" %>
+              <%= link_to t("users.passwords.link_to_login_page"), new_user_session_path, class: "anchor-text" %>
             </div>
           </div>
           <div class="field mb-3">
@@ -59,3 +65,4 @@
     </div>
   </div>
 </div>
+<script src="/js/togglePassword.js"></script>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -28,18 +28,18 @@
             </h6>
             <div class="input-group form-input">
               <%= f.password_field :password, autofocus: true, autocomplete: "off", class: "form-control users-password-input" %>
-              <div class="input-group-addon ms-3 mt-2" onclick="togglePassword()">
+              <button type="button" class="input-group-addon ms-3 mt-2 border-0 bg-transparent" onclick="togglePassword(this)" aria-label="Toggle password visibility">
                 <i class="far fa-eye-slash password-icon" aria-hidden="true" id="toggle-icon"></i>
-              </div>
+              </button>
             </div>
           </div>
           <div class="field mb-3">
             <h6><%= f.label :password_confirmation %></h6>
             <div class="input-group form-input">
               <%= f.password_field :password_confirmation, autocomplete: "off", class: "form-control users-password-input #{'is-invalid' if resource.errors[:password_confirmation].any?}" %>
-              <div class="input-group-addon ms-3 mt-2" onclick="togglePassword()">
+              <button type="button" class="input-group-addon ms-3 mt-2 border-0 bg-transparent" onclick="togglePassword(this)" aria-label="Toggle password visibility">
                 <i class="far fa-eye-slash password-icon" aria-hidden="true" id="toggle-icon-confirmation"></i>
-              </div>
+              </button>
               <% if resource.errors[:password_confirmation].any? %>
                 <div class="invalid-feedback">
                   <%= resource.errors[:password_confirmation].first %>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -36,8 +36,8 @@
           </h6>
           <div class="input-group form-input">
             <%= password_field_tag "#{f.object_name}[password]", nil, autocomplete: "off", placeholder: t('enter_password'), class: "form-control users-password-input" %>
-            <button type="button" class="input-group-addon ms-3 mt-2 border-0 bg-transparent" onclick="togglePassword(this)" aria-label="Toggle password visibility">
-              <i class="far fa-eye-slash password-icon" aria-hidden="true" id="toggle-icon"></i>
+            <button type="button" class="input-group-addon ms-3 mt-2 border-0 bg-transparent" onclick="togglePassword(this)" aria-label="<%= t('toggle_password_visibility') %>">
+              <i class="far fa-eye-slash password-icon" aria-hidden="true"></i>
             </button>
           </div>
         </div>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -36,9 +36,9 @@
           </h6>
           <div class="input-group form-input">
             <%= password_field_tag "#{f.object_name}[password]", nil, autocomplete: "off", placeholder: t('enter_password'), class: "form-control users-password-input" %>
-            <div class="input-group-addon ms-3 mt-2" onclick="togglePassword()">
+            <button type="button" class="input-group-addon ms-3 mt-2 border-0 bg-transparent" onclick="togglePassword(this)" aria-label="Toggle password visibility">
               <i class="far fa-eye-slash password-icon" aria-hidden="true" id="toggle-icon"></i>
-            </div>
+            </button>
           </div>
         </div>
           <div class="field mb-3">

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -30,8 +30,8 @@
           <h6><%= f.label :password %></h6>
           <div class="input-group form-input">
             <%= f.password_field :password, autocomplete: "off", placeholder:t('enter_password') , class: "form-control users-password-input" %>
-            <button type="button" class="input-group-addon ms-3 mt-2 border-0 bg-transparent" onclick="togglePassword(this)" aria-label="Toggle password visibility">
-              <i class="far fa-eye-slash password-icon" aria-hidden="true" id="toggle-icon"></i>
+            <button type="button" class="input-group-addon ms-3 mt-2 border-0 bg-transparent" onclick="togglePassword(this)" aria-label="<%= t('toggle_password_visibility') %>">
+              <i class="far fa-eye-slash password-icon" aria-hidden="true"></i>
             </button>
           </div>
         </div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -30,9 +30,9 @@
           <h6><%= f.label :password %></h6>
           <div class="input-group form-input">
             <%= f.password_field :password, autocomplete: "off", placeholder:t('enter_password') , class: "form-control users-password-input" %>
-            <div class="input-group-addon ms-3 mt-2" onclick="togglePassword()">
+            <button type="button" class="input-group-addon ms-3 mt-2 border-0 bg-transparent" onclick="togglePassword(this)" aria-label="Toggle password visibility">
               <i class="far fa-eye-slash password-icon" aria-hidden="true" id="toggle-icon"></i>
-            </div>
+            </button>
           </div>
         </div>
         <div class="status-container">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,6 +37,7 @@ en:
   facebook: "Facebook"
   github: "Github"
   gitlab: "Gitlab"
+  toggle_password_visibility: "Toggle password visibility"
   components:
     search_bar:
       placeholders:

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,24 +15,24 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_25_102515) do
   enable_extension "pg_catalog.plpgsql"
 
   create_table "active_storage_attachments", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "record_type", null: false
-    t.bigint "record_id", null: false
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.bigint "record_id", null: false
+    t.string "record_type", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
   create_table "active_storage_blobs", force: :cascade do |t|
-    t.string "key", null: false
-    t.string "filename", null: false
-    t.string "content_type"
-    t.text "metadata"
-    t.string "service_name", null: false
     t.bigint "byte_size", null: false
     t.string "checksum"
+    t.string "content_type"
     t.datetime "created_at", null: false
+    t.string "filename", null: false
+    t.string "key", null: false
+    t.text "metadata"
+    t.string "service_name", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
@@ -43,92 +43,92 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_25_102515) do
   end
 
   create_table "ahoy_events", force: :cascade do |t|
-    t.bigint "visit_id"
-    t.bigint "user_id"
     t.string "name"
     t.json "properties"
     t.datetime "time", precision: nil
+    t.bigint "user_id"
+    t.bigint "visit_id"
     t.index ["name", "time"], name: "index_ahoy_events_on_name_and_time"
     t.index ["user_id"], name: "index_ahoy_events_on_user_id"
     t.index ["visit_id"], name: "index_ahoy_events_on_visit_id"
   end
 
   create_table "ahoy_visits", force: :cascade do |t|
-    t.string "visit_token"
-    t.string "visitor_token"
-    t.bigint "user_id"
-    t.string "ip"
-    t.text "user_agent"
-    t.text "referrer"
-    t.string "referring_domain"
-    t.text "landing_page"
-    t.string "browser"
-    t.string "os"
-    t.string "device_type"
-    t.string "country"
-    t.string "region"
-    t.string "city"
-    t.string "utm_source"
-    t.string "utm_medium"
-    t.string "utm_term"
-    t.string "utm_content"
-    t.string "utm_campaign"
     t.string "app_version"
+    t.string "browser"
+    t.string "city"
+    t.string "country"
+    t.string "device_type"
+    t.string "ip"
+    t.text "landing_page"
+    t.string "os"
     t.string "os_version"
     t.string "platform"
+    t.text "referrer"
+    t.string "referring_domain"
+    t.string "region"
     t.datetime "started_at", precision: nil
+    t.text "user_agent"
+    t.bigint "user_id"
+    t.string "utm_campaign"
+    t.string "utm_content"
+    t.string "utm_medium"
+    t.string "utm_source"
+    t.string "utm_term"
+    t.string "visit_token"
+    t.string "visitor_token"
     t.index ["user_id"], name: "index_ahoy_visits_on_user_id"
     t.index ["visit_token"], name: "index_ahoy_visits_on_visit_token", unique: true
   end
 
   create_table "announcements", force: :cascade do |t|
     t.text "body"
+    t.datetime "created_at", null: false
+    t.datetime "end_date", precision: nil
     t.text "link"
     t.datetime "start_date", precision: nil
-    t.datetime "end_date", precision: nil
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
   create_table "assignments", force: :cascade do |t|
-    t.string "name"
+    t.datetime "created_at", precision: nil, null: false
     t.datetime "deadline", null: false
     t.text "description"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
-    t.bigint "group_id"
-    t.string "status"
-    t.integer "grading_scale", default: 0
+    t.jsonb "feature_restrictions", default: {}
     t.boolean "grades_finalized", default: false
-    t.json "restrictions", default: "[]"
+    t.integer "grading_scale", default: 0
+    t.bigint "group_id"
     t.string "lti_consumer_key"
     t.string "lti_shared_secret"
-    t.jsonb "feature_restrictions", default: {}
+    t.string "name"
+    t.json "restrictions", default: "[]"
+    t.string "status"
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["group_id"], name: "index_assignments_on_group_id"
   end
 
   create_table "collaborations", force: :cascade do |t|
-    t.bigint "user_id"
-    t.bigint "project_id"
     t.datetime "created_at", precision: nil, null: false
+    t.bigint "project_id"
     t.datetime "updated_at", precision: nil, null: false
+    t.bigint "user_id"
     t.index ["project_id"], name: "index_collaborations_on_project_id"
     t.index ["user_id"], name: "index_collaborations_on_user_id"
   end
 
   create_table "commontator_comments", id: :serial, force: :cascade do |t|
-    t.string "creator_type"
-    t.integer "creator_id"
-    t.string "editor_type"
-    t.integer "editor_id"
-    t.integer "thread_id", null: false
     t.text "body", null: false
-    t.datetime "deleted_at", precision: nil
-    t.integer "cached_votes_up", default: 0
     t.integer "cached_votes_down", default: 0
+    t.integer "cached_votes_up", default: 0
     t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.integer "creator_id"
+    t.string "creator_type"
+    t.datetime "deleted_at", precision: nil
+    t.integer "editor_id"
+    t.string "editor_type"
     t.bigint "parent_id"
+    t.integer "thread_id", null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["cached_votes_down"], name: "index_commontator_comments_on_cached_votes_down"
     t.index ["cached_votes_up"], name: "index_commontator_comments_on_cached_votes_up"
     t.index ["creator_id", "creator_type", "thread_id"], name: "index_commontator_comments_on_c_id_and_c_type_and_t_id"
@@ -137,21 +137,21 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_25_102515) do
   end
 
   create_table "commontator_subscriptions", id: :serial, force: :cascade do |t|
-    t.string "subscriber_type", null: false
-    t.integer "subscriber_id", null: false
-    t.integer "thread_id", null: false
     t.datetime "created_at", precision: nil, null: false
+    t.integer "subscriber_id", null: false
+    t.string "subscriber_type", null: false
+    t.integer "thread_id", null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["subscriber_id", "subscriber_type", "thread_id"], name: "index_commontator_subscriptions_on_s_id_and_s_type_and_t_id", unique: true
     t.index ["thread_id"], name: "index_commontator_subscriptions_on_thread_id"
   end
 
   create_table "commontator_threads", id: :serial, force: :cascade do |t|
-    t.string "commontable_type"
-    t.integer "commontable_id"
     t.datetime "closed_at", precision: nil
-    t.string "closer_type"
     t.integer "closer_id"
+    t.string "closer_type"
+    t.integer "commontable_id"
+    t.string "commontable_type"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["commontable_id", "commontable_type"], name: "index_commontator_threads_on_c_id_and_c_type", unique: true
@@ -159,9 +159,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_25_102515) do
 
   create_table "contest_winners", force: :cascade do |t|
     t.bigint "contest_id"
-    t.bigint "submission_id"
-    t.bigint "project_id"
     t.datetime "created_at", null: false
+    t.bigint "project_id"
+    t.bigint "submission_id"
     t.datetime "updated_at", null: false
     t.index ["contest_id"], name: "index_contest_winners_on_contest_id", unique: true
     t.index ["project_id"], name: "index_contest_winners_on_project_id"
@@ -169,18 +169,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_25_102515) do
   end
 
   create_table "contests", force: :cascade do |t|
+    t.datetime "created_at", null: false
     t.datetime "deadline", null: false
     t.integer "status", default: 0
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["status"], name: "index_contests_on_status_live_unique", unique: true, where: "(status = 0)"
   end
 
   create_table "custom_mails", force: :cascade do |t|
-    t.text "subject"
     t.text "content"
-    t.boolean "sent", default: false
     t.datetime "created_at", precision: nil, null: false
+    t.boolean "sent", default: false
+    t.text "subject"
     t.datetime "updated_at", precision: nil, null: false
     t.bigint "user_id"
     t.index ["user_id"], name: "index_custom_mails_on_user_id"
@@ -191,67 +191,67 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_25_102515) do
 
   create_table "featured_circuits", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
     t.bigint "project_id"
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["project_id"], name: "index_featured_circuits_on_project_id"
   end
 
   create_table "forum_categories", id: :serial, force: :cascade do |t|
-    t.string "name", null: false
-    t.string "slug", null: false
     t.string "color", default: "000000"
     t.datetime "created_at", precision: nil
+    t.string "name", null: false
+    t.string "slug", null: false
     t.datetime "updated_at", precision: nil
   end
 
   create_table "forum_posts", id: :serial, force: :cascade do |t|
-    t.integer "forum_thread_id"
-    t.integer "user_id"
     t.text "body"
-    t.boolean "solved", default: false
     t.datetime "created_at", precision: nil
+    t.integer "forum_thread_id"
+    t.boolean "solved", default: false
     t.datetime "updated_at", precision: nil
+    t.integer "user_id"
   end
 
   create_table "forum_subscriptions", id: :serial, force: :cascade do |t|
-    t.integer "forum_thread_id"
-    t.integer "user_id"
-    t.string "subscription_type"
     t.datetime "created_at", precision: nil
+    t.integer "forum_thread_id"
+    t.string "subscription_type"
     t.datetime "updated_at", precision: nil
+    t.integer "user_id"
   end
 
   create_table "forum_threads", id: :serial, force: :cascade do |t|
+    t.datetime "created_at", precision: nil
     t.integer "forum_category_id"
-    t.integer "user_id"
-    t.string "title", null: false
-    t.string "slug", null: false
     t.integer "forum_posts_count", default: 0
     t.boolean "pinned", default: false
+    t.string "slug", null: false
     t.boolean "solved", default: false
-    t.datetime "created_at", precision: nil
+    t.string "title", null: false
     t.datetime "updated_at", precision: nil
+    t.integer "user_id"
   end
 
   create_table "friendly_id_slugs", force: :cascade do |t|
+    t.datetime "created_at"
+    t.string "scope"
     t.string "slug", null: false
     t.integer "sluggable_id", null: false
     t.string "sluggable_type", limit: 50
-    t.string "scope"
-    t.datetime "created_at"
     t.index ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true
     t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type"
     t.index ["sluggable_type", "sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_type_and_sluggable_id"
   end
 
   create_table "grades", force: :cascade do |t|
-    t.string "grade"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
-    t.bigint "project_id"
-    t.bigint "user_id"
     t.bigint "assignment_id"
+    t.datetime "created_at", precision: nil, null: false
+    t.string "grade"
+    t.bigint "project_id"
     t.string "remarks"
+    t.datetime "updated_at", precision: nil, null: false
+    t.bigint "user_id"
     t.index ["assignment_id"], name: "index_grades_on_assignment_id"
     t.index ["project_id", "assignment_id"], name: "index_grades_on_project_id_and_assignment_id", unique: true
     t.index ["project_id"], name: "index_grades_on_project_id"
@@ -259,98 +259,98 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_25_102515) do
   end
 
   create_table "group_members", force: :cascade do |t|
-    t.bigint "group_id"
-    t.bigint "user_id"
     t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.bigint "group_id"
     t.boolean "mentor", default: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.bigint "user_id"
     t.index ["group_id", "user_id"], name: "index_group_members_on_group_id_and_user_id", unique: true
     t.index ["group_id"], name: "index_group_members_on_group_id"
     t.index ["user_id"], name: "index_group_members_on_user_id"
   end
 
   create_table "groups", force: :cascade do |t|
-    t.string "name"
-    t.bigint "primary_mentor_id"
     t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
     t.integer "group_members_count"
     t.string "group_token"
-    t.datetime "token_expires_at", precision: nil
+    t.string "name"
     t.bigint "organization_id"
+    t.bigint "primary_mentor_id"
+    t.datetime "token_expires_at", precision: nil
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["group_token"], name: "index_groups_on_group_token", unique: true
     t.index ["organization_id"], name: "index_groups_on_organization_id"
     t.index ["primary_mentor_id"], name: "index_groups_on_primary_mentor_id"
   end
 
   create_table "issue_circuit_data", force: :cascade do |t|
-    t.text "data"
     t.datetime "created_at", null: false
+    t.text "data"
     t.datetime "updated_at", null: false
   end
 
   create_table "mailkick_opt_outs", force: :cascade do |t|
-    t.string "email"
-    t.string "user_type"
-    t.bigint "user_id"
     t.boolean "active", default: true, null: false
-    t.string "reason"
-    t.string "list"
     t.datetime "created_at", null: false
+    t.string "email"
+    t.string "list"
+    t.string "reason"
     t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.string "user_type"
     t.index ["email"], name: "index_mailkick_opt_outs_on_email"
     t.index ["user_type", "user_id"], name: "index_mailkick_opt_outs_on_user_type_and_user_id"
   end
 
   create_table "maintenance_tasks_runs", force: :cascade do |t|
-    t.string "task_name", null: false
-    t.datetime "started_at", precision: nil
-    t.datetime "ended_at", precision: nil
-    t.float "time_running", default: 0.0, null: false
-    t.bigint "tick_count", default: 0, null: false
-    t.bigint "tick_total"
-    t.string "job_id"
-    t.string "cursor"
-    t.string "status", default: "enqueued", null: false
-    t.string "error_class"
-    t.string "error_message"
+    t.text "arguments"
     t.text "backtrace"
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.text "arguments"
+    t.string "cursor"
+    t.datetime "ended_at", precision: nil
+    t.string "error_class"
+    t.string "error_message"
+    t.string "job_id"
     t.integer "lock_version", default: 0, null: false
     t.text "metadata"
+    t.datetime "started_at", precision: nil
+    t.string "status", default: "enqueued", null: false
+    t.string "task_name", null: false
+    t.bigint "tick_count", default: 0, null: false
+    t.bigint "tick_total"
+    t.float "time_running", default: 0.0, null: false
+    t.datetime "updated_at", null: false
     t.index ["task_name", "status", "created_at"], name: "index_maintenance_tasks_runs", order: { created_at: :desc }
   end
 
   create_table "noticed_notifications", force: :cascade do |t|
-    t.string "recipient_type", null: false
-    t.bigint "recipient_id", null: false
-    t.string "type", null: false
+    t.datetime "created_at", null: false
     t.jsonb "params"
     t.datetime "read_at"
-    t.datetime "created_at", null: false
+    t.bigint "recipient_id", null: false
+    t.string "recipient_type", null: false
+    t.string "type", null: false
     t.datetime "updated_at", null: false
     t.index ["read_at"], name: "index_noticed_notifications_on_read_at"
     t.index ["recipient_type", "recipient_id"], name: "index_noticed_notifications_on_recipient"
   end
 
   create_table "notifications", force: :cascade do |t|
-    t.string "target_type", null: false
-    t.bigint "target_id", null: false
-    t.string "notifiable_type", null: false
-    t.bigint "notifiable_id", null: false
-    t.string "key", null: false
-    t.string "group_type"
+    t.datetime "created_at", null: false
     t.bigint "group_id"
     t.integer "group_owner_id"
-    t.string "notifier_type"
-    t.bigint "notifier_id"
-    t.text "parameters"
-    t.datetime "opened_at", precision: nil
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string "group_type"
+    t.string "key", null: false
     t.boolean "migrated", default: false
+    t.bigint "notifiable_id", null: false
+    t.string "notifiable_type", null: false
+    t.bigint "notifier_id"
+    t.string "notifier_type"
+    t.datetime "opened_at", precision: nil
+    t.text "parameters"
+    t.bigint "target_id", null: false
+    t.string "target_type", null: false
+    t.datetime "updated_at", null: false
     t.index ["group_owner_id"], name: "index_notifications_on_group_owner_id"
     t.index ["group_type", "group_id"], name: "index_notifications_on_group_type_and_group_id"
     t.index ["notifiable_type", "notifiable_id"], name: "index_notifications_on_notifiable_type_and_notifiable_id"
@@ -359,27 +359,27 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_25_102515) do
   end
 
   create_table "organization_members", force: :cascade do |t|
-    t.bigint "organization_id", null: false
-    t.bigint "user_id", null: false
-    t.integer "role", default: 2, null: false
     t.datetime "created_at", null: false
+    t.bigint "organization_id", null: false
+    t.integer "role", default: 2, null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
     t.index ["organization_id", "user_id"], name: "index_organization_members_on_org_and_user_unique", unique: true
     t.index ["organization_id"], name: "index_organization_members_on_organization_id"
     t.index ["user_id"], name: "index_organization_members_on_user_id"
   end
 
   create_table "organizations", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "slug", null: false
+    t.datetime "created_at", null: false
     t.text "description"
-    t.string "location"
     t.jsonb "links", default: []
-    t.boolean "private", default: true, null: false
-    t.string "oidc_issuer_url"
+    t.string "location"
+    t.string "name", null: false
     t.string "oidc_client_id"
     t.string "oidc_client_secret_digest"
-    t.datetime "created_at", null: false
+    t.string "oidc_issuer_url"
+    t.boolean "private", default: true, null: false
+    t.string "slug", null: false
     t.datetime "updated_at", null: false
     t.index "lower((name)::text)", name: "index_organizations_on_lower_name_unique", unique: true
     t.index ["slug"], name: "index_organizations_on_slug", unique: true
@@ -389,39 +389,39 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_25_102515) do
   end
 
   create_table "pending_invitations", force: :cascade do |t|
-    t.bigint "group_id"
-    t.string "email"
     t.datetime "created_at", precision: nil, null: false
+    t.string "email"
+    t.bigint "group_id"
     t.datetime "updated_at", precision: nil, null: false
     t.index ["group_id", "email"], name: "index_pending_invitations_on_group_id_and_email", unique: true
     t.index ["group_id"], name: "index_pending_invitations_on_group_id"
   end
 
   create_table "project_data", force: :cascade do |t|
-    t.bigint "project_id", null: false
-    t.text "data"
     t.datetime "created_at", null: false
+    t.text "data"
+    t.bigint "project_id", null: false
     t.datetime "updated_at", null: false
     t.index ["project_id"], name: "index_project_data_on_project_id", unique: true
   end
 
   create_table "projects", force: :cascade do |t|
-    t.string "name"
-    t.bigint "author_id"
-    t.bigint "forked_project_id"
-    t.string "project_access_type", default: "Public"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
     t.bigint "assignment_id"
-    t.boolean "project_submission", default: false
-    t.string "image_preview"
+    t.bigint "author_id"
+    t.datetime "created_at", precision: nil, null: false
     t.text "description"
-    t.bigint "view", default: 1
-    t.string "slug"
+    t.bigint "forked_project_id"
+    t.string "image_preview"
     t.string "lis_result_sourced_id"
-    t.string "version", default: "1.0", null: false
-    t.integer "stars_count", default: 0, null: false
+    t.string "name"
+    t.string "project_access_type", default: "Public"
+    t.boolean "project_submission", default: false
     t.virtual "searchable", type: :tsvector, as: "(setweight(to_tsvector('english'::regconfig, (COALESCE(name, ''::character varying))::text), 'A'::\"char\") || setweight(to_tsvector('english'::regconfig, COALESCE(description, ''::text)), 'B'::\"char\"))", stored: true
+    t.string "slug"
+    t.integer "stars_count", default: 0, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.string "version", default: "1.0", null: false
+    t.bigint "view", default: 1
     t.index ["assignment_id"], name: "index_projects_on_assignment_id"
     t.index ["author_id"], name: "index_projects_on_author_id"
     t.index ["forked_project_id"], name: "index_projects_on_forked_project_id"
@@ -430,20 +430,20 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_25_102515) do
   end
 
   create_table "push_subscriptions", force: :cascade do |t|
+    t.string "auth"
+    t.datetime "created_at", null: false
     t.string "endpoint"
     t.string "p256dh"
-    t.string "auth"
-    t.bigint "user_id"
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id"
     t.index ["user_id"], name: "index_push_subscriptions_on_user_id"
   end
 
   create_table "stars", force: :cascade do |t|
-    t.bigint "user_id"
-    t.bigint "project_id"
     t.datetime "created_at", precision: nil, null: false
+    t.bigint "project_id"
     t.datetime "updated_at", precision: nil, null: false
+    t.bigint "user_id"
     t.index ["project_id"], name: "index_stars_on_project_id"
     t.index ["user_id", "project_id"], name: "index_stars_on_user_id_and_project_id", unique: true
     t.index ["user_id"], name: "index_stars_on_user_id"
@@ -451,10 +451,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_25_102515) do
 
   create_table "submission_votes", force: :cascade do |t|
     t.bigint "contest_id"
-    t.bigint "submission_id"
-    t.bigint "user_id"
     t.datetime "created_at", null: false
+    t.bigint "submission_id"
     t.datetime "updated_at", null: false
+    t.bigint "user_id"
     t.index ["contest_id"], name: "index_submission_votes_on_contest_id"
     t.index ["submission_id"], name: "index_submission_votes_on_submission_id"
     t.index ["user_id", "submission_id", "contest_id"], name: "index_unique_submission_votes", unique: true
@@ -463,29 +463,29 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_25_102515) do
 
   create_table "submissions", force: :cascade do |t|
     t.bigint "contest_id"
-    t.bigint "project_id"
-    t.bigint "user_id"
-    t.bigint "submission_votes_count", default: 0
-    t.boolean "winner", default: false
     t.datetime "created_at", null: false
+    t.bigint "project_id"
+    t.bigint "submission_votes_count", default: 0
     t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.boolean "winner", default: false
     t.index ["contest_id"], name: "index_submissions_on_contest_id"
     t.index ["project_id"], name: "index_submissions_on_project_id"
     t.index ["user_id"], name: "index_submissions_on_user_id"
   end
 
   create_table "subscriptions", force: :cascade do |t|
-    t.string "target_type", null: false
-    t.bigint "target_id", null: false
+    t.datetime "created_at", null: false
     t.string "key", null: false
+    t.text "optional_targets"
+    t.datetime "subscribed_at", precision: nil
+    t.datetime "subscribed_to_email_at", precision: nil
     t.boolean "subscribing", default: true, null: false
     t.boolean "subscribing_to_email", default: true, null: false
-    t.datetime "subscribed_at", precision: nil
+    t.bigint "target_id", null: false
+    t.string "target_type", null: false
     t.datetime "unsubscribed_at", precision: nil
-    t.datetime "subscribed_to_email_at", precision: nil
     t.datetime "unsubscribed_to_email_at", precision: nil
-    t.text "optional_targets"
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["key"], name: "index_subscriptions_on_key"
     t.index ["target_type", "target_id", "key"], name: "index_subscriptions_on_target_type_and_target_id_and_key", unique: true
@@ -493,66 +493,66 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_25_102515) do
   end
 
   create_table "taggings", force: :cascade do |t|
+    t.datetime "created_at", precision: nil, null: false
     t.bigint "project_id"
     t.bigint "tag_id"
-    t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["project_id"], name: "index_taggings_on_project_id"
     t.index ["tag_id"], name: "index_taggings_on_tag_id"
   end
 
   create_table "tags", force: :cascade do |t|
-    t.string "name"
     t.datetime "created_at", precision: nil, null: false
+    t.string "name"
     t.datetime "updated_at", precision: nil, null: false
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at", precision: nil
-    t.datetime "remember_created_at", precision: nil
-    t.integer "sign_in_count", default: 0, null: false
-    t.datetime "current_sign_in_at", precision: nil
-    t.datetime "last_sign_in_at", precision: nil
-    t.string "current_sign_in_ip"
-    t.string "last_sign_in_ip"
-    t.string "name"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
-    t.string "provider"
-    t.string "uid"
-    t.string "profile_picture_file_name"
-    t.string "profile_picture_content_type"
-    t.bigint "profile_picture_file_size"
-    t.datetime "profile_picture_updated_at", precision: nil
     t.boolean "admin", default: false
-    t.string "country"
-    t.string "educational_institute"
-    t.boolean "subscribed", default: true
-    t.string "locale"
+    t.datetime "confirmation_sent_at"
     t.string "confirmation_token"
     t.datetime "confirmed_at"
-    t.datetime "confirmation_sent_at"
-    t.string "unconfirmed_email"
-    t.virtual "searchable", type: :tsvector, as: "(setweight(to_tsvector('english'::regconfig, (COALESCE(name, ''::character varying))::text), 'A'::\"char\") || setweight(to_tsvector('english'::regconfig, (COALESCE(educational_institute, ''::character varying))::text), 'B'::\"char\"))", stored: true
+    t.string "country"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "current_sign_in_at", precision: nil
+    t.string "current_sign_in_ip"
+    t.string "educational_institute"
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.datetime "last_sign_in_at", precision: nil
+    t.string "last_sign_in_ip"
+    t.string "locale"
+    t.string "name"
+    t.string "profile_picture_content_type"
+    t.string "profile_picture_file_name"
+    t.bigint "profile_picture_file_size"
+    t.datetime "profile_picture_updated_at", precision: nil
     t.integer "projects_count", default: 0, null: false
+    t.string "provider"
+    t.datetime "remember_created_at", precision: nil
+    t.datetime "reset_password_sent_at", precision: nil
+    t.string "reset_password_token"
+    t.virtual "searchable", type: :tsvector, as: "(setweight(to_tsvector('english'::regconfig, (COALESCE(name, ''::character varying))::text), 'A'::\"char\") || setweight(to_tsvector('english'::regconfig, (COALESCE(educational_institute, ''::character varying))::text), 'B'::\"char\"))", stored: true
+    t.integer "sign_in_count", default: 0, null: false
+    t.boolean "subscribed", default: true
+    t.string "uid"
+    t.string "unconfirmed_email"
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["searchable"], name: "index_users_on_searchable", using: :gin
   end
 
   create_table "votes", id: :serial, force: :cascade do |t|
-    t.string "votable_type"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.integer "votable_id"
-    t.string "voter_type"
-    t.integer "voter_id"
+    t.string "votable_type"
     t.boolean "vote_flag"
     t.string "vote_scope"
     t.integer "vote_weight"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.integer "voter_id"
+    t.string "voter_type"
     t.index ["votable_id", "votable_type", "vote_scope"], name: "index_votes_on_votable_id_and_votable_type_and_vote_scope"
     t.index ["voter_id", "voter_type", "vote_scope"], name: "index_votes_on_voter_id_and_voter_type_and_vote_scope"
   end

--- a/public/js/togglePassword.js
+++ b/public/js/togglePassword.js
@@ -1,11 +1,11 @@
 function togglePassword() {
     if ($('.users-password-input').attr('type') === 'text') {
         $('.users-password-input').attr('type', 'password');
-        $('#toggle-icon').addClass('fa-eye-slash');
-        $('#toggle-icon').removeClass('fa-eye');
+        $('.password-icon').addClass('fa-eye-slash');
+        $('.password-icon').removeClass('fa-eye');
     } else {
         $('.users-password-input').attr('type', 'text');
-        $('#toggle-icon').addClass('fa-eye');
-        $('#toggle-icon').removeClass('fa-eye-slash');
+        $('.password-icon').addClass('fa-eye');
+        $('.password-icon').removeClass('fa-eye-slash');
     }
 }

--- a/public/js/togglePassword.js
+++ b/public/js/togglePassword.js
@@ -1,11 +1,15 @@
-function togglePassword() {
-    if ($('.users-password-input').attr('type') === 'text') {
-        $('.users-password-input').attr('type', 'password');
-        $('.password-icon').addClass('fa-eye-slash');
-        $('.password-icon').removeClass('fa-eye');
+function togglePassword(element) {
+    const $button = $(element);
+    const $input = $button.siblings('.users-password-input');
+    const $icon = $button.find('.password-icon');
+
+    if ($input.attr('type') === 'text') {
+        $input.attr('type', 'password');
+        $icon.addClass('fa-eye-slash');
+        $icon.removeClass('fa-eye');
     } else {
-        $('.users-password-input').attr('type', 'text');
-        $('.password-icon').addClass('fa-eye');
-        $('.password-icon').removeClass('fa-eye-slash');
+        $input.attr('type', 'text');
+        $icon.addClass('fa-eye');
+        $icon.removeClass('fa-eye-slash');
     }
 }


### PR DESCRIPTION
Fixes #2951

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -
Added an eye button to the password reset form to allow users to show/hide their passwords, matching the existing functionality on the login page.

Changes include:
- Added `.users-password-input` class to both the `:password` and `:password_confirmation` fields in `app/views/users/passwords/edit.html.erb`.
- Injected the eye-icon toggle markup next to both fields.
- Modified `togglePassword.js` to target `.password-icon` by class instead of ID, allowing both fields to stay perfectly in sync when the user clicks the eye icon to verify their passwords match.
- Wrapped the "Change my password" submit button and the "Go to Login Page" link in a `flex-column` to vertically align the login link beneath the button as requested in the issue thread.

### Screenshots of the UI changes -
<img width="1600" height="1000" alt="image" src="https://github.com/user-attachments/assets/6166ef85-1919-46fd-a2bc-d830c4cc6232" />
<img width="1600" height="1000" alt="image" src="https://github.com/user-attachments/assets/b71a1c67-c5af-4654-a132-8d1f04079afb" />


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
To fix the missing eye icon, I closely referenced how the login page (`app/views/users/sessions/new.html.erb`) implements the `togglePassword()` function. 

Since the password reset form has two password inputs (a primary password and a confirmation), I chose to implement dual eye icons. To support this without duplicating JS, I updated `public/js/togglePassword.js` to rely on the `.password-icon` CSS class rather than a hardcoded `#toggle-icon` ID. Now, clicking either eye icon securely toggles both inputs in sync, allowing the user to easily compare them. Finally, I restructured the flexbox container beneath the form to neatly stack the "Go to Login Page" link vertically.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Refreshed password visibility controls across password reset, registration, and login forms for a cleaner, more consistent layout.
  * Updated the layout of the password reset submit area to stack actions vertically with improved alignment.
* **Bug Fixes**
  * Password visibility toggles now reliably target the correct field and icon, ensuring the right input is shown/hidden.
  * Improved toggle accessibility by switching to proper button controls with clearer labeling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->