### PR TITLE
feat(organizations): add organization settings (edit) page

### DIFF
--- a/app/assets/stylesheets/organizations.scss
+++ b/app/assets/stylesheets/organizations.scss
@@ -1,408 +1,105 @@
-.organizations-page-wrapper {
-  margin: 0 auto;
-  max-width: 800px;
-  padding: 30px 20px 60px;
-}
-.organizations-page-header {
-  margin-bottom: 28px;
-}
-.organizations-back-link {
-  align-items: center;
-  color: #42b983;
-  display: inline-flex;
-  font-size: 14px;
-  font-weight: 500;
-  gap: 6px;
-  margin-bottom: 16px;
-  text-decoration: none;
-  &:hover {
-    color: #026e57;
-    text-decoration: none;
+$org-green:       #42b983;
+$org-green-dark:  #026e57;
+
+.btn-success {
+  background-color: $org-green;
+  border-color: $org-green;
+  color: #fff;
+  font-weight: 400;
+  transition: filter 0.2s;
+
+  &:hover,
+  &:focus,
+  &:active {
+    background-color: $org-green !important;
+    border-color: $org-green !important;
+    color: #fff !important;
+    filter: brightness(1.05);
   }
 }
-.organizations-page-title {
-  color: #42b983;
-  font-size: 26px;
-  font-weight: 700;
-  margin-bottom: 6px;
+
+.text-success {
+  color: $org-green !important;
 }
-.organizations-page-subtitle {
-  color: #6b7280;
-  font-size: 14px;
-  margin-bottom: 0;
+
+.btn-outline-secondary {
+  border-color: #e5e7eb;
+  color: #374151;
+
+  &:hover,
+  &:focus,
+  &:active {
+    background-color: #f8fafc !important;
+    border-color: #e5e7eb !important;
+    color: #374151 !important;
+  }
 }
-.organizations-form-card {
+
+.input-group-text {
   background-color: #fff;
-  border: 1.5px solid #e5e5e5;
-  border-radius: 10px;
-  padding: 36px 40px 40px;
-}
-.organizations-error-banner {
-  align-items: flex-start;
-  background-color: #fae3e3;
-  border-radius: 6px;
-  color: #ff5959;
-  display: flex;
-  font-size: 14px;
-  gap: 10px;
-  margin-bottom: 24px;
-  padding: 14px 16px;
-  i {
-    flex-shrink: 0;
-    font-size: 16px;
-    margin-top: 2px;
+  border-color: #e5e7eb;
+
+  .fa-building,
+  .fa-map-marker-alt {
+    color: $org-green;
   }
-}
-.organizations-error-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  li {
-    margin-bottom: 4px;
-    &:last-child {
-      margin-bottom: 0;
-    }
-  }
-}
-.organizations-form-section-header {
-  border-bottom: 1.5px solid #e5e5e5;
-  margin-bottom: 28px;
-  padding-bottom: 16px;
-}
-.organizations-form-section-title {
-  font-size: 17px;
-  font-weight: 600;
-  margin-bottom: 4px;
-}
-.organizations-form-section-subtitle {
-  color: #6b7280;
-  font-size: 13px;
-  margin-bottom: 0;
-}
-.organizations-field {
-  margin-bottom: 24px;
-}
-.organizations-field-label {
-  display: block;
-  font-size: 14px;
-  font-weight: 600;
-  margin-bottom: 4px;
-}
-.organizations-field-hint {
-  color: #6b7280;
-  font-size: 12px;
-  margin-bottom: 8px;
-}
-.organizations-required-asterisk {
-  color: #ff5959;
-  font-size: 13px;
-  margin-left: 3px;
-}
-.organizations-text-input {
-  border: 1.5px solid #e5e5e5;
-  border-radius: 6px;
-  color: #111;
-  font-size: 14px;
-  padding: 10px 14px;
-  transition: border-color 0.2s, box-shadow 0.2s;
-  width: 100%;
-  &:focus {
-    border-color: #42b983;
-    box-shadow: 0 0 0 3px rgba(66, 185, 131, 0.25);
-    outline: none;
-  }
-  &::placeholder {
+  .fa-link {
     color: #9ca3af;
   }
 }
-.organizations-input-wrapper {
-  position: relative;
-  .organizations-input-icon {
-    color: #9ca3af;
-    left: 14px;
-    pointer-events: none;
-    position: absolute;
-    top: 50%;
-    transform: translateY(-50%);
-    font-size: 16px;
-    &.fa-youtube { color: #ff0000; }
-    &.fa-github { color: #24292e; }
-    &.fa-instagram { color: #e1306c; }
-    &.fa-linkedin { color: #0a66c2; }
-    &.fa-discord { color: #5865F2; }
-    &.fa-facebook { color: #1877f2; }
-    &.fa-slack { color: #e01e5a; }
-  }
-  .custom-icon-x {
-    display: inline-block;
-    width: 16px;
-    height: 16px;
-    background-image: image-url('logos/twitter-x.png');
-    background-size: contain;
-    background-repeat: no-repeat;
-    background-position: center;
-    position: absolute;
-    left: 14px;
-    top: 50%;
-    transform: translateY(-50%);
-    pointer-events: none;
-  }
-  .organizations-text-input--with-icon {
-    padding-left: 40px;
-  }
+
+.organizations-input-icon,
+.org-social-icon {
+  &.fa-youtube   { color: #ff0000; }
+  &.fa-github    { color: #24292e; }
+  &.fa-instagram { color: #e1306c; }
+  &.fa-linkedin  { color: #0a66c2; }
+  &.fa-discord   { color: #5865f2; }
+  &.fa-facebook  { color: #1877f2; }
+  &.fa-slack     { color: #e01e5a; }
 }
-.organizations-input-group {
-  display: flex;
-  width: 100%;
-  border-radius: 6px;
-  &:focus-within {
-    box-shadow: 0 0 0 3px rgba(66, 185, 131, 0.25);
-    .organizations-input-group__field,
-    .organizations-input-group__suffix {
-      border-color: #42b983;
-    }
-  }
-  .organizations-input-group__field {
-    border-radius: 6px 0 0 6px;
-    border-right: 0;
-    flex: 1;
-    min-width: 0;
-    &:focus {
-      box-shadow: none;
-    }
-  }
-  .organizations-input-group__suffix {
-    align-items: center;
-    background-color: #f8fafc;
-    border: 1.5px solid #e5e5e5;
-    border-left: 0;
-    border-radius: 0 6px 6px 0;
-    color: #6b7280;
-    display: flex;
-    font-size: 13px;
-    padding: 0 12px;
-    white-space: nowrap;
-    transition: border-color 0.2s ease;
-  }
-}
-#organizations-links-container {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  margin-bottom: 12px;
-}
-.organizations-link-item {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  .organizations-text-input {
-    flex: 1;
-  }
-}
+
 .organizations-remove-link-btn {
-  background: none;
-  border: none;
-  color: #ff5959;
-  cursor: pointer;
-  font-size: 16px;
-  padding: 6px;
-  transition: color 0.2s, transform 0.15s;
+  border: 1px solid #e5e7eb;
+  background: #fff;
+  color: #9ca3af;
+  transition: all 0.15s;
+
   &:hover {
-    color: #c21d1d;
-    transform: scale(1.1);
+    background: #fef2f2;
+    color: #ef4444;
+    border-color: #fecaca;
   }
 }
-.organizations-add-link-btn {
-  background: none;
-  border: 1px dashed #42b983;
-  border-radius: 6px;
-  color: #42b983;
-  cursor: pointer;
-  font-size: 13px;
-  font-weight: 500;
-  padding: 8px 14px;
-  transition: background-color 0.2s, color 0.2s;
-  width: fit-content;
-  &:hover {
-    background-color: #eef7f3;
-    color: #026e57;
-  }
-}
-.organizations-textarea {
-  border: 1.5px solid #e5e5e5;
-  border-radius: 6px;
-  color: #111;
-  font-size: 14px;
-  padding: 10px 14px;
-  resize: vertical;
-  transition: border-color 0.2s, box-shadow 0.2s;
-  width: 100%;
-  &:focus {
-    border-color: #42b983;
-    box-shadow: 0 0 0 3px rgba(66, 185, 131, 0.25);
-    outline: none;
-  }
-  &::placeholder {
-    color: #9ca3af;
-  }
-}
-.organizations-select-wrapper {
-  position: relative;
-}
-.organizations-select {
-  appearance: none;
-  border: 1.5px solid #e5e5e5;
-  border-radius: 6px;
-  color: #111;
-  cursor: pointer;
-  font-size: 14px;
-  padding: 10px 36px 10px 14px;
-  transition: border-color 0.2s, box-shadow 0.2s;
-  width: 100%;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%236b7280' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
-  background-position: right 14px center;
-  background-repeat: no-repeat;
-  &:focus {
-    border-color: #42b983;
-    box-shadow: 0 0 0 3px rgba(66, 185, 131, 0.25);
-    outline: none;
-  }
-}
-.organizations-upload-zone {
+
+.org-upload-zone {
   background-color: #f9fffc;
-  border: 2px dashed #026e57;
+  border: 2px dashed $org-green-dark;
   border-radius: 8px;
   cursor: pointer;
   padding: 36px 20px;
   text-align: center;
   transition: background-color 0.2s, border-color 0.2s;
+
   &:hover,
   &--active {
     background-color: #eef7f3;
-    border-color: #42b983;
+    border-color: $org-green;
+  }
+
+  &__icon {
+    color: $org-green;
+    font-size: 32px;
+    margin-bottom: 10px;
   }
 }
-.organizations-upload-zone__content {
-  pointer-events: none;
-}
-.organizations-upload-zone__icon {
-  color: #42b983;
-  font-size: 32px;
-  margin-bottom: 10px;
-}
-.organizations-upload-zone__text {
-  color: #374151;
-  font-size: 14px;
-  margin-bottom: 4px;
-}
-.organizations-upload-zone__link {
-  color: #42b983;
-  font-weight: 600;
-  &:hover {
-    text-decoration: underline;
-  }
-}
-.organizations-upload-zone__hint {
-  color: #9ca3af;
-  font-size: 12px;
-  margin-bottom: 0;
-}
-.organizations-upload-zone__input {
-  display: none;
-}
-.organizations-upload-filename {
-  color: #42b983;
-  font-size: 13px;
-  font-weight: 500;
-  margin-top: 8px;
-  min-height: 20px;
-}
-.organizations-form-actions {
-  align-items: center;
-  border-top: 1.5px solid #e5e5e5;
-  display: flex;
-  gap: 12px;
-  justify-content: flex-end;
-  margin-top: 32px;
-  padding-top: 24px;
-}
-.organizations-btn-primary {
-  background-color: #42b983;
-  border: none;
-  border-radius: 6px;
-  color: #fff;
-  font-size: 14px;
-  font-weight: 600;
-  padding: 10px 24px;
-  transition: background-color 0.2s, transform 0.15s;
-  &:hover {
-    background-color: #026e57;
-    color: #fff;
-    text-decoration: none;
-    transform: translateY(-1px);
-  }
-  &:active {
-    transform: translateY(0);
-  }
-}
-.organizations-btn-secondary {
-  background-color: transparent;
-  border: 1.5px solid #e5e5e5;
-  border-radius: 6px;
-  color: #374151;
-  font-size: 14px;
-  font-weight: 500;
-  padding: 10px 20px;
-  transition: background-color 0.2s, border-color 0.2s;
-  &:hover {
-    background-color: #f8fafc;
-    color: #374151;
-    text-decoration: none;
-  }
-}
-.org-btn-danger-outline {
-  background-color: transparent;
-  color: $primary-red;
-  border: 1px solid $primary-red;
-  border-radius: 8px;
-  padding: 10px 20px;
-  font-weight: 600;
-  font-size: 14px;
-  transition: all 0.2s;
-  i {
-    margin-right: 6px;
-  }
-  &:hover {
-    background-color: $primary-red;
-    color: $white;
-    text-decoration: none;
-  }
-}
-@media (max-width: 600px) {
-  .organizations-form-card {
-    padding: 24px 18px;
-  }
-  .organizations-input-group {
-    flex-direction: column;
-    .organizations-input-group__field {
-      border-radius: 6px 6px 0 0;
-      border-right: 1.5px solid #e5e5e5;
-      border-bottom: 0;
-    }
-    .organizations-input-group__suffix {
-      border-left: 1.5px solid #e5e5e5;
-      border-radius: 0 0 6px 6px;
-      border-top: 0;
-      justify-content: center;
-      padding: 8px 12px;
-    }
-  }
-  .organizations-form-actions {
-    flex-direction: column-reverse;
-    .organizations-btn-primary,
-    .organizations-btn-secondary {
-      text-align: center;
-      width: 100%;
-    }
-  }
+
+.custom-icon-x {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  background-image: image-url('logos/twitter-x.png');
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
 }

--- a/app/assets/stylesheets/organizations.scss
+++ b/app/assets/stylesheets/organizations.scss
@@ -1,0 +1,408 @@
+.organizations-page-wrapper {
+  margin: 0 auto;
+  max-width: 800px;
+  padding: 30px 20px 60px;
+}
+.organizations-page-header {
+  margin-bottom: 28px;
+}
+.organizations-back-link {
+  align-items: center;
+  color: #42b983;
+  display: inline-flex;
+  font-size: 14px;
+  font-weight: 500;
+  gap: 6px;
+  margin-bottom: 16px;
+  text-decoration: none;
+  &:hover {
+    color: #026e57;
+    text-decoration: none;
+  }
+}
+.organizations-page-title {
+  color: #42b983;
+  font-size: 26px;
+  font-weight: 700;
+  margin-bottom: 6px;
+}
+.organizations-page-subtitle {
+  color: #6b7280;
+  font-size: 14px;
+  margin-bottom: 0;
+}
+.organizations-form-card {
+  background-color: #fff;
+  border: 1.5px solid #e5e5e5;
+  border-radius: 10px;
+  padding: 36px 40px 40px;
+}
+.organizations-error-banner {
+  align-items: flex-start;
+  background-color: #fae3e3;
+  border-radius: 6px;
+  color: #ff5959;
+  display: flex;
+  font-size: 14px;
+  gap: 10px;
+  margin-bottom: 24px;
+  padding: 14px 16px;
+  i {
+    flex-shrink: 0;
+    font-size: 16px;
+    margin-top: 2px;
+  }
+}
+.organizations-error-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  li {
+    margin-bottom: 4px;
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+}
+.organizations-form-section-header {
+  border-bottom: 1.5px solid #e5e5e5;
+  margin-bottom: 28px;
+  padding-bottom: 16px;
+}
+.organizations-form-section-title {
+  font-size: 17px;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+.organizations-form-section-subtitle {
+  color: #6b7280;
+  font-size: 13px;
+  margin-bottom: 0;
+}
+.organizations-field {
+  margin-bottom: 24px;
+}
+.organizations-field-label {
+  display: block;
+  font-size: 14px;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+.organizations-field-hint {
+  color: #6b7280;
+  font-size: 12px;
+  margin-bottom: 8px;
+}
+.organizations-required-asterisk {
+  color: #ff5959;
+  font-size: 13px;
+  margin-left: 3px;
+}
+.organizations-text-input {
+  border: 1.5px solid #e5e5e5;
+  border-radius: 6px;
+  color: #111;
+  font-size: 14px;
+  padding: 10px 14px;
+  transition: border-color 0.2s, box-shadow 0.2s;
+  width: 100%;
+  &:focus {
+    border-color: #42b983;
+    box-shadow: 0 0 0 3px rgba(66, 185, 131, 0.25);
+    outline: none;
+  }
+  &::placeholder {
+    color: #9ca3af;
+  }
+}
+.organizations-input-wrapper {
+  position: relative;
+  .organizations-input-icon {
+    color: #9ca3af;
+    left: 14px;
+    pointer-events: none;
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    font-size: 16px;
+    &.fa-youtube { color: #ff0000; }
+    &.fa-github { color: #24292e; }
+    &.fa-instagram { color: #e1306c; }
+    &.fa-linkedin { color: #0a66c2; }
+    &.fa-discord { color: #5865F2; }
+    &.fa-facebook { color: #1877f2; }
+    &.fa-slack { color: #e01e5a; }
+  }
+  .custom-icon-x {
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    background-image: image-url('logos/twitter-x.png');
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+    position: absolute;
+    left: 14px;
+    top: 50%;
+    transform: translateY(-50%);
+    pointer-events: none;
+  }
+  .organizations-text-input--with-icon {
+    padding-left: 40px;
+  }
+}
+.organizations-input-group {
+  display: flex;
+  width: 100%;
+  border-radius: 6px;
+  &:focus-within {
+    box-shadow: 0 0 0 3px rgba(66, 185, 131, 0.25);
+    .organizations-input-group__field,
+    .organizations-input-group__suffix {
+      border-color: #42b983;
+    }
+  }
+  .organizations-input-group__field {
+    border-radius: 6px 0 0 6px;
+    border-right: 0;
+    flex: 1;
+    min-width: 0;
+    &:focus {
+      box-shadow: none;
+    }
+  }
+  .organizations-input-group__suffix {
+    align-items: center;
+    background-color: #f8fafc;
+    border: 1.5px solid #e5e5e5;
+    border-left: 0;
+    border-radius: 0 6px 6px 0;
+    color: #6b7280;
+    display: flex;
+    font-size: 13px;
+    padding: 0 12px;
+    white-space: nowrap;
+    transition: border-color 0.2s ease;
+  }
+}
+#organizations-links-container {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+.organizations-link-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  .organizations-text-input {
+    flex: 1;
+  }
+}
+.organizations-remove-link-btn {
+  background: none;
+  border: none;
+  color: #ff5959;
+  cursor: pointer;
+  font-size: 16px;
+  padding: 6px;
+  transition: color 0.2s, transform 0.15s;
+  &:hover {
+    color: #c21d1d;
+    transform: scale(1.1);
+  }
+}
+.organizations-add-link-btn {
+  background: none;
+  border: 1px dashed #42b983;
+  border-radius: 6px;
+  color: #42b983;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+  padding: 8px 14px;
+  transition: background-color 0.2s, color 0.2s;
+  width: fit-content;
+  &:hover {
+    background-color: #eef7f3;
+    color: #026e57;
+  }
+}
+.organizations-textarea {
+  border: 1.5px solid #e5e5e5;
+  border-radius: 6px;
+  color: #111;
+  font-size: 14px;
+  padding: 10px 14px;
+  resize: vertical;
+  transition: border-color 0.2s, box-shadow 0.2s;
+  width: 100%;
+  &:focus {
+    border-color: #42b983;
+    box-shadow: 0 0 0 3px rgba(66, 185, 131, 0.25);
+    outline: none;
+  }
+  &::placeholder {
+    color: #9ca3af;
+  }
+}
+.organizations-select-wrapper {
+  position: relative;
+}
+.organizations-select {
+  appearance: none;
+  border: 1.5px solid #e5e5e5;
+  border-radius: 6px;
+  color: #111;
+  cursor: pointer;
+  font-size: 14px;
+  padding: 10px 36px 10px 14px;
+  transition: border-color 0.2s, box-shadow 0.2s;
+  width: 100%;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%236b7280' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
+  background-position: right 14px center;
+  background-repeat: no-repeat;
+  &:focus {
+    border-color: #42b983;
+    box-shadow: 0 0 0 3px rgba(66, 185, 131, 0.25);
+    outline: none;
+  }
+}
+.organizations-upload-zone {
+  background-color: #f9fffc;
+  border: 2px dashed #026e57;
+  border-radius: 8px;
+  cursor: pointer;
+  padding: 36px 20px;
+  text-align: center;
+  transition: background-color 0.2s, border-color 0.2s;
+  &:hover,
+  &--active {
+    background-color: #eef7f3;
+    border-color: #42b983;
+  }
+}
+.organizations-upload-zone__content {
+  pointer-events: none;
+}
+.organizations-upload-zone__icon {
+  color: #42b983;
+  font-size: 32px;
+  margin-bottom: 10px;
+}
+.organizations-upload-zone__text {
+  color: #374151;
+  font-size: 14px;
+  margin-bottom: 4px;
+}
+.organizations-upload-zone__link {
+  color: #42b983;
+  font-weight: 600;
+  &:hover {
+    text-decoration: underline;
+  }
+}
+.organizations-upload-zone__hint {
+  color: #9ca3af;
+  font-size: 12px;
+  margin-bottom: 0;
+}
+.organizations-upload-zone__input {
+  display: none;
+}
+.organizations-upload-filename {
+  color: #42b983;
+  font-size: 13px;
+  font-weight: 500;
+  margin-top: 8px;
+  min-height: 20px;
+}
+.organizations-form-actions {
+  align-items: center;
+  border-top: 1.5px solid #e5e5e5;
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+  margin-top: 32px;
+  padding-top: 24px;
+}
+.organizations-btn-primary {
+  background-color: #42b983;
+  border: none;
+  border-radius: 6px;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+  padding: 10px 24px;
+  transition: background-color 0.2s, transform 0.15s;
+  &:hover {
+    background-color: #026e57;
+    color: #fff;
+    text-decoration: none;
+    transform: translateY(-1px);
+  }
+  &:active {
+    transform: translateY(0);
+  }
+}
+.organizations-btn-secondary {
+  background-color: transparent;
+  border: 1.5px solid #e5e5e5;
+  border-radius: 6px;
+  color: #374151;
+  font-size: 14px;
+  font-weight: 500;
+  padding: 10px 20px;
+  transition: background-color 0.2s, border-color 0.2s;
+  &:hover {
+    background-color: #f8fafc;
+    color: #374151;
+    text-decoration: none;
+  }
+}
+.org-btn-danger-outline {
+  background-color: transparent;
+  color: $primary-red;
+  border: 1px solid $primary-red;
+  border-radius: 8px;
+  padding: 10px 20px;
+  font-weight: 600;
+  font-size: 14px;
+  transition: all 0.2s;
+  i {
+    margin-right: 6px;
+  }
+  &:hover {
+    background-color: $primary-red;
+    color: $white;
+    text-decoration: none;
+  }
+}
+@media (max-width: 600px) {
+  .organizations-form-card {
+    padding: 24px 18px;
+  }
+  .organizations-input-group {
+    flex-direction: column;
+    .organizations-input-group__field {
+      border-radius: 6px 6px 0 0;
+      border-right: 1.5px solid #e5e5e5;
+      border-bottom: 0;
+    }
+    .organizations-input-group__suffix {
+      border-left: 1.5px solid #e5e5e5;
+      border-radius: 0 0 6px 6px;
+      border-top: 0;
+      justify-content: center;
+      padding: 8px 12px;
+    }
+  }
+  .organizations-form-actions {
+    flex-direction: column-reverse;
+    .organizations-btn-primary,
+    .organizations-btn-secondary {
+      text-align: center;
+      width: 100%;
+    }
+  }
+}

--- a/app/views/organizations/edit.html.erb
+++ b/app/views/organizations/edit.html.erb
@@ -1,0 +1,482 @@
+<% content_for :title, "Edit Organization" %>
+
+<div class="organizations-page-wrapper">
+  <%# Back link + Page header %>
+  <div class="organizations-page-header">
+    <%= link_to organization_path(@organization), class: "organizations-back-link" do %>
+      <i class="fas fa-arrow-left"></i>
+      <%= t("back") %>
+    <% end %>
+    <h1 class="organizations-page-title">Edit Organization</h1>
+    <p class="organizations-page-subtitle">Update your organization's profile and settings.</p>
+  </div>
+
+  <%# Main card %>
+  <div class="organizations-form-card">
+    <%= form_with(model: @organization, local: true,
+                  html: { enctype: "multipart/form-data", id: "edit-organization-form" }) do |form| %>
+      <%# Validation errors banner %>
+      <% if @organization.errors.any? %>
+        <div class="organizations-error-banner" role="alert">
+          <i class="fas fa-exclamation-circle"></i>
+          <ul class="organizations-error-list" role="list">
+            <% @organization.errors.full_messages.each do |message| %>
+              <li role="listitem"><%= message %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+      <%# Section heading %>
+      <div class="organizations-form-section-header">
+        <h2 class="organizations-form-section-title">Organization Details</h2>
+        <p class="organizations-form-section-subtitle">Basic information about your organization.</p>
+      </div>
+
+      <%# Organization Name %>
+      <div class="organizations-field">
+        <label class="organizations-field-label" for="organization_name">
+          <%= t("organizations.new.name_label") %>
+          <span class="organizations-required-asterisk" aria-hidden="true">*</span>
+        </label>
+        <p class="organizations-field-hint"><%= t("organizations.new.name_hint") %></p>
+        <div class="organizations-input-wrapper">
+          <i class="fas fa-building organizations-input-icon"></i>
+          <%= form.text_field :name,
+              id: "organization_name",
+              class: "organizations-text-input organizations-text-input--with-icon",
+              placeholder: t("organizations.new.name_placeholder"),
+              required: true,
+              maxlength: 50 %>
+        </div>
+        <div style="text-align: right; margin-top: 6px;">
+          <span id="org-name-counter" style="font-size: 12px; color: #6b7280; font-weight: 500;">
+            50 characters remaining
+          </span>
+        </div>
+      </div>
+
+      <%# Organization URL / Slug Preview %>
+      <div class="organizations-field">
+        <label class="organizations-field-label">
+          Organization URL
+        </label>
+        <div class="organizations-url-preview" id="org-slug-preview-box" style="display: flex; align-items: center; gap: 4px; padding: 10px 14px; background-color: #f9fafb; border: 1px solid #e5e7eb; border-radius: 6px; color: #6b7280; margin-top: 8px; flex-wrap: wrap;">
+          <span>circuitverse.org/organizations/</span><span id="organization-slug-preview" style="color: <%= @organization.slug.present? ? '#111827' : '#9ca3af' %>;"><%= @organization.slug.presence || 'your-org-name' %></span>
+          <span id="org-slug-status" style="display: none; font-size: 12px; font-weight: 600; padding: 2px 8px; border-radius: 12px;"></span>
+        </div>
+        <p id="org-slug-hint" class="organizations-field-hint" style="margin-top: 6px; display: none;"></p>
+      </div>
+
+      <%# Description %>
+      <div class="organizations-field">
+        <%= form.label :description, class: "organizations-field-label" do %>
+          <%= t("organizations.new.description_label") %>
+        <% end %>
+        <p class="organizations-field-hint"><%= t("organizations.new.description_hint") %></p>
+        <%= form.text_area :description,
+            class: "organizations-textarea",
+            id: "org-description-input",
+            maxlength: 160,
+            rows: 3,
+            placeholder: t("organizations.new.description_placeholder") %>
+        <div style="text-align: right; margin-top: 6px;">
+          <span id="org-description-counter" style="font-size: 12px; color: #6b7280; font-weight: 500;">
+            160 characters remaining
+          </span>
+        </div>
+      </div>
+
+      <%# Location %>
+      <div class="organizations-field">
+        <label class="organizations-field-label" for="organization_location">
+          Location
+        </label>
+        <p class="organizations-field-hint">Where is your organization based?</p>
+        <div class="organizations-input-wrapper">
+          <i class="fas fa-map-marker-alt organizations-input-icon"></i>
+          <%= form.text_field :location,
+              id: "organization_location",
+              class: "organizations-text-input organizations-text-input--with-icon",
+              placeholder: "e.g. San Francisco, CA",
+              maxlength: 100 %>
+        </div>
+      </div>
+
+      <%# Visibility %>
+      <div class="organizations-field">
+        <%= form.label :private, t("organizations.new.visibility_label"), class: "organizations-field-label" %>
+        <p class="organizations-field-hint"><%= t("organizations.new.visibility_hint") %></p>
+        <div class="organizations-select-wrapper">
+          <%= form.select :private,
+              [
+                [t("organizations.new.visibility_private"), true],
+                [t("organizations.new.visibility_public"), false]
+              ],
+              {},
+              { id: "organization_private", class: "organizations-select" } %>
+        </div>
+      </div>
+
+      <%# External Links %>
+      <div class="organizations-field">
+        <label class="organizations-field-label"><%= t("organizations.new.links_label") %></label>
+        <p class="organizations-field-hint"><%= t("organizations.new.links_hint") %></p>
+        <div id="organizations-links-container">
+          <% if @organization.respond_to?(:links) && @organization.links.present? && @organization.links.is_a?(Array) && @organization.links.reject(&:blank?).any? %>
+            <% @organization.links.reject(&:blank?).each do |link| %>
+              <div class="organizations-input-wrapper organizations-link-item">
+                <i class="fas fa-link organizations-input-icon"></i>
+                <input type="url" name="organization[links][]" class="organizations-text-input organizations-text-input--with-icon" value="<%= link %>" placeholder="<%= t('organizations.new.links_placeholder') %>">
+                <button type="button" class="organizations-remove-link-btn" title="Remove link" style="display: none;">
+                  <i class="fas fa-times"></i>
+                </button>
+              </div>
+            <% end %>
+          <% else %>
+            <div class="organizations-input-wrapper organizations-link-item">
+              <i class="fas fa-link organizations-input-icon"></i>
+              <input type="url" name="organization[links][]" class="organizations-text-input organizations-text-input--with-icon" placeholder="<%= t('organizations.new.links_placeholder') %>">
+              <button type="button" class="organizations-remove-link-btn" title="Remove link" style="display: none;">
+                <i class="fas fa-times"></i>
+              </button>
+            </div>
+          <% end %>
+        </div>
+        <button type="button" id="organizations-add-link-btn" class="organizations-add-link-btn" aria-label="<%= t('organizations.new.add_link') %>">
+          <%= t("organizations.new.add_link") %>
+        </button>
+      </div>
+
+      <%# Logo Upload %>
+      <div class="organizations-field">
+        <%= form.label :logo, t("organizations.new.logo_label"), class: "organizations-field-label" %>
+        <p class="organizations-field-hint"><%= t("organizations.new.logo_hint") %></p>
+        <% if @organization.logo.attached? %>
+          <div style="margin-bottom: 12px; display: flex; align-items: center; gap: 12px; padding: 12px; border: 1px solid #e5e7eb; border-radius: 8px; background: #f9fafb;">
+            <%= image_tag @organization.logo, style: "width: 48px; height: 48px; border-radius: 8px; object-fit: cover; border: 1px solid #d1d5db;", alt: "#{@organization.name} logo" %>
+            <div style="display: flex; flex-direction: column;">
+              <span style="font-size: 14px; font-weight: 600; color: #374151;">Current Logo</span>
+              <span style="font-size: 12px; color: #6b7280;">Upload a new image below to replace</span>
+            </div>
+          </div>
+        <% end %>
+        <div class="organizations-upload-zone"
+             id="organization-upload-zone"
+             role="button"
+             tabindex="0"
+             onclick="document.getElementById('organization_logo').click()"
+             onkeydown="if(event.key==='Enter')this.click()">
+          <div class="organizations-upload-zone__content">
+            <i class="fas fa-cloud-upload-alt organizations-upload-zone__icon"></i>
+            <p class="organizations-upload-zone__text">
+              <span class="organizations-upload-zone__link"><%= t("organizations.new.upload_click") %></span>
+              <%= t("organizations.new.upload_drag") %>
+            </p>
+            <p class="organizations-upload-zone__hint"><%= t("organizations.new.upload_hint") %></p>
+          </div>
+          <%= form.file_field :logo,
+              id: "organization_logo",
+              class: "organizations-upload-zone__input",
+              accept: "image/png,image/jpeg,image/svg+xml" %>
+        </div>
+        <%# Show filename after file is selected %>
+        <p class="organizations-upload-filename" id="organization-upload-filename"></p>
+      </div>
+
+      <%# Form actions %>
+      <div class="organizations-form-actions">
+        <%= link_to t("cancel"), organization_path(@organization), class: "btn organizations-btn-secondary" %>
+        <%= form.submit "Update Organization",
+            id: "organization-submit-btn",
+            class: "btn organizations-btn-primary" %>
+      </div>
+    <% end %>
+  </div>
+
+  <%# Danger Zone - Delete Organization %>
+  <% if policy(@organization).destroy? %>
+    <div class="organizations-form-card" style="margin-top: 24px; border-color: #ff5959; background-color: #fffafa;">
+      <div class="organizations-form-section-header" style="border-bottom-color: #fca5a5;">
+        <h2 class="organizations-form-section-title" style="color: #ff5959;">Danger Zone</h2>
+        <p class="organizations-form-section-subtitle">Irreversible actions for this organization.</p>
+      </div>
+      <div style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 16px;">
+        <div>
+          <strong style="color: #111; font-size: 15px;">Delete this organization</strong>
+          <p style="color: #6b7280; font-size: 13px; margin: 4px 0 0 0; max-width: 400px;">
+            Once you delete an organization, all its member associations will be permanently removed. Any groups inside this organization will not be deleted, but will become standard standalone groups. There is no going back.
+          </p>
+        </div>
+        <button type="button" class="btn org-btn-danger-outline" data-bs-toggle="modal" data-bs-target="#deleteOrgModal" aria-label="<%= t('organizations.show.delete_btn') %>">
+          <i class="fas fa-trash-alt" aria-hidden="true"></i> <%= t("organizations.show.delete_btn") %>
+        </button>
+      </div>
+    </div>
+  <% end %>
+</div>
+
+<%# ── Delete Organization Modal (Bootstrap) ───────────────────────── %>
+<div class="modal fade" id="deleteOrgModal" tabindex="-1" aria-labelledby="deleteOrgModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content" style="border-radius: 12px; overflow: hidden; border: none; box-shadow: 0 10px 25px rgba(0,0,0,0.15);">
+      <div class="modal-header" style="background-color: #fee2e2; border-bottom: 1px solid #fca5a5; padding: 16px 24px;">
+        <h5 class="modal-title" id="deleteOrgModalLabel" style="color: #b91c1c; font-weight: 700; font-size: 16px;">
+          <i class="fas fa-exclamation-triangle" style="margin-right: 8px;"></i> Delete Organization
+        </h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body" style="padding: 24px;">
+        <div style="background-color: #fffafa; border-left: 4px solid #ef4444; padding: 12px 16px; margin-bottom: 20px; font-size: 14px; color: #374151;">
+          This action <strong>cannot</strong> be undone. This will permanently delete the <strong><%= @organization.name %></strong> organization. Any groups inside this organization will not be deleted, but will become standard standalone groups.
+        </div>
+        <p style="font-size: 14px; color: #4b5563; margin-bottom: 8px; font-weight: 500;">
+          Please type <strong><%= @organization.name %></strong> to confirm.
+        </p>
+        <input type="text" id="deleteOrgConfirmInput" class="organizations-text-input" autocomplete="off" style="width: 100%; margin-bottom: 24px;">
+        <%= form_with url: organization_path(@organization), method: :delete, local: true do |f| %>
+          <button type="submit" id="deleteOrgSubmitBtn" class="btn" style="width: 100%; background-color: #ef4444; color: white; font-weight: 500; font-size: 15px; padding: 10px;" disabled>
+            I understand the consequences, delete this organization
+          </button>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>
+
+<%# JS: update filename label + drag-and-drop highlight + dynamic links + modal validation %>
+<script>
+  (function () {
+    // --- Delete Organization Modal Logic ---
+    const deleteInput = document.getElementById('deleteOrgConfirmInput');
+    const deleteBtn = document.getElementById('deleteOrgSubmitBtn');
+    const orgName = "<%= j @organization.name %>";
+    if (deleteInput && deleteBtn) {
+      deleteInput.addEventListener('input', function() {
+        if (this.value === orgName) {
+          deleteBtn.disabled = false;
+          deleteBtn.style.opacity = '1';
+        } else {
+          deleteBtn.disabled = true;
+          deleteBtn.style.opacity = '0.5';
+        }
+      });
+      const modalEl = document.getElementById('deleteOrgModal');
+      if (modalEl) {
+        modalEl.addEventListener('show.bs.modal', function () {
+          deleteInput.value = '';
+          deleteBtn.disabled = true;
+          deleteBtn.style.opacity = '0.5';
+        });
+      }
+    }
+
+    // --- File Upload Logic ---
+    const zone     = document.getElementById("organization-upload-zone");
+    const input    = document.getElementById("organization_logo");
+    const label    = document.getElementById("organization-upload-filename");
+    input.addEventListener("change", function () {
+      if (this.files && this.files[0]) {
+        label.textContent = this.files[0].name;
+      }
+    });
+    ["dragover", "dragenter"].forEach(function (evt) {
+      zone.addEventListener(evt, function (e) {
+        e.preventDefault();
+        zone.classList.add("organizations-upload-zone--active");
+      });
+    });
+    ["dragleave", "drop"].forEach(function (evt) {
+      zone.addEventListener(evt, function () {
+        zone.classList.remove("organizations-upload-zone--active");
+      });
+    });
+    zone.addEventListener("drop", function (e) {
+      e.preventDefault();
+      if (e.dataTransfer.files && e.dataTransfer.files[0]) {
+        input.files = e.dataTransfer.files;
+        label.textContent = e.dataTransfer.files[0].name;
+      }
+    });
+
+    // --- Dynamic Links Logic ---
+    const linksContainer = document.getElementById("organizations-links-container");
+    const addLinkBtn     = document.getElementById("organizations-add-link-btn");
+    const MAX_LINKS      = 5;
+    function updateRemoveButtons() {
+      const items = linksContainer.querySelectorAll(".organizations-link-item");
+      items.forEach((item, index) => {
+        const btn = item.querySelector(".organizations-remove-link-btn");
+        // Show remove button if there is more than 1 item
+        if (items.length > 1) {
+          btn.style.display = "block";
+        } else {
+          btn.style.display = "none";
+        }
+      });
+      // Hide add button if max reached
+      addLinkBtn.style.display = items.length >= MAX_LINKS ? "none" : "inline-block";
+    }
+    function updateLinkIcon(input) {
+      const urlString = input.value.trim();
+      const icon = input.closest(".organizations-link-item").querySelector(".organizations-input-icon");
+      if (!icon) return;
+      icon.className = "organizations-input-icon"; // reset base class
+      if (!urlString) {
+        icon.classList.add("fas", "fa-link");
+        return;
+      }
+      let hostname = "";
+      try {
+        // Prefix with http:// if missing so URL parser doesn't throw on valid domains
+        const parsedUrl = new URL(urlString.startsWith('http') ? urlString : 'https://' + urlString);
+        hostname = parsedUrl.hostname.toLowerCase();
+      } catch (e) {
+        icon.classList.add("fas", "fa-link");
+        return;
+      }
+      const isDomain = (host, domain) => host === domain || host.endsWith('.' + domain);
+      if (isDomain(hostname, "github.com")) icon.classList.add("fab", "fa-github");
+      else if (isDomain(hostname, "instagram.com")) icon.classList.add("fab", "fa-instagram");
+      else if (isDomain(hostname, "twitter.com") || isDomain(hostname, "x.com")) icon.classList.add("custom-icon-x");
+      else if (isDomain(hostname, "linkedin.com")) icon.classList.add("fab", "fa-linkedin");
+      else if (isDomain(hostname, "youtube.com") || isDomain(hostname, "youtu.be")) icon.classList.add("fab", "fa-youtube");
+      else if (isDomain(hostname, "discord.com") || isDomain(hostname, "discord.gg")) icon.classList.add("fab", "fa-discord");
+      else if (isDomain(hostname, "facebook.com")) icon.classList.add("fab", "fa-facebook");
+      else if (isDomain(hostname, "slack.com")) icon.classList.add("fab", "fa-slack");
+      else icon.classList.add("fas", "fa-link");
+    }
+    linksContainer.addEventListener("input", function (e) {
+      if (e.target.tagName === "INPUT" && e.target.type === "url") {
+        updateLinkIcon(e.target);
+      }
+    });
+    // Run on load for existing inputs
+    linksContainer.querySelectorAll('input[type="url"]').forEach(updateLinkIcon);
+    // Call once on init to handle pre-populated links
+    updateRemoveButtons();
+    addLinkBtn.addEventListener("click", function () {
+      const items = linksContainer.querySelectorAll(".organizations-link-item");
+      if (items.length < MAX_LINKS) {
+        const newItem = items[0].cloneNode(true);
+        const input = newItem.querySelector("input");
+        input.value = "";
+        linksContainer.appendChild(newItem);
+        updateRemoveButtons();
+        updateLinkIcon(input);
+      }
+    });
+    linksContainer.addEventListener("click", function (e) {
+      const removeBtn = e.target.closest(".organizations-remove-link-btn");
+      if (removeBtn) {
+        const items = linksContainer.querySelectorAll(".organizations-link-item");
+        if (items.length > 1) {
+          removeBtn.closest(".organizations-link-item").remove();
+          updateRemoveButtons();
+        }
+      }
+    });
+
+    // --- Character Counter Helper ---
+    function setupCounter(inputId, counterId, maxLen) {
+      const input = document.getElementById(inputId);
+      const counter = document.getElementById(counterId);
+      if (input && counter) {
+        const updateCounter = () => {
+          const remaining = maxLen - input.value.length;
+          counter.textContent = `${remaining} characters remaining`;
+          if (remaining <= Math.floor(maxLen * 0.15)) {
+            counter.style.color = "#ff5959"; // primary red
+          } else {
+            counter.style.color = "#6b7280"; // gray
+          }
+        };
+        updateCounter(); // run once on load
+        input.addEventListener("input", updateCounter);
+      }
+    }
+    // Initialize Counters
+    setupCounter("organization_name", "org-name-counter", 50);
+    setupCounter("org-description-input", "org-description-counter", 160);
+
+    // --- Slug Preview + Availability Check Logic ---
+    const nameInput = document.getElementById('organization_name');
+    const slugPreview = document.getElementById('organization-slug-preview');
+    const slugStatus = document.getElementById('org-slug-status');
+    const slugHint   = document.getElementById('org-slug-hint');
+    const slugBox    = document.getElementById('org-slug-preview-box');
+    const currentSlug = '<%= @organization.slug %>';
+    let slugDebounce = null;
+    let slugRequestId = 0;
+    function setSlugStatus(state, slug) {
+      if (state === 'idle') {
+        slugStatus.style.display = 'none';
+        slugHint.style.display = 'none';
+        slugBox.style.borderColor = '#e5e7eb';
+        slugPreview.style.color = slugPreview.textContent === 'your-org-name' ? '#9ca3af' : '#111827';
+      } else if (state === 'checking') {
+        slugStatus.style.display = 'inline-block';
+        slugStatus.textContent = 'Checking...';
+        slugStatus.style.background = '#f3f4f6';
+        slugStatus.style.color = '#6b7280';
+        slugHint.style.display = 'none';
+        slugBox.style.borderColor = '#e5e7eb';
+        slugPreview.style.color = '#111827';
+      } else if (state === 'available') {
+        slugStatus.style.display = 'inline-block';
+        slugStatus.textContent = '✓ Available';
+        slugStatus.style.background = '#d1fae5';
+        slugStatus.style.color = '#065f46';
+        slugBox.style.borderColor = '#34d399';
+        slugPreview.style.color = '#065f46';
+        slugHint.style.display = 'none';
+      } else if (state === 'taken') {
+        slugStatus.style.display = 'inline-block';
+        slugStatus.textContent = '✗ Already taken';
+        slugStatus.style.background = '#fee2e2';
+        slugStatus.style.color = '#991b1b';
+        slugBox.style.borderColor = '#f87171';
+        slugPreview.style.color = '#991b1b';
+        slugHint.style.display = 'block';
+        slugHint.style.color = '#991b1b';
+        slugHint.textContent = 'This URL is taken. FriendlyId will append a unique number (e.g. ' + slug + '-1) when you save.';
+      }
+    }
+    if (nameInput && slugPreview) {
+      nameInput.addEventListener('input', function() {
+        const rawName = nameInput.value.trim();
+        if (!rawName) {
+          slugPreview.textContent = currentSlug || 'your-org-name';
+          setSlugStatus('idle', '');
+          return;
+        }
+        const localSlug = rawName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+        slugPreview.textContent = localSlug || 'your-org-name';
+        // If the slug hasn't changed from the current saved slug, no need to check
+        if (localSlug === currentSlug) {
+          setSlugStatus('idle', '');
+          return;
+        }
+        setSlugStatus('checking', localSlug);
+        clearTimeout(slugDebounce);
+        slugDebounce = setTimeout(function() {
+          const requestId = ++slugRequestId;
+          fetch('/organizations/check_slug?name=' + encodeURIComponent(rawName), {
+            headers: { 'X-Requested-With': 'XMLHttpRequest' }
+          })
+          .then(function(res) { return res.json(); })
+          .then(function(data) {
+            if (requestId !== slugRequestId) return;
+            slugPreview.textContent = data.slug || currentSlug;
+            // If the returned slug matches the org's own current slug, it's effectively available
+            setSlugStatus((data.available || data.slug === currentSlug) ? 'available' : 'taken', data.slug);
+          })
+          .catch(function() {
+            if (requestId !== slugRequestId) return;
+            setSlugStatus('idle', '');
+          });
+        }, 350);
+      });
+    }
+  })();
+</script>

--- a/app/views/organizations/edit.html.erb
+++ b/app/views/organizations/edit.html.erb
@@ -1,482 +1,383 @@
 <% content_for :title, "Edit Organization" %>
 
-<div class="organizations-page-wrapper">
-  <%# Back link + Page header %>
-  <div class="organizations-page-header">
-    <%= link_to organization_path(@organization), class: "organizations-back-link" do %>
-      <i class="fas fa-arrow-left"></i>
-      <%= t("back") %>
-    <% end %>
-    <h1 class="organizations-page-title">Edit Organization</h1>
-    <p class="organizations-page-subtitle">Update your organization's profile and settings.</p>
-  </div>
+<div class="container my-5">
+  <div class="row justify-content-center">
+    <div class="col-lg-8">
 
-  <%# Main card %>
-  <div class="organizations-form-card">
-    <%= form_with(model: @organization, local: true,
-                  html: { enctype: "multipart/form-data", id: "edit-organization-form" }) do |form| %>
-      <%# Validation errors banner %>
-      <% if @organization.errors.any? %>
-        <div class="organizations-error-banner" role="alert">
-          <i class="fas fa-exclamation-circle"></i>
-          <ul class="organizations-error-list">
-            <% @organization.errors.full_messages.each do |message| %>
-              <li><%= message %></li>
-            <% end %>
-          </ul>
-        </div>
-      <% end %>
-
-      <%# Section heading %>
-      <div class="organizations-form-section-header">
-        <h2 class="organizations-form-section-title">Organization Details</h2>
-        <p class="organizations-form-section-subtitle">Basic information about your organization.</p>
-      </div>
-
-      <%# Organization Name %>
-      <div class="organizations-field">
-        <label class="organizations-field-label" for="organization_name">
-          <%= t("organizations.new.name_label") %>
-          <span class="organizations-required-asterisk" aria-hidden="true">*</span>
-        </label>
-        <p class="organizations-field-hint"><%= t("organizations.new.name_hint") %></p>
-        <div class="organizations-input-wrapper">
-          <i class="fas fa-building organizations-input-icon"></i>
-          <%= form.text_field :name,
-              id: "organization_name",
-              class: "organizations-text-input organizations-text-input--with-icon",
-              placeholder: t("organizations.new.name_placeholder"),
-              required: true,
-              maxlength: 50 %>
-        </div>
-        <div style="text-align: right; margin-top: 6px;">
-          <span id="org-name-counter" style="font-size: 12px; color: #6b7280; font-weight: 500;">
-            50 characters remaining
-          </span>
-        </div>
-      </div>
-
-      <%# Organization URL / Slug Preview %>
-      <div class="organizations-field">
-        <label class="organizations-field-label">
-          Organization URL
-        </label>
-        <div class="organizations-url-preview" id="org-slug-preview-box" style="display: flex; align-items: center; gap: 4px; padding: 10px 14px; background-color: #f9fafb; border: 1px solid #e5e7eb; border-radius: 6px; color: #6b7280; margin-top: 8px; flex-wrap: wrap;">
-          <span>circuitverse.org/organizations/</span><span id="organization-slug-preview" style="color: <%= @organization.slug.present? ? '#111827' : '#9ca3af' %>;"><%= @organization.slug.presence || 'your-org-name' %></span>
-          <span id="org-slug-status" style="display: none; font-size: 12px; font-weight: 600; padding: 2px 8px; border-radius: 12px;"></span>
-        </div>
-        <p id="org-slug-hint" class="organizations-field-hint" style="margin-top: 6px; display: none;"></p>
-      </div>
-
-      <%# Description %>
-      <div class="organizations-field">
-        <%= form.label :description, class: "organizations-field-label", for: "org-description-input" do %>
-          <%= t("organizations.new.description_label") %>
+      <%# ── Header ───────────────────────────────────────────── %>
+      <div class="mb-4">
+        <%= link_to organization_path(@organization),
+              class: "text-success text-decoration-none d-inline-flex align-items-center gap-2 mb-3" do %>
+          <i class="fa fa-arrow-left"></i> <%= t("back") %>
         <% end %>
-        <p class="organizations-field-hint"><%= t("organizations.new.description_hint") %></p>
-        <%= form.text_area :description,
-            class: "organizations-textarea",
-            id: "org-description-input",
-            maxlength: 160,
-            rows: 3,
-            placeholder: t("organizations.new.description_placeholder") %>
-        <div style="text-align: right; margin-top: 6px;">
-          <span id="org-description-counter" style="font-size: 12px; color: #6b7280; font-weight: 500;">
-            160 characters remaining
-          </span>
-        </div>
+        <h1 class="h3 fw-bold text-success mb-1">Edit Organization</h1>
+        <p class="text-muted mb-0">Update your organization's profile and settings.</p>
       </div>
 
-      <%# Location %>
-      <div class="organizations-field">
-        <label class="organizations-field-label" for="organization_location">
-          Location
-        </label>
-        <p class="organizations-field-hint">Where is your organization based?</p>
-        <div class="organizations-input-wrapper">
-          <i class="fas fa-map-marker-alt organizations-input-icon"></i>
-          <%= form.text_field :location,
-              id: "organization_location",
-              class: "organizations-text-input organizations-text-input--with-icon",
-              placeholder: "e.g. San Francisco, CA",
-              maxlength: 100 %>
-        </div>
-      </div>
+      <%# ── Main form card ───────────────────────────────────── %>
+      <div class="card shadow-sm">
+        <div class="card-body p-4 p-md-5">
+          <%= form_with(model: @organization, local: true,
+                        html: { enctype: "multipart/form-data", id: "edit-organization-form" }) do |form| %>
 
-      <%# Visibility %>
-      <div class="organizations-field">
-        <%= form.label :private, t("organizations.new.visibility_label"), class: "organizations-field-label" %>
-        <p class="organizations-field-hint"><%= t("organizations.new.visibility_hint") %></p>
-        <div class="organizations-select-wrapper">
-          <%= form.select :private,
-              [
-                [t("organizations.new.visibility_private"), true],
-                [t("organizations.new.visibility_public"), false]
-              ],
-              {},
-              { id: "organization_private", class: "organizations-select" } %>
-        </div>
-      </div>
-
-      <%# External Links %>
-      <div class="organizations-field">
-        <label class="organizations-field-label"><%= t("organizations.new.links_label") %></label>
-        <p class="organizations-field-hint"><%= t("organizations.new.links_hint") %></p>
-        <div id="organizations-links-container">
-          <% if @organization.respond_to?(:links) && @organization.links.present? && @organization.links.is_a?(Array) && @organization.links.reject(&:blank?).any? %>
-            <% @organization.links.reject(&:blank?).each do |link| %>
-              <div class="organizations-input-wrapper organizations-link-item">
-                <i class="fas fa-link organizations-input-icon"></i>
-                <input type="url" name="organization[links][]" class="organizations-text-input organizations-text-input--with-icon" value="<%= link %>" placeholder="<%= t('organizations.new.links_placeholder') %>">
-                <button type="button" class="organizations-remove-link-btn" title="Remove link" style="display: none;">
-                  <i class="fas fa-times"></i>
-                </button>
+            <%# Validation errors %>
+            <% if @organization.errors.any? %>
+              <div class="alert alert-danger d-flex align-items-start gap-2" role="alert">
+                <i class="fa fa-exclamation-circle mt-1"></i>
+                <ul class="list-unstyled mb-0">
+                  <% @organization.errors.full_messages.each do |message| %>
+                    <li><%= message %></li>
+                  <% end %>
+                </ul>
               </div>
             <% end %>
-          <% else %>
-            <div class="organizations-input-wrapper organizations-link-item">
-              <i class="fas fa-link organizations-input-icon"></i>
-              <input type="url" name="organization[links][]" class="organizations-text-input organizations-text-input--with-icon" placeholder="<%= t('organizations.new.links_placeholder') %>">
-              <button type="button" class="organizations-remove-link-btn" title="Remove link" style="display: none;">
-                <i class="fas fa-times"></i>
+
+            <%# Section heading %>
+            <div class="border-bottom pb-3 mb-4">
+              <h2 class="h5 fw-semibold mb-1">Organization Details</h2>
+              <p class="text-muted small mb-0">Basic information about your organization.</p>
+            </div>
+
+            <%# Name %>
+            <div class="mb-3">
+              <label class="form-label fw-semibold" for="organization_name">
+                <%= t("organizations.new.name_label") %> <span class="text-danger">*</span>
+              </label>
+              <div class="form-text mt-0 mb-2"><%= t("organizations.new.name_hint") %></div>
+              <div class="input-group">
+                <span class="input-group-text"><i class="fa fa-building"></i></span>
+                <%= form.text_field :name, id: "organization_name", class: "form-control",
+                      placeholder: t("organizations.new.name_placeholder"), required: true, maxlength: 50 %>
+              </div>
+              <div class="text-end"><small id="org-name-counter" class="form-text">50 characters remaining</small></div>
+            </div>
+
+            <%# Slug preview %>
+            <div class="mb-3">
+              <label class="form-label fw-semibold">Organization URL</label>
+              <div id="org-slug-preview-box"
+                   class="d-flex align-items-center flex-wrap gap-1 p-2 bg-light border rounded text-muted">
+                <span>circuitverse.org/organizations/</span><span id="organization-slug-preview" class="<%= @organization.slug.present? ? 'text-dark' : 'text-secondary' %>"><%= @organization.slug.presence || 'your-org-name' %></span>
+                <span id="org-slug-status" class="badge d-none"></span>
+              </div>
+              <div id="org-slug-hint" class="form-text text-danger d-none"></div>
+            </div>
+
+            <%# Description %>
+            <div class="mb-3">
+              <%= form.label :description, t("organizations.new.description_label"),
+                    class: "form-label fw-semibold", for: "org-description-input" %>
+              <div class="form-text mt-0 mb-2"><%= t("organizations.new.description_hint") %></div>
+              <%= form.text_area :description, class: "form-control", id: "org-description-input",
+                    maxlength: 160, rows: 3, placeholder: t("organizations.new.description_placeholder") %>
+              <div class="text-end"><small id="org-description-counter" class="form-text">160 characters remaining</small></div>
+            </div>
+
+            <%# Location %>
+            <div class="mb-3">
+              <label class="form-label fw-semibold" for="organization_location">Location</label>
+              <div class="form-text mt-0 mb-2">Where is your organization based?</div>
+              <div class="input-group">
+                <span class="input-group-text"><i class="fa fa-map-marker-alt"></i></span>
+                <%= form.text_field :location, id: "organization_location", class: "form-control",
+                      placeholder: "e.g. San Francisco, CA", maxlength: 100 %>
+              </div>
+            </div>
+
+            <%# Visibility %>
+            <div class="mb-3">
+              <%= form.label :private, t("organizations.new.visibility_label"), class: "form-label fw-semibold" %>
+              <div class="form-text mt-0 mb-2"><%= t("organizations.new.visibility_hint") %></div>
+              <%= form.select :private,
+                    [[t("organizations.new.visibility_private"), true], [t("organizations.new.visibility_public"), false]],
+                    {}, { id: "organization_private", class: "form-select" } %>
+            </div>
+
+            <%# External Links %>
+            <div class="mb-3">
+              <label class="form-label fw-semibold"><%= t("organizations.new.links_label") %></label>
+              <div class="form-text mt-0 mb-2"><%= t("organizations.new.links_hint") %></div>
+              <div id="organizations-links-container" class="d-flex flex-column gap-2 mb-2">
+                <% existing_links = (@organization.respond_to?(:links) && @organization.links.is_a?(Array)) ? @organization.links.reject(&:blank?) : [] %>
+                <% (existing_links.presence || [nil]).each do |link| %>
+                  <div class="input-group organizations-link-item">
+                    <span class="input-group-text"><i class="fa fa-link organizations-input-icon"></i></span>
+                    <input type="url" name="organization[links][]" class="form-control"
+                           value="<%= link %>" placeholder="<%= t('organizations.new.links_placeholder') %>">
+                    <button type="button" class="organizations-remove-link-btn"
+                            title="Remove link" style="display: none;"><i class="fa fa-times"></i></button>
+                  </div>
+                <% end %>
+              </div>
+              <button type="button" id="organizations-add-link-btn" class="btn btn-sm btn-outline-success">
+                <%= t("organizations.new.add_link") %>
               </button>
+            </div>
+
+            <%# Logo upload — custom drag-and-drop zone (no Bootstrap equivalent) %>
+            <div class="mb-3">
+              <%= form.label :logo, t("organizations.new.logo_label"), class: "form-label fw-semibold" %>
+              <div class="form-text mt-0 mb-2"><%= t("organizations.new.logo_hint") %></div>
+              <% if @organization.logo.attached? %>
+                <div class="d-flex align-items-center gap-3 p-2 mb-2 border rounded bg-light">
+                  <%= image_tag @organization.logo, class: "rounded border",
+                        style: "width:48px;height:48px;object-fit:cover;", alt: "#{@organization.name} logo" %>
+                  <div class="d-flex flex-column">
+                    <span class="fw-semibold small">Current Logo</span>
+                    <span class="text-muted small">Upload a new image below to replace</span>
+                  </div>
+                </div>
+              <% end %>
+              <div class="org-upload-zone" id="organization-upload-zone" role="button" tabindex="0"
+                   onclick="document.getElementById('organization_logo').click()"
+                   onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}">
+                <i class="fa fa-cloud-upload-alt org-upload-zone__icon"></i>
+                <p class="mb-1">
+                  <span class="text-success fw-semibold"><%= t("organizations.new.upload_click") %></span>
+                  <%= t("organizations.new.upload_drag") %>
+                </p>
+                <p class="text-muted small mb-0"><%= t("organizations.new.upload_hint") %></p>
+                <%= form.file_field :logo, id: "organization_logo", class: "d-none",
+                      accept: "image/png,image/jpeg,image/svg+xml" %>
+              </div>
+              <p class="text-success small fw-semibold mt-2 mb-0" id="organization-upload-filename"></p>
+            </div>
+
+            <%# Actions %>
+            <div class="d-flex justify-content-end gap-2 border-top pt-3 mt-4">
+              <%= link_to t("cancel"), organization_path(@organization), class: "btn btn-outline-secondary" %>
+              <%= form.submit "Update Organization", id: "organization-submit-btn", class: "btn btn-success" %>
             </div>
           <% end %>
         </div>
-        <button type="button" id="organizations-add-link-btn" class="organizations-add-link-btn" aria-label="<%= t('organizations.new.add_link') %>">
-          <%= t("organizations.new.add_link") %>
-        </button>
       </div>
 
-      <%# Logo Upload %>
-      <div class="organizations-field">
-        <%= form.label :logo, t("organizations.new.logo_label"), class: "organizations-field-label" %>
-        <p class="organizations-field-hint"><%= t("organizations.new.logo_hint") %></p>
-        <% if @organization.logo.attached? %>
-          <div style="margin-bottom: 12px; display: flex; align-items: center; gap: 12px; padding: 12px; border: 1px solid #e5e7eb; border-radius: 8px; background: #f9fafb;">
-            <%= image_tag @organization.logo, style: "width: 48px; height: 48px; border-radius: 8px; object-fit: cover; border: 1px solid #d1d5db;", alt: "#{@organization.name} logo" %>
-            <div style="display: flex; flex-direction: column;">
-              <span style="font-size: 14px; font-weight: 600; color: #374151;">Current Logo</span>
-              <span style="font-size: 12px; color: #6b7280;">Upload a new image below to replace</span>
+      <%# ── Danger Zone ──────────────────────────────────────── %>
+      <% if policy(@organization).destroy? %>
+        <div class="card border-danger mt-4">
+          <div class="card-body p-4">
+            <div class="border-bottom pb-3 mb-3">
+              <h2 class="h5 fw-semibold text-danger mb-1">Danger Zone</h2>
+              <p class="text-muted small mb-0">Irreversible actions for this organization.</p>
+            </div>
+            <div class="d-flex justify-content-between align-items-center flex-wrap gap-3">
+              <div>
+                <strong>Delete this organization</strong>
+                <p class="text-muted small mb-0" style="max-width: 420px;">
+                  Once you delete an organization, all its member associations will be permanently removed.
+                  Any groups inside this organization will not be deleted, but will become standard standalone groups.
+                  There is no going back.
+                </p>
+              </div>
+              <button type="button" class="btn btn-outline-danger" data-bs-toggle="modal" data-bs-target="#deleteOrgModal">
+                <i class="fa fa-trash-alt me-1"></i> <%= t("organizations.show.delete_btn") %>
+              </button>
             </div>
           </div>
-        <% end %>
-        <div class="organizations-upload-zone"
-             id="organization-upload-zone"
-             role="button"
-             tabindex="0"
-             onclick="document.getElementById('organization_logo').click()"
-             onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}">
-          <div class="organizations-upload-zone__content">
-            <i class="fas fa-cloud-upload-alt organizations-upload-zone__icon"></i>
-            <p class="organizations-upload-zone__text">
-              <span class="organizations-upload-zone__link"><%= t("organizations.new.upload_click") %></span>
-              <%= t("organizations.new.upload_drag") %>
-            </p>
-            <p class="organizations-upload-zone__hint"><%= t("organizations.new.upload_hint") %></p>
-          </div>
-          <%= form.file_field :logo,
-              id: "organization_logo",
-              class: "organizations-upload-zone__input",
-              accept: "image/png,image/jpeg,image/svg+xml" %>
         </div>
-        <%# Show filename after file is selected %>
-        <p class="organizations-upload-filename" id="organization-upload-filename"></p>
-      </div>
+      <% end %>
 
-      <%# Form actions %>
-      <div class="organizations-form-actions">
-        <%= link_to t("cancel"), organization_path(@organization), class: "btn organizations-btn-secondary" %>
-        <%= form.submit "Update Organization",
-            id: "organization-submit-btn",
-            class: "btn organizations-btn-primary" %>
-      </div>
-    <% end %>
-  </div>
-
-  <%# Danger Zone - Delete Organization %>
-  <% if policy(@organization).destroy? %>
-    <div class="organizations-form-card" style="margin-top: 24px; border-color: #ff5959; background-color: #fffafa;">
-      <div class="organizations-form-section-header" style="border-bottom-color: #fca5a5;">
-        <h2 class="organizations-form-section-title" style="color: #ff5959;">Danger Zone</h2>
-        <p class="organizations-form-section-subtitle">Irreversible actions for this organization.</p>
-      </div>
-      <div style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 16px;">
-        <div>
-          <strong style="color: #111; font-size: 15px;">Delete this organization</strong>
-          <p style="color: #6b7280; font-size: 13px; margin: 4px 0 0 0; max-width: 400px;">
-            Once you delete an organization, all its member associations will be permanently removed. Any groups inside this organization will not be deleted, but will become standard standalone groups. There is no going back.
-          </p>
-        </div>
-        <button type="button" class="btn org-btn-danger-outline" data-bs-toggle="modal" data-bs-target="#deleteOrgModal" aria-label="<%= t('organizations.show.delete_btn') %>">
-          <i class="fas fa-trash-alt" aria-hidden="true"></i> <%= t("organizations.show.delete_btn") %>
-        </button>
-      </div>
     </div>
-  <% end %>
+  </div>
 </div>
 
-<%# ── Delete Organization Modal (Bootstrap) — only rendered for users who can delete ── %>
+<%# ── Delete Organization Modal (Bootstrap) ─────────────────── %>
 <% if policy(@organization).destroy? %>
-<div class="modal fade" id="deleteOrgModal" tabindex="-1" aria-labelledby="deleteOrgModalLabel" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered">
-    <div class="modal-content" style="border-radius: 12px; overflow: hidden; border: none; box-shadow: 0 10px 25px rgba(0,0,0,0.15);">
-      <div class="modal-header" style="background-color: #fee2e2; border-bottom: 1px solid #fca5a5; padding: 16px 24px;">
-        <h5 class="modal-title" id="deleteOrgModalLabel" style="color: #b91c1c; font-weight: 700; font-size: 16px;">
-          <i class="fas fa-exclamation-triangle" style="margin-right: 8px;"></i> Delete Organization
-        </h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-      </div>
-      <div class="modal-body" style="padding: 24px;">
-        <div style="background-color: #fffafa; border-left: 4px solid #ef4444; padding: 12px 16px; margin-bottom: 20px; font-size: 14px; color: #374151;">
-          This action <strong>cannot</strong> be undone. This will permanently delete the <strong><%= @organization.name %></strong> organization. Any groups inside this organization will not be deleted, but will become standard standalone groups.
+  <div class="modal fade" id="deleteOrgModal" tabindex="-1" aria-labelledby="deleteOrgModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header bg-danger-subtle">
+          <h5 class="modal-title text-danger fw-bold" id="deleteOrgModalLabel">
+            <i class="fa fa-exclamation-triangle me-2"></i>Delete Organization
+          </h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
-        <p style="font-size: 14px; color: #4b5563; margin-bottom: 8px; font-weight: 500;">
-          Please type <strong><%= @organization.name %></strong> to confirm.
-        </p>
-        <input type="text" id="deleteOrgConfirmInput" class="organizations-text-input" autocomplete="off" style="width: 100%; margin-bottom: 24px;">
-        <%= form_with url: organization_path(@organization), method: :delete, local: true do |f| %>
-          <button type="submit" id="deleteOrgSubmitBtn" class="btn" style="width: 100%; background-color: #ef4444; color: white; font-weight: 500; font-size: 15px; padding: 10px;" disabled>
-            I understand the consequences, delete this organization
-          </button>
-        <% end %>
+        <div class="modal-body p-4">
+          <div class="alert alert-danger py-2 small">
+            This action <strong>cannot</strong> be undone. This will permanently delete the
+            <strong><%= @organization.name %></strong> organization. Any groups inside this organization
+            will not be deleted, but will become standard standalone groups.
+          </div>
+          <p class="small mb-2">Please type <strong><%= @organization.name %></strong> to confirm.</p>
+          <input type="text" id="deleteOrgConfirmInput" class="form-control mb-3" autocomplete="off">
+          <%= form_with url: organization_path(@organization), method: :delete, local: true do %>
+            <button type="submit" id="deleteOrgSubmitBtn" class="btn btn-danger w-100" disabled>
+              I understand the consequences, delete this organization
+            </button>
+          <% end %>
+        </div>
       </div>
     </div>
   </div>
-</div>
 <% end %>
 
-<%# JS: update filename label + drag-and-drop highlight + dynamic links + modal validation %>
 <script>
   (function () {
-    // --- Delete Organization Modal Logic ---
-    const deleteInput = document.getElementById('deleteOrgConfirmInput');
-    const deleteBtn = document.getElementById('deleteOrgSubmitBtn');
-    const orgName = "<%= j @organization.name %>";
+    // ---- Delete modal: type-to-confirm ----
+    var deleteInput = document.getElementById('deleteOrgConfirmInput');
+    var deleteBtn   = document.getElementById('deleteOrgSubmitBtn');
+    var orgName     = "<%= j @organization.name %>";
     if (deleteInput && deleteBtn) {
-      deleteInput.addEventListener('input', function() {
-        if (this.value === orgName) {
-          deleteBtn.disabled = false;
-          deleteBtn.style.opacity = '1';
-        } else {
-          deleteBtn.disabled = true;
-          deleteBtn.style.opacity = '0.5';
-        }
+      deleteInput.addEventListener('input', function () {
+        deleteBtn.disabled = (this.value !== orgName);
       });
-      const modalEl = document.getElementById('deleteOrgModal');
+      var modalEl = document.getElementById('deleteOrgModal');
       if (modalEl) {
         modalEl.addEventListener('show.bs.modal', function () {
           deleteInput.value = '';
           deleteBtn.disabled = true;
-          deleteBtn.style.opacity = '0.5';
         });
       }
     }
 
-    // --- File Upload Logic ---
-    const zone     = document.getElementById("organization-upload-zone");
-    const input    = document.getElementById("organization_logo");
-    const label    = document.getElementById("organization-upload-filename");
-    input.addEventListener("change", function () {
-      if (this.files && this.files[0]) {
-        label.textContent = this.files[0].name;
-      }
-    });
-    ["dragover", "dragenter"].forEach(function (evt) {
-      zone.addEventListener(evt, function (e) {
+    // ---- Logo upload: filename + drag/drop ----
+    var zone  = document.getElementById("organization-upload-zone");
+    var input = document.getElementById("organization_logo");
+    var label = document.getElementById("organization-upload-filename");
+    if (input) {
+      input.addEventListener("change", function () {
+        if (this.files && this.files[0]) label.textContent = this.files[0].name;
+      });
+    }
+    if (zone) {
+      ["dragover", "dragenter"].forEach(function (evt) {
+        zone.addEventListener(evt, function (e) { e.preventDefault(); zone.classList.add("org-upload-zone--active"); });
+      });
+      ["dragleave", "drop"].forEach(function (evt) {
+        zone.addEventListener(evt, function () { zone.classList.remove("org-upload-zone--active"); });
+      });
+      zone.addEventListener("drop", function (e) {
         e.preventDefault();
-        zone.classList.add("organizations-upload-zone--active");
-      });
-    });
-    ["dragleave", "drop"].forEach(function (evt) {
-      zone.addEventListener(evt, function () {
-        zone.classList.remove("organizations-upload-zone--active");
-      });
-    });
-    zone.addEventListener("drop", function (e) {
-      e.preventDefault();
-      if (e.dataTransfer.files && e.dataTransfer.files[0]) {
-        input.files = e.dataTransfer.files;
-        label.textContent = e.dataTransfer.files[0].name;
-      }
-    });
-
-    // --- Dynamic Links Logic ---
-    const linksContainer = document.getElementById("organizations-links-container");
-    const addLinkBtn     = document.getElementById("organizations-add-link-btn");
-    const MAX_LINKS      = 5;
-    function updateRemoveButtons() {
-      const items = linksContainer.querySelectorAll(".organizations-link-item");
-      items.forEach((item, index) => {
-        const btn = item.querySelector(".organizations-remove-link-btn");
-        // Show remove button if there is more than 1 item
-        if (items.length > 1) {
-          btn.style.display = "block";
-        } else {
-          btn.style.display = "none";
+        if (e.dataTransfer.files && e.dataTransfer.files[0]) {
+          input.files = e.dataTransfer.files;
+          label.textContent = e.dataTransfer.files[0].name;
         }
       });
-      // Hide add button if max reached
+    }
+
+    // ---- Dynamic links ----
+    var linksContainer = document.getElementById("organizations-links-container");
+    var addLinkBtn     = document.getElementById("organizations-add-link-btn");
+    var MAX_LINKS      = 5;
+    function updateRemoveButtons() {
+      var items = linksContainer.querySelectorAll(".organizations-link-item");
+      items.forEach(function (item) {
+        var btn = item.querySelector(".organizations-remove-link-btn");
+        btn.style.display = items.length > 1 ? "block" : "none";
+      });
       addLinkBtn.style.display = items.length >= MAX_LINKS ? "none" : "inline-block";
     }
-    function updateLinkIcon(input) {
-      const urlString = input.value.trim();
-      const icon = input.closest(".organizations-link-item").querySelector(".organizations-input-icon");
+    function updateLinkIcon(field) {
+      var urlString = field.value.trim();
+      var icon = field.closest(".organizations-link-item").querySelector(".organizations-input-icon");
       if (!icon) return;
-      icon.className = "organizations-input-icon"; // reset base class
-      if (!urlString) {
-        icon.classList.add("fas", "fa-link");
-        return;
-      }
-      let hostname = "";
+      icon.className = "organizations-input-icon";
+      if (!urlString) { icon.classList.add("fa", "fa-link"); return; }
+      var hostname = "";
       try {
-        // Prefix with http:// if missing so URL parser doesn't throw on valid domains
-        const parsedUrl = new URL(urlString.startsWith('http') ? urlString : 'https://' + urlString);
-        hostname = parsedUrl.hostname.toLowerCase();
-      } catch (e) {
-        icon.classList.add("fas", "fa-link");
-        return;
-      }
-      const isDomain = (host, domain) => host === domain || host.endsWith('.' + domain);
-      if (isDomain(hostname, "github.com")) icon.classList.add("fab", "fa-github");
-      else if (isDomain(hostname, "instagram.com")) icon.classList.add("fab", "fa-instagram");
-      else if (isDomain(hostname, "twitter.com") || isDomain(hostname, "x.com")) icon.classList.add("custom-icon-x");
-      else if (isDomain(hostname, "linkedin.com")) icon.classList.add("fab", "fa-linkedin");
-      else if (isDomain(hostname, "youtube.com") || isDomain(hostname, "youtu.be")) icon.classList.add("fab", "fa-youtube");
-      else if (isDomain(hostname, "discord.com") || isDomain(hostname, "discord.gg")) icon.classList.add("fab", "fa-discord");
-      else if (isDomain(hostname, "facebook.com")) icon.classList.add("fab", "fa-facebook");
-      else if (isDomain(hostname, "slack.com")) icon.classList.add("fab", "fa-slack");
-      else icon.classList.add("fas", "fa-link");
+        var parsed = new URL(urlString.startsWith('http') ? urlString : 'https://' + urlString);
+        hostname = parsed.hostname.toLowerCase();
+      } catch (e) { icon.classList.add("fa", "fa-link"); return; }
+      var is = function (host, domain) { return host === domain || host.endsWith('.' + domain); };
+      if (is(hostname, "github.com")) icon.classList.add("fab", "fa-github");
+      else if (is(hostname, "instagram.com")) icon.classList.add("fab", "fa-instagram");
+      else if (is(hostname, "twitter.com") || is(hostname, "x.com")) icon.classList.add("custom-icon-x");
+      else if (is(hostname, "linkedin.com")) icon.classList.add("fab", "fa-linkedin");
+      else if (is(hostname, "youtube.com") || is(hostname, "youtu.be")) icon.classList.add("fab", "fa-youtube");
+      else if (is(hostname, "discord.com") || is(hostname, "discord.gg")) icon.classList.add("fab", "fa-discord");
+      else if (is(hostname, "facebook.com")) icon.classList.add("fab", "fa-facebook");
+      else if (is(hostname, "slack.com")) icon.classList.add("fab", "fa-slack");
+      else icon.classList.add("fa", "fa-link");
     }
-    linksContainer.addEventListener("input", function (e) {
-      if (e.target.tagName === "INPUT" && e.target.type === "url") {
-        updateLinkIcon(e.target);
-      }
-    });
-    // Run on load for existing inputs
-    linksContainer.querySelectorAll('input[type="url"]').forEach(updateLinkIcon);
-    // Call once on init to handle pre-populated links
-    updateRemoveButtons();
-    addLinkBtn.addEventListener("click", function () {
-      const items = linksContainer.querySelectorAll(".organizations-link-item");
-      if (items.length < MAX_LINKS) {
-        const newItem = items[0].cloneNode(true);
-        const input = newItem.querySelector("input");
-        input.value = "";
-        linksContainer.appendChild(newItem);
-        updateRemoveButtons();
-        updateLinkIcon(input);
-      }
-    });
-    linksContainer.addEventListener("click", function (e) {
-      const removeBtn = e.target.closest(".organizations-remove-link-btn");
-      if (removeBtn) {
-        const items = linksContainer.querySelectorAll(".organizations-link-item");
-        if (items.length > 1) {
+    if (linksContainer) {
+      linksContainer.addEventListener("input", function (e) {
+        if (e.target.tagName === "INPUT" && e.target.type === "url") updateLinkIcon(e.target);
+      });
+      linksContainer.querySelectorAll('input[type="url"]').forEach(updateLinkIcon);
+      updateRemoveButtons();
+      addLinkBtn.addEventListener("click", function () {
+        var items = linksContainer.querySelectorAll(".organizations-link-item");
+        if (items.length < MAX_LINKS) {
+          var newItem = items[0].cloneNode(true);
+          var field = newItem.querySelector("input");
+          field.value = "";
+          linksContainer.appendChild(newItem);
+          updateRemoveButtons();
+          updateLinkIcon(field);
+        }
+      });
+      linksContainer.addEventListener("click", function (e) {
+        var removeBtn = e.target.closest(".organizations-remove-link-btn");
+        if (removeBtn && linksContainer.querySelectorAll(".organizations-link-item").length > 1) {
           removeBtn.closest(".organizations-link-item").remove();
           updateRemoveButtons();
         }
-      }
-    });
-
-    // --- Character Counter Helper ---
-    function setupCounter(inputId, counterId, maxLen) {
-      const input = document.getElementById(inputId);
-      const counter = document.getElementById(counterId);
-      if (input && counter) {
-        const updateCounter = () => {
-          const remaining = maxLen - input.value.length;
-          counter.textContent = `${remaining} characters remaining`;
-          if (remaining <= Math.floor(maxLen * 0.15)) {
-            counter.style.color = "#ff5959"; // primary red
-          } else {
-            counter.style.color = "#6b7280"; // gray
-          }
-        };
-        updateCounter(); // run once on load
-        input.addEventListener("input", updateCounter);
-      }
+      });
     }
-    // Initialize Counters
+
+    // ---- Character counters ----
+    function setupCounter(inputId, counterId, maxLen) {
+      var el = document.getElementById(inputId);
+      var counter = document.getElementById(counterId);
+      if (!el || !counter) return;
+      function update() {
+        var remaining = maxLen - el.value.length;
+        counter.textContent = remaining + " characters remaining";
+        counter.classList.toggle("text-danger", remaining <= Math.floor(maxLen * 0.15));
+      }
+      update();
+      el.addEventListener("input", update);
+    }
     setupCounter("organization_name", "org-name-counter", 50);
     setupCounter("org-description-input", "org-description-counter", 160);
 
-    // --- Slug Preview + Availability Check Logic ---
-    const nameInput = document.getElementById('organization_name');
-    const slugPreview = document.getElementById('organization-slug-preview');
-    const slugStatus = document.getElementById('org-slug-status');
-    const slugHint   = document.getElementById('org-slug-hint');
-    const slugBox    = document.getElementById('org-slug-preview-box');
-    const currentSlug = '<%= @organization.slug %>';
-    let slugDebounce = null;
-    let slugRequestId = 0;
+    // ---- Slug preview + availability ----
+    var nameInput  = document.getElementById('organization_name');
+    var slugPreview = document.getElementById('organization-slug-preview');
+    var slugStatus = document.getElementById('org-slug-status');
+    var slugHint   = document.getElementById('org-slug-hint');
+    var currentSlug = '<%= @organization.slug %>';
+    var slugDebounce = null, slugRequestId = 0;
+
     function setSlugStatus(state, slug) {
+      // reset badge colour classes
+      slugStatus.className = "badge";
+      slugHint.classList.add("d-none");
       if (state === 'idle') {
-        slugStatus.style.display = 'none';
-        slugHint.style.display = 'none';
-        slugBox.style.borderColor = '#e5e7eb';
-        slugPreview.style.color = slugPreview.textContent === 'your-org-name' ? '#9ca3af' : '#111827';
+        slugStatus.classList.add("d-none");
       } else if (state === 'checking') {
-        slugStatus.style.display = 'inline-block';
+        slugStatus.classList.add("text-bg-secondary");
         slugStatus.textContent = 'Checking...';
-        slugStatus.style.background = '#f3f4f6';
-        slugStatus.style.color = '#6b7280';
-        slugHint.style.display = 'none';
-        slugBox.style.borderColor = '#e5e7eb';
-        slugPreview.style.color = '#111827';
       } else if (state === 'available') {
-        slugStatus.style.display = 'inline-block';
+        slugStatus.classList.add("text-bg-success");
         slugStatus.textContent = '✓ Available';
-        slugStatus.style.background = '#d1fae5';
-        slugStatus.style.color = '#065f46';
-        slugBox.style.borderColor = '#34d399';
-        slugPreview.style.color = '#065f46';
-        slugHint.style.display = 'none';
       } else if (state === 'taken') {
-        slugStatus.style.display = 'inline-block';
+        slugStatus.classList.add("text-bg-danger");
         slugStatus.textContent = '✗ Already taken';
-        slugStatus.style.background = '#fee2e2';
-        slugStatus.style.color = '#991b1b';
-        slugBox.style.borderColor = '#f87171';
-        slugPreview.style.color = '#991b1b';
-        slugHint.style.display = 'block';
-        slugHint.style.color = '#991b1b';
-        slugHint.textContent = 'This URL is taken. FriendlyId will append a unique number (e.g. ' + slug + '-1) when you save.';
+        slugHint.classList.remove("d-none");
+        slugHint.textContent = 'This URL is taken. A unique number will be appended (e.g. ' + slug + '-1) when you save.';
       }
     }
     if (nameInput && slugPreview) {
-      nameInput.addEventListener('input', function() {
-        const rawName = nameInput.value.trim();
-        if (!rawName) {
-          slugPreview.textContent = currentSlug || 'your-org-name';
-          setSlugStatus('idle', '');
-          return;
-        }
-        const localSlug = rawName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+      nameInput.addEventListener('input', function () {
+        var rawName = nameInput.value.trim();
+        if (!rawName) { slugPreview.textContent = currentSlug || 'your-org-name'; setSlugStatus('idle', ''); return; }
+        var localSlug = rawName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
         slugPreview.textContent = localSlug || 'your-org-name';
-        // If the slug hasn't changed from the current saved slug, no need to check
-        if (localSlug === currentSlug) {
-          setSlugStatus('idle', '');
-          return;
-        }
+        if (localSlug === currentSlug) { setSlugStatus('idle', ''); return; }
         setSlugStatus('checking', localSlug);
         clearTimeout(slugDebounce);
-        slugDebounce = setTimeout(function() {
-          const requestId = ++slugRequestId;
-          fetch('/organizations/check_slug?name=' + encodeURIComponent(rawName), {
-            headers: { 'X-Requested-With': 'XMLHttpRequest' }
-          })
-          .then(function(res) { return res.json(); })
-          .then(function(data) {
-            if (requestId !== slugRequestId) return;
-            slugPreview.textContent = data.slug || currentSlug;
-            // If the returned slug matches the org's own current slug, it's effectively available
-            setSlugStatus((data.available || data.slug === currentSlug) ? 'available' : 'taken', data.slug);
-          })
-          .catch(function() {
-            if (requestId !== slugRequestId) return;
-            setSlugStatus('idle', '');
-          });
+        slugDebounce = setTimeout(function () {
+          var requestId = ++slugRequestId;
+          fetch('/organizations/check_slug?name=' + encodeURIComponent(rawName),
+                { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+              if (requestId !== slugRequestId) return;
+              slugPreview.textContent = data.slug || currentSlug;
+              setSlugStatus((data.available || data.slug === currentSlug) ? 'available' : 'taken', data.slug);
+            })
+            .catch(function () { if (requestId === slugRequestId) setSlugStatus('idle', ''); });
         }, 350);
       });
     }

--- a/app/views/organizations/edit.html.erb
+++ b/app/views/organizations/edit.html.erb
@@ -19,9 +19,9 @@
       <% if @organization.errors.any? %>
         <div class="organizations-error-banner" role="alert">
           <i class="fas fa-exclamation-circle"></i>
-          <ul class="organizations-error-list" role="list">
+          <ul class="organizations-error-list">
             <% @organization.errors.full_messages.each do |message| %>
-              <li role="listitem"><%= message %></li>
+              <li><%= message %></li>
             <% end %>
           </ul>
         </div>
@@ -70,7 +70,7 @@
 
       <%# Description %>
       <div class="organizations-field">
-        <%= form.label :description, class: "organizations-field-label" do %>
+        <%= form.label :description, class: "organizations-field-label", for: "org-description-input" do %>
           <%= t("organizations.new.description_label") %>
         <% end %>
         <p class="organizations-field-hint"><%= t("organizations.new.description_hint") %></p>
@@ -166,7 +166,7 @@
              role="button"
              tabindex="0"
              onclick="document.getElementById('organization_logo').click()"
-             onkeydown="if(event.key==='Enter')this.click()">
+             onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}">
           <div class="organizations-upload-zone__content">
             <i class="fas fa-cloud-upload-alt organizations-upload-zone__icon"></i>
             <p class="organizations-upload-zone__text">
@@ -216,7 +216,8 @@
   <% end %>
 </div>
 
-<%# ── Delete Organization Modal (Bootstrap) ───────────────────────── %>
+<%# ── Delete Organization Modal (Bootstrap) — only rendered for users who can delete ── %>
+<% if policy(@organization).destroy? %>
 <div class="modal fade" id="deleteOrgModal" tabindex="-1" aria-labelledby="deleteOrgModalLabel" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content" style="border-radius: 12px; overflow: hidden; border: none; box-shadow: 0 10px 25px rgba(0,0,0,0.15);">
@@ -243,6 +244,7 @@
     </div>
   </div>
 </div>
+<% end %>
 
 <%# JS: update filename label + drag-and-drop highlight + dynamic links + modal validation %>
 <script>

--- a/app/views/organizations/edit.html.erb
+++ b/app/views/organizations/edit.html.erb
@@ -8,7 +8,7 @@
       <div class="mb-4">
         <%= link_to organization_path(@organization),
               class: "text-success text-decoration-none d-inline-flex align-items-center gap-2 mb-3" do %>
-          <i class="fa fa-arrow-left"></i> <%= t("back") %>
+          <i class="fa fa-arrow-left" aria-hidden="true"></i> <%= t("back") %>
         <% end %>
         <h1 class="h3 fw-bold text-success mb-1">Edit Organization</h1>
         <p class="text-muted mb-0">Update your organization's profile and settings.</p>
@@ -23,7 +23,7 @@
             <%# Validation errors %>
             <% if @organization.errors.any? %>
               <div class="alert alert-danger d-flex align-items-start gap-2" role="alert">
-                <i class="fa fa-exclamation-circle mt-1"></i>
+                <i class="fa fa-exclamation-circle mt-1" aria-hidden="true"></i>
                 <ul class="list-unstyled mb-0">
                   <% @organization.errors.full_messages.each do |message| %>
                     <li><%= message %></li>
@@ -45,7 +45,7 @@
               </label>
               <div class="form-text mt-0 mb-2"><%= t("organizations.new.name_hint") %></div>
               <div class="input-group">
-                <span class="input-group-text"><i class="fa fa-building"></i></span>
+                <span class="input-group-text"><i class="fa fa-building" aria-hidden="true"></i></span>
                 <%= form.text_field :name, id: "organization_name", class: "form-control",
                       placeholder: t("organizations.new.name_placeholder"), required: true, maxlength: 50 %>
               </div>
@@ -78,7 +78,7 @@
               <label class="form-label fw-semibold" for="organization_location">Location</label>
               <div class="form-text mt-0 mb-2">Where is your organization based?</div>
               <div class="input-group">
-                <span class="input-group-text"><i class="fa fa-map-marker-alt"></i></span>
+                <span class="input-group-text"><i class="fa fa-map-marker-alt" aria-hidden="true"></i></span>
                 <%= form.text_field :location, id: "organization_location", class: "form-control",
                       placeholder: "e.g. San Francisco, CA", maxlength: 100 %>
               </div>
@@ -101,11 +101,11 @@
                 <% existing_links = (@organization.respond_to?(:links) && @organization.links.is_a?(Array)) ? @organization.links.reject(&:blank?) : [] %>
                 <% (existing_links.presence || [nil]).each do |link| %>
                   <div class="input-group organizations-link-item">
-                    <span class="input-group-text"><i class="fa fa-link organizations-input-icon"></i></span>
+                    <span class="input-group-text"><i class="fa fa-link organizations-input-icon" aria-hidden="true"></i></span>
                     <input type="url" name="organization[links][]" class="form-control"
                            value="<%= link %>" placeholder="<%= t('organizations.new.links_placeholder') %>">
-                    <button type="button" class="organizations-remove-link-btn"
-                            title="Remove link" style="display: none;"><i class="fa fa-times"></i></button>
+                    <button type="button" class="btn organizations-remove-link-btn"
+                            title="Remove link" aria-label="Remove link" style="display: none;"><i class="fa fa-times" aria-hidden="true"></i></button>
                   </div>
                 <% end %>
               </div>
@@ -131,7 +131,7 @@
               <div class="org-upload-zone" id="organization-upload-zone" role="button" tabindex="0"
                    onclick="document.getElementById('organization_logo').click()"
                    onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}">
-                <i class="fa fa-cloud-upload-alt org-upload-zone__icon"></i>
+                <i class="fa fa-cloud-upload-alt org-upload-zone__icon" aria-hidden="true"></i>
                 <p class="mb-1">
                   <span class="text-success fw-semibold"><%= t("organizations.new.upload_click") %></span>
                   <%= t("organizations.new.upload_drag") %>
@@ -169,8 +169,9 @@
                   There is no going back.
                 </p>
               </div>
-              <button type="button" class="btn btn-outline-danger" data-bs-toggle="modal" data-bs-target="#deleteOrgModal">
-                <i class="fa fa-trash-alt me-1"></i> <%= t("organizations.show.delete_btn") %>
+              <button type="button" class="btn btn-outline-danger" data-bs-toggle="modal" data-bs-target="#deleteOrgModal"
+                      aria-label="<%= t('organizations.show.delete_btn') %>">
+                <i class="fa fa-trash-alt me-1" aria-hidden="true"></i> <%= t("organizations.show.delete_btn") %>
               </button>
             </div>
           </div>
@@ -188,7 +189,7 @@
       <div class="modal-content">
         <div class="modal-header bg-danger-subtle">
           <h5 class="modal-title text-danger fw-bold" id="deleteOrgModalLabel">
-            <i class="fa fa-exclamation-triangle me-2"></i>Delete Organization
+            <i class="fa fa-exclamation-triangle me-2" aria-hidden="true"></i>Delete Organization
           </h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>

--- a/config/locales/views/organizations/en.yml
+++ b/config/locales/views/organizations/en.yml
@@ -1,0 +1,24 @@
+en:
+  organizations:
+    new:
+      name_label: "Organization Name"
+      name_hint: "Enter the full name of your organization or institution."
+      name_placeholder: "e.g. Indian Institute of Technology Bombay"
+      description_label: "Description"
+      description_hint: "A short description of the organization and its focus."
+      description_placeholder: "e.g. This organization covers digital logic courses for undergraduate students."
+      visibility_label: "Visibility"
+      visibility_hint: "Control who can discover and view your organization."
+      visibility_private: "Private — only members can view"
+      visibility_public: "Public — anyone can view"
+      logo_label: "Organization Logo"
+      logo_hint: "Upload an optional logo for your organization."
+      upload_click: "Click to upload"
+      upload_drag: "or drag and drop"
+      upload_hint: "PNG, JPG, SVG up to 2MB"
+      links_label: "External Links"
+      links_hint: "Add up to 5 external links (e.g., your institution website or LinkedIn)."
+      links_placeholder: "https://..."
+      add_link: "+ Add another link"
+    show:
+      delete_btn: "Delete Organization"


### PR DESCRIPTION
Fixes #7611

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -
This PR adds the organization settings (edit) page — the view + styles for editing an organization's details.

- A form to update the organization's name, description, location, and visibility
- Logo upload/replace with a drag-and-drop zone and filename preview
- Dynamic external links (add/remove, up to 5) with auto-detected platform icons
- Live character counters on name and description
- A live slug preview + availability check (AJAX to check_slug) while editing the name
- A "Danger Zone" to delete the organization, with a type-to-confirm modal so it can't be triggered by mistake
- The SCSS for all of the above (organizations.scss form styles)

Depends on #7457 for the edit/update/destroy controller actions and #7568, so CI will be red until that merges

### Screenshots of the UI changes (If any) -

Old video (Now we can't update our own slug until unless name gets updated)
https://github.com/user-attachments/assets/f7bfb11b-9789-44e6-804a-acfd84eb52a2


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The problem: organizations had no way to edit their details after creation, and no way to delete one from its own page.

I built a dedicated settings/edit page rather than reusing the create form, because the edit flow also needs the delete/danger-zone actions, and keeping them on one page is clearer than overloading the create form.

Key parts:
- The form uses form_with on @ organization to update name, description, location, visibility, logo, and links. Links are sent as an array (organization[links][]) and capped at 5 on both the UI and the backend.
- Slug preview: as the user types a name, JS generates a local slug preview instantly, then debounces an AJAX call to check_slug to show whether that URL is available. Requests are tracked by an incrementing id so a slow earlier response can't overwrite a newer one.
- Character counters and dynamic add/remove of link fields are handled with small vanilla JS helpers.
- Delete is gated behind policy(@ organization).destroy? and a modal that only enables the delete button once the user types the exact org name, to prevent accidental deletion.

Styling is in organizations.scss using the same design tokens as the rest of the organizations UI (shared SCSS variables for the theme colors), so it stays consistent with the dashboard.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an “Edit Organization” page with editable details (name, description, location, visibility), external links (with add/remove controls and limits), and logo replacement via drag-and-drop upload.
  * Included live UX enhancements such as remaining-character counters, link host icon updates, and debounced slug availability status.

* **Bug Fixes**
  * Improved the protected delete experience by requiring exact-name confirmation before enabling deletion.

* **Style**
  * Updated organizations theming for buttons, icons (including social platforms), link/upload UI, and remove-link interactions.

* **Documentation**
  * Added/updated English locale strings for organization creation/show and deletion-related text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->