### PR TITLE
fix: prevent primary mentor from removing own org membership (#7615)

### DIFF
--- a/app/policies/organization_member_policy.rb
+++ b/app/policies/organization_member_policy.rb
@@ -14,11 +14,16 @@ class OrganizationMemberPolicy < ApplicationPolicy
 
   def destroy?
     return false if leaving_self? && sole_admin?
+    return false if leaving_self? && primary_mentor_of_any_group?
 
     org_admin? || leaving_self? || user.admin?
   end
 
   private
+
+    def primary_mentor_of_any_group?
+      record.organization.groups.exists?(primary_mentor_id: user.id)
+    end
 
     def org_membership
       return @org_membership if defined?(@org_membership)

--- a/spec/policies/organization_member_policy_spec.rb
+++ b/spec/policies/organization_member_policy_spec.rb
@@ -83,6 +83,24 @@ describe OrganizationMemberPolicy do
     it { is_expected.not_to permit(:destroy) }
   end
 
+  context "when the user is the primary mentor of a group in the org" do
+    before do
+      @mentor = FactoryBot.create(:user)
+      @mentor_membership = FactoryBot.create(
+        :organization_member,
+        organization: @organization,
+        user: @mentor,
+        role: :member
+      )
+      FactoryBot.create(:group, name: "Mentored Group", primary_mentor: @mentor, organization: @organization)
+    end
+
+    let(:user) { @mentor }
+    let(:organization_member) { @mentor_membership }
+
+    it { is_expected.not_to permit(:destroy) }
+  end
+
   context "when there are multiple admins and one demotes the other" do
     before do
       @second_admin = FactoryBot.create(:user)


### PR DESCRIPTION
## Fixes #7615

### What does this PR do?
Adds a missing authorization guard to `OrganizationMemberPolicy#destroy?` that prevents a user from removing their own organization membership if they are the `primary_mentor` of any group in that organization.

### Why is this needed?
Without this guard, a primary mentor can destroy their own `OrganizationMember` record, orphaning any `Group` they mentor (since `Group` has a required `belongs_to :primary_mentor`). The sibling policy `OrganizationPolicy#leave?` already has this guard — this PR brings `destroy?` into parity.

### Changes
- `app/policies/organization_member_policy.rb`: Added `primary_mentor_of_any_group?` check to `destroy?`
- `spec/policies/organization_member_policy_spec.rb`: Added test for the new guard

### Testing
- [x] New spec context: "when the user is the primary mentor of a group in the org" — asserts `destroy` is denied
- [x] No regressions in existing policy spec contexts
- [x] Code reviewed for correctness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented users from deleting their own organization membership if they are the primary mentor for any group in that organization.
  - Added coverage for this self-removal restriction to keep permission behavior consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->