### PR TITLE
fix: sanitize_name now correctly mutates params read by project_params (#7559)

### DIFF
--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -111,7 +111,7 @@ class Api::V1::ProjectsController < Api::V1::BaseController
   # PATCH /api/v1/projects/:id
   def update
     authorize @project, :check_edit_access?
-    params.permit(:project)[:name] = sanitize(project_params[:name])
+    params[:project][:name] = sanitize(project_params[:name])
     @project.update!(project_params)
     if @project.update(project_params)
       render json: Api::V1::ProjectSerializer.new(@project, @options), status: :accepted

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -146,7 +146,7 @@ class ProjectsController < ApplicationController
     end
 
     def sanitize_name
-      params.permit(:project)[:name] = sanitize(project_params[:name])
+      params[:project][:name] = sanitize(project_params[:name])
     end
 
     # Sanitize description before passing to view

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -180,6 +180,18 @@ describe ProjectsController, type: :request do
           check_project_access_error(response)
         end
       end
+
+      context "name contains unsafe HTML" do
+        before { sign_in @author }
+
+        it "sanitizes the name before saving" do
+          put user_project_path(@author, @project),
+              params: { project: { name: "<script>alert(1)</script>Evil Name" } }
+          @project.reload
+          expect(@project.name).not_to include("<script>")
+          expect(@project.name).to include("Evil Name")
+        end
+      end
     end
 
     describe "#destroy" do

--- a/spec/requests/api/v1/projects_controller/update_spec.rb
+++ b/spec/requests/api/v1/projects_controller/update_spec.rb
@@ -76,5 +76,21 @@ RSpec.describe Api::V1::ProjectsController, "#update", type: :request do
         expect(response.parsed_body).to have_jsonapi_errors
       end
     end
+
+    context "when name contains unsafe HTML" do
+      before do
+        token = get_auth_token(user)
+        patch "/api/v1/projects/#{project.id}",
+              headers: { Authorization: "Token #{token}" },
+              params: { project: { name: "<script>alert(1)</script>Evil Name" } }, as: :json
+      end
+
+      it "sanitizes the name before saving" do
+        expect(response).to have_http_status(:accepted)
+        project.reload
+        expect(project.name).not_to include("<script>")
+        expect(project.name).to include("Evil Name")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Fixes #7559

### What does this PR do?
Fixes the `sanitize_name` method in both `ProjectsController` and `Api::V1::ProjectsController` so that it actually mutates the params hash that `project_params` reads from.

### Root Cause
The existing code used `params.permit(:project)[:name] = ...` which returns a **new, separate** `ActionController::Parameters` object. Setting `[:name]` on that copy is a no-op — it never touches `params[:project][:name]`, so when `create`/`update` later call `project_params` (which reads `params.expect(project: [...])`), they get the original unsanitized name.

### The Fix
Replace `params.permit(:project)[:name]` with `params[:project][:name]` in both controllers, so the sanitized value is written directly to the params hash that `project_params` subsequently reads.

### Files Changed

| File | Change |
|------|--------|
| `app/controllers/projects_controller.rb` | `sanitize_name`: mutate `params[:project][:name]` directly |
| `app/controllers/api/v1/projects_controller.rb` | `update`: same fix for inline sanitization |
| `spec/controllers/projects_controller_spec.rb` | Added test: name with `<script>` tags gets sanitized on update |
| `spec/requests/api/v1/projects_controller/update_spec.rb` | Added test: API update sanitizes unsafe HTML in name |

### Testing
- [x] New spec: main controller `#update` with `<script>` in name — asserts tag is stripped
- [x] New spec: API `#update` with `<script>` in name — asserts tag is stripped and returns `:accepted`
- [x] No regressions in existing specs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project name handling during updates so unsafe HTML is sanitized before saving.
  * Project names now preserve valid text while removing script content in both the web app and API update flows.
  * Added coverage to verify sanitized names are stored correctly after updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->