### PR TITLE
fix: block removing an org member who is a group's primary mentor (#7615)

### DIFF
--- a/app/policies/organization_member_policy.rb
+++ b/app/policies/organization_member_policy.rb
@@ -14,6 +14,7 @@ class OrganizationMemberPolicy < ApplicationPolicy
 
   def destroy?
     return false if leaving_self? && sole_admin?
+    return false if member_primary_mentor_of_any_group?
 
     org_admin? || leaving_self? || user.admin?
   end
@@ -32,6 +33,10 @@ class OrganizationMemberPolicy < ApplicationPolicy
 
     def leaving_self?
       record.user == user
+    end
+
+    def member_primary_mentor_of_any_group?
+      record.organization.groups.exists?(primary_mentor_id: record.user_id)
     end
 
     def sole_admin?

--- a/spec/policies/organization_member_policy_spec.rb
+++ b/spec/policies/organization_member_policy_spec.rb
@@ -110,4 +110,45 @@ describe OrganizationMemberPolicy do
     it { is_expected.not_to permit(:update) }
     it { is_expected.not_to permit(:destroy) }
   end
+
+  context "when the primary mentor of a group tries to delete their own membership" do
+    before do
+      @mentor = FactoryBot.create(:user)
+      @mentor_membership = FactoryBot.create(:organization_member, organization: @organization, user: @mentor,
+                                                                   role: :member)
+      FactoryBot.create(:group, name: "Mentored Group", primary_mentor: @mentor, organization: @organization)
+    end
+
+    let(:user) { @mentor }
+    let(:organization_member) { @mentor_membership }
+
+    it { is_expected.not_to permit(:destroy) }
+  end
+
+  context "when an admin removes a member who is the primary mentor of a group" do
+    before do
+      @mentor = FactoryBot.create(:user)
+      @mentor_membership = FactoryBot.create(:organization_member, organization: @organization, user: @mentor,
+                                                                   role: :member)
+      FactoryBot.create(:group, name: "Mentored Group", primary_mentor: @mentor, organization: @organization)
+    end
+
+    let(:user) { @admin }
+    let(:organization_member) { @mentor_membership }
+
+    it { is_expected.not_to permit(:destroy) }
+  end
+
+  context "when a member who mentors no group deletes their own membership" do
+    before do
+      @plain_member = FactoryBot.create(:user)
+      @plain_membership = FactoryBot.create(:organization_member, organization: @organization, user: @plain_member,
+                                                                  role: :member)
+    end
+
+    let(:user) { @plain_member }
+    let(:organization_member) { @plain_membership }
+
+    it { is_expected.to permit(:destroy) }
+  end
 end


### PR DESCRIPTION
Fixes #7615

#### Describe the changes you have made in this PR -

`OrganizationMemberPolicy#destroy?` was missing the primary-mentor guard that its sibling `OrganizationPolicy#leave?` already has. As a result a user who is the `primary_mentor` of one or more organization groups could remove their own `OrganizationMember` record through the destroy endpoint and orphan those groups. Since `Group` requires a `primary_mentor` (`belongs_to :primary_mentor`), that leaves the group in an invalid state.

This adds a guard to `destroy?` that denies removing any membership whose user is still the primary mentor of a group in the organization:

- In this policy `record` is the membership (not the organization, as in `leave?`), so the groups are reached via `record.organization.groups`.
- The check is keyed on the member being removed (`record.user_id`), so it also covers an org/site admin removing a mentor's membership — because the group is orphaned regardless of who triggers the removal. This is intentionally broader than `leave?`, which only concerns the user leaving themselves.

### Screenshots of the UI changes (If any) -

N/A — this is an authorization-policy change with no UI.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

- **Problem:** `destroy?` allowed a primary mentor's membership to be deleted, orphaning the group(s) they mentor.
- **Approach:** mirror the existing `leave?` guard, but key it on the membership being removed (`record.user_id`) instead of only the current user, so admin-initiated removals are covered too.
- **Alternative considered:** gating the check on `leaving_self?` only (blocking just self-removal). Rejected because an org/site admin could still orphan a group by removing a mentor.
- **Key method:** `member_primary_mentor_of_any_group?` → `record.organization.groups.exists?(primary_mentor_id: record.user_id)`.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened member deletion rules so a person who is the primary mentor for any group can’t have their membership removed.
  * Prevented admins from removing the membership of a primary mentor.
  * Confirmed that members who do not mentor any group can still delete their own membership.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->