### PR TITLE
fix: sanitize project name inside project_params so it is persisted (#7559)

### DIFF
--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -111,7 +111,6 @@ class Api::V1::ProjectsController < Api::V1::BaseController
   # PATCH /api/v1/projects/:id
   def update
     authorize @project, :check_edit_access?
-    params.permit(:project)[:name] = sanitize(project_params[:name])
     @project.update!(project_params)
     if @project.update(project_params)
       render json: Api::V1::ProjectSerializer.new(@project, @options), status: :accepted
@@ -269,7 +268,9 @@ class Api::V1::ProjectsController < Api::V1::BaseController
     end
 
     def project_params
-      params.expect(project: %i[name project_access_type description tag_list])
+      project = params.expect(project: %i[name project_access_type description tag_list])
+      project[:name] = sanitize(project[:name]) if project[:name]
+      project
     end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -11,7 +11,6 @@ class ProjectsController < ApplicationController
   before_action :check_access, only: %i[edit update destroy]
   before_action :check_delete_access, only: [:destroy]
   before_action :check_view_access, only: %i[show create_fork]
-  before_action :sanitize_name, only: %i[create update]
   before_action :sanitize_project_description, only: %i[show edit]
 
   # GET /projects
@@ -142,11 +141,9 @@ class ProjectsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def project_params
-      params.expect(project: %i[name project_access_type description tag_list tags])
-    end
-
-    def sanitize_name
-      params.permit(:project)[:name] = sanitize(project_params[:name])
+      project = params.expect(project: %i[name project_access_type description tag_list tags])
+      project[:name] = sanitize(project[:name]) if project[:name]
+      project
     end
 
     # Sanitize description before passing to view

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -146,6 +146,15 @@ describe ProjectsController, type: :request do
         expect(project.name).to eq("Test Project")
         expect(project.project_access_type).to eq("Public")
       end
+
+      it "sanitizes the project name before saving" do
+        post "/users/#{@user.id}/projects", params: {
+          project: { name: "<script>alert(1)</script>Hello", project_access_type: "Public" }
+        }
+
+        project = Project.order(:created_at).last
+        expect(project.name).not_to include("<script>")
+      end
     end
 
     describe "#update" do
@@ -170,6 +179,14 @@ describe ProjectsController, type: :request do
           put user_project_path(@author, @project), params: update_params
           @project.reload
           expect(@project.name).to eq("Updated Name")
+        end
+
+        it "sanitizes the project name before saving" do
+          put user_project_path(@author, @project), params: {
+            project: { name: "<script>alert(1)</script>Hello" }
+          }
+          @project.reload
+          expect(@project.name).not_to include("<script>")
         end
       end
 

--- a/spec/requests/api/v1/projects_controller/update_spec.rb
+++ b/spec/requests/api/v1/projects_controller/update_spec.rb
@@ -63,6 +63,20 @@ RSpec.describe Api::V1::ProjectsController, "#update", type: :request do
       end
     end
 
+    context "when authenticated user updates own project with an unsafe name" do
+      before do
+        token = get_auth_token(user)
+        patch "/api/v1/projects/#{project.id}",
+              headers: { Authorization: "Token #{token}" },
+              params: { project: { name: "<script>alert(1)</script>Hello" } }, as: :json
+      end
+
+      it "sanitizes the project name before saving" do
+        expect(response).to have_http_status(:accepted)
+        expect(project.reload.name).not_to include("<script>")
+      end
+    end
+
     context "when authenticated user tries to update non existent project details" do
       before do
         token = get_auth_token(random_user)


### PR DESCRIPTION
Fixes #7559

#### Describe the changes you have made in this PR -

`ProjectsController#sanitize_name` (a `before_action` on `create`/`update`) assigned the sanitized value to `params.permit(:project)[:name]`. `ActionController::Parameters#permit` returns a **new** Parameters object, so that write landed on a throwaway copy and never touched `params[:project][:name]`. `project_params` then read the **original, unsanitized** name and stored raw HTML in the project name — a stored-XSS vector (e.g. `<script>…` persisted). The identical broken pattern existed in `Api::V1::ProjectsController#update`.

Instead of mutating `params` from a `before_action`, this moves the sanitization into `project_params` in both controllers — the single method every create/update path reads from — so the persisted name is always sanitized. The dead `sanitize_name` `before_action` and the API's inline line are removed.

Regression specs are added for **web `#create`**, **web `#update`**, and **API `#update`** (a name containing `<script>` is no longer stored). On current `master` all three fail; with the fix they pass.

### Screenshots of the UI changes (If any) -

N/A — controller/params sanitization, no UI change.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

- **Problem:** the sanitized name was written to a `params.permit(:project)` copy, so `project_params` still read and stored the unsanitized name (stored XSS). Same bug in the API `update`.
- **Approach:** sanitize `:name` inside `project_params` (the one method all create/update reads flow through), rather than trying to mutate `params` from a `before_action`. This fixes both the web and API paths and removes the fragile copy-mutation.
- **Alternative considered:** the minimal `params[:project][:name] = sanitize(project_params[:name])` — rejected because it trips `Rails/StrongParametersExpect` (rubocop) and reintroduces raw `params[:project]` mutation; sanitizing in `project_params` is cleaner and rubocop-clean.
- **Tests:** cover web create, web update, and API update — including the create path.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project names are now sanitized consistently during create and update, including API updates.
  * Unsafe script content in project names is removed before saving, helping prevent injection issues.

* **Tests**
  * Added coverage to confirm project names are cleaned when creating or updating projects.
  * Added API request coverage for updating a project with unsafe input while still returning a successful response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->