### PR TITLE
Fix dropdown toggle

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -36,7 +36,6 @@
               class="nav-link dropdown-toggle navbar-item navbar-text"
               type="button"
               data-bs-toggle="dropdown"
-              data-bs-auto-close="true"
               aria-haspopup="true"
               aria-expanded="false"
               aria-label="<%= t('layout.getting_started_dropdown') %>">
@@ -67,7 +66,6 @@
                 id="navbar-dropdown-2"
                 type="button"
                 data-bs-toggle="dropdown"
-                data-bs-auto-close="true"
                 aria-haspopup="true"
                 aria-expanded="false"
                 aria-label="<%= current_user.name %>">


### PR DESCRIPTION
Fixes #7332

#### Describe the changes you have made in this PR -
I resolved an issue where the "Getting Started" and User profile dropdowns in the navbar would not close when clicked a second time. This was caused by two overlapping issues:
1. `bootstrap.min.js` was being double-loaded (once through Sprockets in `application_sprockets.js` and once through Webpack in `application.js`). This caused Bootstrap to register its event listeners twice, meaning a single click would trigger a close-and-immediate-reopen toggle.
2. The `data-bs-auto-close="true"` attribute on the dropdown buttons conflicted with Bootstrap 5's standard toggle behavior. 

I removed the duplicate Sprockets import and removed the conflicting `data-bs-auto-close` attributes.

### Screenshots of the UI changes (If any) -
*(No visible UI changes, just functional fixes to the dropdown behavior)*

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
- **What problem does your code solve?** It fixes a bug where clicking the 'Getting Started' and User profile dropdown buttons a second time failed to close them, forcing the user to click elsewhere on the screen.
- **What alternative approaches did you consider?** I considered overriding the Bootstrap dropdown behavior with custom JavaScript in `_header.html.erb` to force it closed on a second click, but that would just be a band-aid fix over the root cause.
- **Why did you choose this specific implementation?** By removing the duplicate `bootstrap.min.js` include from Sprockets (since it's properly managed by Webpack in modern Rails), we eliminate the double event listener registration that caused the immediate reopen on toggle. Removing the redundant `data-bs-auto-close="true"` attribute prevents further conflicts with standard Bootstrap toggling.
- **What are the key functions/components and what do they do?** 
  - `application_sprockets.js`: Removed the duplicate bootstrap require.
  - `_header.html.erb`: Removed `data-bs-auto-close="true"` from the two dropdown buttons.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dropdown behavior for the “Getting Started” and signed-in user menus.
  * Preserved dropdowns while interacting with their contents, preventing unintended automatic closure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->