### PR TITLE
feat(groups): subgroups (teams) within a group

### DIFF
--- a/app/controllers/api/v1/groups_controller.rb
+++ b/app/controllers/api/v1/groups_controller.rb
@@ -11,14 +11,14 @@ class Api::V1::GroupsController < Api::V1::BaseController
 
   # GET /api/v1/groups
   def index
-    @groups = paginate(current_user.groups)
+    @groups = paginate(current_user.groups.merge(Group.top_level))
     @options[:links] = link_attrs(@groups, api_v1_groups_url)
     render json: Api::V1::GroupSerializer.new(@groups, @options)
   end
 
   # GET /api/v1/groups/owned
   def groups_owned
-    @groups = paginate(current_user.groups_owned)
+    @groups = paginate(current_user.groups_owned.merge(Group.top_level))
     @options[:links] = link_attrs(@groups, api_v1_groups_owned_url)
     render json: Api::V1::GroupSerializer.new(@groups, @options)
   end

--- a/app/controllers/api/v1/subgroups_controller.rb
+++ b/app/controllers/api/v1/subgroups_controller.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+class Api::V1::SubgroupsController < Api::V1::BaseController
+  before_action :authenticate_user!
+  before_action :set_parent_group, only: %i[index create]
+  before_action :set_subgroup, only: %i[show destroy update_members]
+  before_action :check_show_access, only: %i[index show]
+  before_action :check_manage_access, only: %i[create destroy update_members]
+  before_action :set_options, only: %i[index show create]
+
+  # GET /api/v1/groups/:group_id/subgroups
+  def index
+    @subgroups = paginate(@parent_group.subgroups)
+    @options[:links] = link_attrs(@subgroups, api_v1_group_subgroups_url(@parent_group.id))
+    render json: Api::V1::GroupSerializer.new(@subgroups, @options)
+  end
+
+  # GET /api/v1/subgroups/:id
+  def show
+    render json: Api::V1::GroupSerializer.new(@subgroup, @options)
+  end
+
+  # POST /api/v1/groups/:group_id/subgroups
+  def create
+    @subgroup = @parent_group.subgroups.new(subgroup_params)
+    if @subgroup.save
+      render json: Api::V1::GroupSerializer.new(@subgroup, @options), status: :created
+    else
+      invalid_resource!(@subgroup.errors)
+    end
+  end
+
+  # DELETE /api/v1/subgroups/:id
+  def destroy
+    @subgroup.destroy!
+    head :no_content
+  end
+
+  # PATCH /api/v1/subgroups/:id/members
+  # Syncs the subgroup's (non-mentor) membership to the submitted user ids,
+  # restricted to members of the parent group.
+  def update_members
+    parent = @subgroup.parent_group
+    target_ids = Array(params[:user_ids]).map(&:to_i) & parent.group_members.pluck(:user_id)
+
+    current_member_ids = @subgroup.group_members.member.pluck(:user_id)
+    existing_ids = @subgroup.group_members.pluck(:user_id)
+
+    @subgroup.group_members.member.where(user_id: current_member_ids - target_ids).destroy_all
+    (target_ids - existing_ids).each { |user_id| @subgroup.group_members.create(user_id: user_id) }
+
+    @options = { include: [:group_members] }
+    render json: Api::V1::GroupSerializer.new(@subgroup.reload, @options), status: :accepted
+  end
+
+  private
+
+    def set_parent_group
+      @parent_group = Group.find(params.expect(:group_id))
+    end
+
+    def set_subgroup
+      @subgroup = Group.where.not(parent_group_id: nil).find(params.expect(:id))
+    end
+
+    def check_show_access
+      authorize(@subgroup || @parent_group, :show_access?)
+    end
+
+    # Subgroups are managed from their top-level parent by its mentors.
+    def check_manage_access
+      parent = @parent_group || @subgroup.parent_group
+      authorize parent, :manage_subgroups?
+    end
+
+    def set_options
+      @options = {}
+      @options[:params] = { current_user: current_user }
+    end
+
+    def subgroup_params
+      params.expect(subgroup: %i[name])
+    end
+end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -10,6 +10,7 @@ class GroupsController < ApplicationController
   # GET /groups/1.json
   def show
     @group_member = @group.group_members.new
+    @subgroups = visible_subgroups
     @group.assignments.each do |assignment|
       if (assignment.status == "reopening") && (assignment.deadline < Time.zone.now)
         assignment.status = "closed"
@@ -20,6 +21,10 @@ class GroupsController < ApplicationController
 
   def generate_token
     @group = Group.find(params.expect(:id))
+    # Subgroup membership is instructor-assigned from the parent's roster,
+    # never via invite links.
+    head :forbidden and return if @group.subgroup?
+
     @group.reset_group_token unless @group.has_valid_token?
   end
 
@@ -109,5 +114,15 @@ class GroupsController < ApplicationController
 
     def check_edit_access
       authorize @group, :admin_access?
+    end
+
+    # Mentors manage every subgroup; students only see the ones they belong to.
+    def visible_subgroups
+      return Group.none if @group.subgroup?
+
+      subgroups = @group.subgroups.includes(:group_members)
+      return subgroups if policy(@group).mentor_access?
+
+      subgroups.joins(:group_members).where(group_members: { user_id: current_user.id })
     end
 end

--- a/app/controllers/subgroups_controller.rb
+++ b/app/controllers/subgroups_controller.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class SubgroupsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_parent_group
+  before_action :check_manage_access
+  before_action :set_subgroup, only: %i[destroy update_members]
+
+  # POST /groups/:group_id/subgroups
+  def create
+    @subgroup = @parent_group.subgroups.new(subgroup_params)
+
+    if @subgroup.save
+      redirect_to group_path(@parent_group), notice: t(".notice_created")
+    else
+      redirect_to group_path(@parent_group),
+                  alert: @subgroup.errors.full_messages.to_sentence
+    end
+  end
+
+  # DELETE /groups/:group_id/subgroups/:id
+  def destroy
+    @subgroup.destroy
+    redirect_to group_path(@parent_group), notice: t(".notice_deleted")
+  end
+
+  # PATCH /groups/:group_id/subgroups/:id/update_members
+  # Syncs the subgroup's (non-mentor) membership to the submitted user ids,
+  # which are restricted to members of the parent group.
+  def update_members
+    user_ids = Array(params[:user_ids]).map(&:to_i)
+    allowed_ids = @parent_group.group_members.pluck(:user_id)
+    target_ids = user_ids & allowed_ids
+
+    current_ids = @subgroup.group_members.member.pluck(:user_id)
+
+    @subgroup.group_members.member.where(user_id: current_ids - target_ids).destroy_all
+    (target_ids - current_ids).each do |user_id|
+      @subgroup.group_members.create(user_id: user_id)
+    end
+
+    redirect_to group_path(@subgroup), notice: t(".notice_updated")
+  end
+
+  private
+
+    def set_parent_group
+      @parent_group = Group.find(params.expect(:group_id))
+    end
+
+    def set_subgroup
+      @subgroup = @parent_group.subgroups.find(params.expect(:id))
+    end
+
+    def check_manage_access
+      authorize @parent_group, :manage_subgroups?
+    end
+
+    def subgroup_params
+      params.expect(group: %i[name])
+    end
+end

--- a/app/controllers/subgroups_controller.rb
+++ b/app/controllers/subgroups_controller.rb
@@ -32,10 +32,13 @@ class SubgroupsController < ApplicationController
     allowed_ids = @parent_group.group_members.pluck(:user_id)
     target_ids = user_ids & allowed_ids
 
-    current_ids = @subgroup.group_members.member.pluck(:user_id)
+    current_member_ids = @subgroup.group_members.member.pluck(:user_id)
+    # Mentor rows are managed via the mentors flow, so the checkbox sync must
+    # neither remove them nor try to insert a duplicate row for them.
+    existing_ids = @subgroup.group_members.pluck(:user_id)
 
-    @subgroup.group_members.member.where(user_id: current_ids - target_ids).destroy_all
-    (target_ids - current_ids).each do |user_id|
+    @subgroup.group_members.member.where(user_id: current_member_ids - target_ids).destroy_all
+    (target_ids - existing_ids).each do |user_id|
       @subgroup.group_members.create(user_id: user_id)
     end
 

--- a/app/controllers/users/circuitverse_controller.rb
+++ b/app/controllers/users/circuitverse_controller.rb
@@ -38,7 +38,8 @@ class Users::CircuitverseController < ApplicationController
 
   def groups
     @user = authorize @user
-    @groups_owned = Group.where(id: Group.joins(:primary_mentor).where(primary_mentor: @user))
+    @groups_owned = Group.top_level
+                         .where(id: Group.joins(:primary_mentor).where(primary_mentor: @user))
                          .select("groups.*, COUNT(group_members.id) as group_member_count")
                          .left_outer_joins(:group_members)
                          .group("groups.id")

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -5,15 +5,27 @@ class Group < ApplicationRecord
   validates :name, length: { minimum: 1 }, presence: true
   belongs_to :primary_mentor, class_name: "User"
   belongs_to :organization, optional: true
+  belongs_to :parent_group, class_name: "Group", optional: true
   has_many :group_members, dependent: :destroy
   has_many :users, through: :group_members
+  has_many :subgroups, class_name: "Group", foreign_key: :parent_group_id,
+                       inverse_of: :parent_group, dependent: :destroy
 
   has_many :assignments, dependent: :destroy
   has_many :pending_invitations, dependent: :destroy
 
-  after_commit :send_creation_mail, on: :create
+  before_validation :inherit_primary_mentor_from_parent, on: :create, if: :subgroup?
+  validates :name, uniqueness: { scope: :parent_group_id, case_sensitive: false }, if: :subgroup?
+  validate :parent_group_must_be_top_level, if: :subgroup?
+
+  after_commit :send_creation_mail, on: :create, unless: :subgroup?
   scope :with_valid_token, -> { where(token_expires_at: Time.zone.now..) }
+  scope :top_level, -> { where(parent_group_id: nil) }
   TOKEN_DURATION = 12.days
+
+  def subgroup?
+    parent_group_id.present?
+  end
 
   def send_creation_mail
     GroupMailer.new_group_email(primary_mentor, self).deliver_later
@@ -29,4 +41,19 @@ class Group < ApplicationRecord
       update(token_expires_at: Time.zone.now + TOKEN_DURATION)
     end
   end
+
+  private
+
+    # Subgroups are managed by the parent group's instructor: they always share
+    # the parent's primary mentor so existing policies apply unchanged.
+    def inherit_primary_mentor_from_parent
+      self.primary_mentor = parent_group.primary_mentor if parent_group
+    end
+
+    # Only one level of nesting: a subgroup's parent must be a top-level group.
+    def parent_group_must_be_top_level
+      return if parent_group.blank?
+
+      errors.add(:parent_group, "cannot itself be a subgroup") if parent_group.subgroup?
+    end
 end

--- a/app/models/group_member.rb
+++ b/app/models/group_member.rb
@@ -5,11 +5,26 @@ class GroupMember < ApplicationRecord
   belongs_to :user
   has_many :assignments, through: :group
 
-  after_commit :send_welcome_email, on: :create
+  validate :user_must_belong_to_parent_group, if: -> { group&.subgroup? }
+
+  after_commit :send_welcome_email, on: :create, unless: -> { group.subgroup? }
   scope :mentor, -> { where(mentor: true) }
   scope :member, -> { where(mentor: false) }
 
   def send_welcome_email
     GroupMailer.new_member_email(user, group).deliver_later
   end
+
+  private
+
+    # Subgroups partition an existing class: only users already in the parent
+    # group (or its primary mentor) can be placed in a subgroup.
+    def user_must_belong_to_parent_group
+      parent = group.parent_group
+      return if parent.blank?
+      return if parent.primary_mentor_id == user_id
+      return if parent.group_members.exists?(user_id: user_id)
+
+      errors.add(:user, "must be a member of the parent group")
+    end
 end

--- a/app/models/group_member.rb
+++ b/app/models/group_member.rb
@@ -5,6 +5,9 @@ class GroupMember < ApplicationRecord
   belongs_to :user
   has_many :assignments, through: :group
 
+  # Mirrors the unique DB index so duplicates fail validation instead of
+  # raising PG::UniqueViolation.
+  validates :user_id, uniqueness: { scope: :group_id }
   validate :user_must_belong_to_parent_group, if: -> { group&.subgroup? }
 
   after_commit :send_welcome_email, on: :create, unless: -> { group.subgroup? }

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -20,4 +20,9 @@ class GroupPolicy < ApplicationPolicy
   def mentor_access?
     @admin_access || @group.group_members.exists?(user_id: user.id, mentor: true)
   end
+
+  # Subgroups are managed from their top-level parent by its mentors.
+  def manage_subgroups?
+    !group.subgroup? && mentor_access?
+  end
 end

--- a/app/serializers/api/v1/group_serializer.rb
+++ b/app/serializers/api/v1/group_serializer.rb
@@ -11,7 +11,7 @@ class Api::V1::GroupSerializer
     group.primary_mentor.name
   end
 
-  attributes :name, :primary_mentor_id, :created_at, :updated_at
+  attributes :name, :primary_mentor_id, :parent_group_id, :created_at, :updated_at
 
   has_many :group_members
   has_many :assignments

--- a/app/views/groups/_create_subgroup_modal.html.erb
+++ b/app/views/groups/_create_subgroup_modal.html.erb
@@ -1,0 +1,22 @@
+<div id="createsubgroupModal" class="modal fade" role="dialog">
+  <div class="modal-dialog primary-modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header primary-modal-header">
+        <h4 class="modal-title"><%= t("groups.show.subgroups.create_modal_heading") %></h4>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="close"></button>
+      </div>
+      <div class="modal-body">
+        <p><%= t("groups.show.subgroups.create_modal_description") %></p>
+        <%= form_with(model: Group.new, url: group_subgroups_path(group), local: true) do |form| %>
+          <div class="mb-3 d-flex flex-column">
+            <%= form.label :name %>
+            <%= form.text_field :name, class: "form-control", required: true %>
+          </div>
+          <div class="modal-footer">
+            <%= form.submit t("groups.show.subgroups.create_subgroup_btn"), class: "btn primary-button" %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/groups/_delete_subgroup_confirmation_modal.html.erb
+++ b/app/views/groups/_delete_subgroup_confirmation_modal.html.erb
@@ -1,0 +1,28 @@
+<div id="deletesubgroupModal" class="modal fade" role="dialog">
+  <div class="modal-dialog primary-modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header primary-modal-header">
+        <h4 class="modal-title"><%= t("delete") %></h4>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="close"></button>
+      </div>
+      <div class="modal-body">
+        <p><%= t("groups.show.subgroups.remove_subgroup_message") %></p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-outline-primary" data-bs-dismiss="modal"><%= t("cancel") %></button>
+        <%= button_to t("delete"), "#", method: :delete, class: "btn btn-danger", id: "subgroup-delete-button" %>
+      </div>
+    </div>
+  </div>
+</div>
+<script type="text/javascript">
+  $(document).ready(function() {
+    $("#deletesubgroupModal").on("show.bs.modal", function(e) {
+      const group = $(e.relatedTarget).data("currentgroup");
+      const subgroup = $(e.relatedTarget).data("currentsubgroup");
+      $(e.currentTarget).find("#subgroup-delete-button").parent().attr(
+        "action", `/groups/${group.toString()}/subgroups/${subgroup.toString()}`
+      );
+    });
+  });
+</script>

--- a/app/views/groups/_manage_subgroup_members_modal.html.erb
+++ b/app/views/groups/_manage_subgroup_members_modal.html.erb
@@ -1,0 +1,35 @@
+<div id="managesubgroupmembersModal" class="modal fade" role="dialog">
+  <div class="modal-dialog primary-modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header primary-modal-header">
+        <h4 class="modal-title"><%= t("groups.show.subgroups.manage_members_heading") %></h4>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="close"></button>
+      </div>
+      <div class="modal-body">
+        <p><%= t("groups.show.subgroups.manage_members_description", parent_name: subgroup.parent_group.name) %></p>
+        <%= form_with(url: update_members_group_subgroup_path(subgroup.parent_group, subgroup),
+                      method: :patch, local: true) do |form| %>
+          <% subgroup_member_ids = subgroup.group_members.member.pluck(:user_id) %>
+          <% parent_members = subgroup.parent_group.group_members.member.includes(:user) %>
+          <% if parent_members.blank? %>
+            <span class="null-text"><%= t("groups.show.subgroups.no_parent_members") %></span>
+          <% end %>
+          <div class="mb-3 d-flex flex-column">
+            <% parent_members.each do |member| %>
+              <div class="form-check">
+                <%= check_box_tag "user_ids[]", member.user_id,
+                      subgroup_member_ids.include?(member.user_id),
+                      id: "subgroup-member-#{member.user_id}", class: "form-check-input" %>
+                <%= label_tag "subgroup-member-#{member.user_id}",
+                      "#{member.user.name} (#{member.user.email})", class: "form-check-label" %>
+              </div>
+            <% end %>
+          </div>
+          <div class="modal-footer">
+            <%= form.submit t("groups.show.subgroups.update_members_btn"), class: "btn primary-button" %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/groups/_subgroups.html.erb
+++ b/app/views/groups/_subgroups.html.erb
@@ -1,0 +1,25 @@
+<% subgroups.each do |subgroup| %>
+  <div class="col-12 col-sm-12 col-md-6 col-lg-4">
+    <div class="groups-card groups-mentor-card">
+      <div class="groups-mentor-card-name"><%= subgroup.name %></div>
+      <div>
+        <p><%= t("groups.show.subgroups.member_count", count: subgroup.group_members.size) %></p>
+        <p><%= t("groups.show.subgroups.assignment_count", count: subgroup.assignments.size) %></p>
+      </div>
+      <div class="groups-mentor-card-mini-buttons">
+        <%= link_to group_path(subgroup), class: "mini-button groups-mentor-card-view-mini-button" do %>
+          <%= image_tag("svgs/viewGroup.svg", alt: "View Subgroup") %>
+          <span><%= t("view") %></span>
+        <% end %>
+        <% if policy(group).manage_subgroups? %>
+          <%= link_to "#", class: "mini-button groups-mentor-card-delete-mini-button",
+                data: { bs_toggle: "modal", bs_target: "#deletesubgroupModal",
+                        currentgroup: group.id, currentsubgroup: subgroup.id } do %>
+            <%= image_tag("svgs/deleteGroup.svg", alt: "Delete Subgroup") %>
+            <span><%= t("delete") %></span>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -27,6 +27,12 @@
         <strong><%= t("groups.show.primary_mentor_heading") %></strong>
         <%= @group.primary_mentor.name %>
       </h4>
+      <% if @group.subgroup? %>
+        <h4 class="group-mentor-heading">
+          <strong><%= t("groups.show.subgroups.subgroup_of") %></strong>
+          <%= link_to @group.parent_group.name, group_path(@group.parent_group), class: "anchor-text" %>
+        </h4>
+      <% end %>
     </div>
   </div>
   <!-- Mentor Section -->
@@ -52,7 +58,15 @@
 <!-- Members Section -->
 <div class="d-flex justify-content-between align-items-center mb-2">
   <h3 class="mb-0"><%= t("groups.show.group_members_heading") %></h3>
-  <% if policy(@group).admin_access? %>
+  <% if @group.subgroup? %>
+    <% if policy(@group.parent_group).manage_subgroups? %>
+      <button type="button" class="btn primary-button groups-primary-button"
+        data-bs-toggle="modal"
+        data-bs-target="#managesubgroupmembersModal">
+        <%= t("groups.show.subgroups.manage_members_btn") %>
+      </button>
+    <% end %>
+  <% elsif policy(@group).admin_access? %>
     <button type="button" class="btn primary-button groups-primary-button"
       data-bs-toggle="modal"
       data-bs-target="#addmemberModal"
@@ -68,6 +82,33 @@
   <%= render partial: "group_members", locals: { group: @group } %>
 </div>
 <hr>
+
+<% unless @group.subgroup? %>
+  <!-- Subgroups Section -->
+  <div class="d-flex justify-content-between align-items-center mb-2">
+    <h3 class="mb-0"><%= t("groups.show.subgroups.heading") %></h3>
+    <% if policy(@group).manage_subgroups? %>
+      <button type="button" class="btn primary-button groups-primary-button"
+        data-bs-toggle="modal"
+        data-bs-target="#createsubgroupModal">
+        <%= t("groups.show.subgroups.add_subgroup_btn") %>
+      </button>
+    <% end %>
+  </div>
+  <% if @subgroups.blank? %>
+    <span class="null-text">
+      <% if policy(@group).manage_subgroups? %>
+        <%= t("groups.show.subgroups.no_subgroups_html") %>
+      <% else %>
+        <%= t("groups.show.subgroups.not_in_any_subgroup") %>
+      <% end %>
+    </span>
+  <% end %>
+  <div class="row">
+    <%= render partial: "subgroups", locals: { group: @group, subgroups: @subgroups } %>
+  </div>
+  <hr>
+<% end %>
 
 <!-- Assignments Section -->
 <div class="d-flex justify-content-between align-items-center mb-2">
@@ -363,7 +404,17 @@
   </div>
   <%= render partial: "delete_member_confirmation_modal" %>
   <%= render partial: "delete_assignment_confirmation_modal" %>
-  <%= render partial: "add_member_modal", locals: { group_member: @group_member } %>
+  <% if @group.subgroup? %>
+    <% if policy(@group.parent_group).manage_subgroups? %>
+      <%= render partial: "manage_subgroup_members_modal", locals: { subgroup: @group } %>
+    <% end %>
+  <% else %>
+    <%= render partial: "add_member_modal", locals: { group_member: @group_member } %>
+    <% if policy(@group).manage_subgroups? %>
+      <%= render partial: "create_subgroup_modal", locals: { group: @group } %>
+      <%= render partial: "delete_subgroup_confirmation_modal" %>
+    <% end %>
+  <% end %>
   <%= render partial: "add_mentor_modal", locals: { group_member: @group_member } %>
   <%= render partial: "promote_member_confirmation_modal" %>
 </div>

--- a/app/views/users/circuitverse/groups.html.erb
+++ b/app/views/users/circuitverse/groups.html.erb
@@ -50,10 +50,10 @@
     </div>
   <% end %>
   <br>
-  <% if @user.groups.count!=0 %>
+  <% if @user.groups.top_level.count != 0 %>
     <h4 class="submain-heading"><%= t("users.circuitverse.groups.groups_user_belong_to") %></h4>
     <div class="row center-row">
-      <% @user.groups.each do |group| %>
+      <% @user.groups.top_level.each do |group| %>
         <div class="col-12 col-sm-12 col-md-6 col-lg-4">
           <div class="groups-card groups-member-card">
             <div class="groups-member-card-details">

--- a/config/locales/controllers/subgroups/en.yml
+++ b/config/locales/controllers/subgroups/en.yml
@@ -1,0 +1,8 @@
+en:
+  subgroups:
+    create:
+      notice_created: "Subgroup was successfully created."
+    destroy:
+      notice_deleted: "Subgroup was successfully deleted."
+    update_members:
+      notice_updated: "Subgroup members were successfully updated."

--- a/config/locales/views/groups/en.yml
+++ b/config/locales/views/groups/en.yml
@@ -27,6 +27,27 @@ en:
       add_mentors_btn: "+ Add Mentors"
       no_mentors_html: "There are no mentors in this group, click <strong>+ Add Mentors</strong> button to add mentors."
       no_members_html: "There are no members in this group, click <strong>+ Add Members</strong> button to add members."
+      subgroups:
+        heading: "SUBGROUPS:"
+        subgroup_of: "Subgroup of:"
+        add_subgroup_btn: "+ Create Subgroup"
+        manage_members_btn: "Manage Members"
+        create_modal_heading: "Create Subgroup"
+        create_modal_description: "Subgroups let you split this group into smaller teams. Assignments created inside a subgroup are only visible to its members."
+        create_subgroup_btn: "Create Subgroup"
+        manage_members_heading: "Manage Subgroup Members"
+        manage_members_description: "Select members of %{parent_name} to include in this subgroup."
+        update_members_btn: "Update Members"
+        no_parent_members: "The parent group has no members yet. Add members to the parent group first."
+        no_subgroups_html: "There are no subgroups in this group, click <strong>+ Create Subgroup</strong> button to create one."
+        not_in_any_subgroup: "You are not part of any subgroup in this group."
+        remove_subgroup_message: "Are you sure you want to delete this subgroup? Its assignments will also be deleted. Members remain in the parent group."
+        member_count:
+          one: "1 member"
+          other: "%{count} members"
+        assignment_count:
+          one: "1 assignment"
+          other: "%{count} assignments"
       no_assignments_html: "There are no assignments in the group, click <strong>+ Add Assignment</strong> button to start an assignment."
       assignment:
         heading: "ASSIGNMENTS:"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,21 +14,24 @@ Rails.application.routes.draw do
     mount MaintenanceTasks::Engine => "/maintenance_tasks"
   end
 
-  if Rails.env.development?
-    mount Lookbook::Engine, at: "/lookbook"
-  end
+  mount Lookbook::Engine, at: "/lookbook" if Rails.env.development?
 
   devise_scope :user do
-    get '/users/sign_out' => 'devise/sessions#destroy'
-    get '/users/saml/sign_in', to: 'users/saml_sessions#new'
-    post '/users/saml/auth', to: 'users/saml_sessions#create'
-    get '/users/saml/metadata', to: 'users/saml_sessions#metadata'
+    get "/users/sign_out" => "devise/sessions#destroy"
+    get "/users/saml/sign_in", to: "users/saml_sessions#new"
+    post "/users/saml/auth", to: "users/saml_sessions#create"
+    get "/users/saml/metadata", to: "users/saml_sessions#metadata"
   end
 
   # resources :assignment_submissions
   resources :group_members, only: %i[create destroy update]
   resources :groups, except: %i[index] do
     resources :assignments, except: %i[index]
+    resources :subgroups, only: %i[create destroy], controller: "subgroups" do
+      member do
+        patch :update_members
+      end
+    end
     member do
       get "invite/:token", to: "groups#group_invite", as: "invite"
       put :generate_token
@@ -66,10 +69,10 @@ Rails.application.routes.draw do
   resources :featured_circuits, only: %i[index create]
   delete "/featured_circuits", to: "featured_circuits#destroy"
 
-  get "/users/edit", to: redirect('/')
+  get "/users/edit", to: redirect("/")
   devise_for :users, controllers: {
     registrations: "users/registrations", omniauth_callbacks: "users/omniauth_callbacks",
-    sessions: "users/sessions", :saml_sessions => "users/saml_sessions"
+    sessions: "users/sessions", saml_sessions: "users/saml_sessions"
   }
 
   # Circuitverse web pages resources
@@ -82,22 +85,25 @@ Rails.application.routes.draw do
   # Explore
   get "/explore", to: "explore#index", as: :explore
 
-  #announcements
+  # announcements
   resources :announcements, except: %i[show]
 
   # users
 
   scope "/users" do
-    get "/:id/profile", to: redirect('/users/%{id}'), as: "profile"
+    get "/:id/profile", to: redirect("/users/%{id}"), as: "profile"
     get "/:id/profile/edit", to: "users/circuitverse#edit", as: "profile_edit"
     patch "/:id/update", to: "users/circuitverse#update", as: "profile_update"
     get "/:id/groups", to: "users/circuitverse#groups", as: "user_groups"
     get "/:id/", to: "users/circuitverse#index", as: "user_projects"
     get "/educational_institute/typeahead/:query" => "users/circuitverse#typeahead_educational_institute"
     get "/:id/notifications", to: "users/noticed_notifications#index", as: "notifications"
-    patch "/:id/notifications/mark_all_as_read", to: "users/noticed_notifications#mark_all_as_read", as: "mark_all_as_read"
-    patch "/:id/notifications/read_all_notifications", to: "users/noticed_notifications#read_all_notifications", as: "read_all_notifications"
-    post "/:id/notifications/mark_as_read/:notification_id", to: "users/noticed_notifications#mark_as_read", as: "mark_as_read"
+    patch "/:id/notifications/mark_all_as_read", to: "users/noticed_notifications#mark_all_as_read",
+                                                 as: "mark_all_as_read"
+    patch "/:id/notifications/read_all_notifications", to: "users/noticed_notifications#read_all_notifications",
+                                                       as: "read_all_notifications"
+    post "/:id/notifications/mark_as_read/:notification_id", to: "users/noticed_notifications#mark_as_read",
+                                                             as: "mark_as_read"
   end
 
   post "/push/subscription/new", to: "push_subscription#create"
@@ -107,7 +113,7 @@ Rails.application.routes.draw do
   scope "/projects" do
     post "/create_fork/:id", to: "projects#create_fork", as: "create_fork_project"
     get "/change_stars/:id", to: "projects#change_stars", as: "change_stars"
-    get "tags/:tag", to: redirect('/tags/%{tag}'), as: "legacy_tag"
+    get "tags/:tag", to: redirect("/tags/%{tag}"), as: "legacy_tag"
   end
 
   get "/tags/:tag", to: "tags#show", as: "tag"
@@ -120,8 +126,8 @@ Rails.application.routes.draw do
       end
     end
 
-      member do
-        get :leaderboard
+    member do
+      get :leaderboard
     end
   end
 
@@ -130,8 +136,8 @@ Rails.application.routes.draw do
   end
 
   # lti
-  scope "lti"  do
-    match 'launch', to: 'lti#launch', via: [:get, :post]
+  scope "lti" do
+    match "launch", to: "lti#launch", via: %i[get post]
   end
 
   mount Commontator::Engine => "/commontator"
@@ -177,7 +183,7 @@ Rails.application.routes.draw do
   get "/features", to: redirect("/#home-features-section")
 
   # Health Check at /up ~> will be default in rails 7.1
-  get '/up', to: ->(_env) { [200, {}, ['']] }
+  get "/up", to: ->(_env) { [200, {}, [""]] }
 
   # get 'comments/create_reply/:id', to: 'comments#create_reply', as: 'reply_comment'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -236,6 +236,12 @@ Rails.application.routes.draw do
       resources :groups do
         resources :members, controller: "group_members", shallow: true, only: %i[index create]
         resources :assignments, shallow: true
+        resources :subgroups, only: %i[index create], shallow: true
+      end
+      resources :subgroups, only: %i[show destroy] do
+        member do
+          patch :members, to: "subgroups#update_members"
+        end
       end
       resources :assignments do
         member do

--- a/db/migrate/20260705074159_add_parent_group_to_groups.rb
+++ b/db/migrate/20260705074159_add_parent_group_to_groups.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddParentGroupToGroups < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :groups, :parent_group,
+                  null: true,
+                  foreign_key: false,
+                  index: { algorithm: :concurrently }
+  end
+end

--- a/db/migrate/20260705074310_add_foreign_key_parent_group_to_groups.rb
+++ b/db/migrate/20260705074310_add_foreign_key_parent_group_to_groups.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddForeignKeyParentGroupToGroups < ActiveRecord::Migration[8.1]
+  def change
+    # New column, all values NULL: validate: false is safe and avoids
+    # blocking writes (matches 20260518215840 for the organization FK).
+    add_foreign_key :groups, :groups, column: :parent_group_id, validate: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_25_102515) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_05_074310) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -278,8 +278,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_25_102515) do
     t.string "group_token"
     t.datetime "token_expires_at", precision: nil
     t.bigint "organization_id"
+    t.bigint "parent_group_id"
     t.index ["group_token"], name: "index_groups_on_group_token", unique: true
     t.index ["organization_id"], name: "index_groups_on_organization_id"
+    t.index ["parent_group_id"], name: "index_groups_on_parent_group_id"
     t.index ["primary_mentor_id"], name: "index_groups_on_primary_mentor_id"
   end
 
@@ -579,6 +581,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_25_102515) do
   add_foreign_key "grades", "users"
   add_foreign_key "group_members", "groups"
   add_foreign_key "group_members", "users"
+  add_foreign_key "groups", "groups", column: "parent_group_id"
   add_foreign_key "groups", "organizations", on_delete: :nullify
   add_foreign_key "groups", "users", column: "primary_mentor_id"
   add_foreign_key "organization_members", "organizations", on_delete: :cascade

--- a/spec/models/group_member_spec.rb
+++ b/spec/models/group_member_spec.rb
@@ -28,4 +28,39 @@ RSpec.describe GroupMember, type: :model do
       end.to have_enqueued_job.on_queue("mailers")
     end
   end
+
+  describe "subgroup membership" do
+    before do
+      @subgroup = FactoryBot.create(:group, name: "Team A", parent_group: @group)
+      @student = FactoryBot.create(:user)
+    end
+
+    it "rejects users who are not members of the parent group" do
+      member = described_class.new(group: @subgroup, user: @student)
+      expect(member).not_to be_valid
+      expect(member.errors[:user]).to be_present
+    end
+
+    it "allows members of the parent group" do
+      FactoryBot.create(:group_member, group: @group, user: @student)
+      expect(described_class.new(group: @subgroup, user: @student)).to be_valid
+    end
+
+    it "allows the parent group's primary mentor" do
+      expect(described_class.new(group: @subgroup, user: @user)).to be_valid
+    end
+
+    it "allows the same user in multiple subgroups of one parent" do
+      other_subgroup = FactoryBot.create(:group, name: "Team B", parent_group: @group)
+      FactoryBot.create(:group_member, group: @group, user: @student)
+      FactoryBot.create(:group_member, group: @subgroup, user: @student)
+      expect(described_class.new(group: other_subgroup, user: @student)).to be_valid
+    end
+
+    it "does not send a welcome email for subgroup membership" do
+      FactoryBot.create(:group_member, group: @group, user: @student)
+      expect_any_instance_of(described_class).not_to receive(:send_welcome_email)
+      FactoryBot.create(:group_member, group: @subgroup, user: @student)
+    end
+  end
 end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -9,10 +9,71 @@ RSpec.describe Group, type: :model do
 
   describe "associations" do
     it { is_expected.to belong_to(:primary_mentor) }
+    it { is_expected.to belong_to(:parent_group).optional }
     it { is_expected.to have_many(:users) }
     it { is_expected.to have_many(:group_members) }
     it { is_expected.to have_many(:assignments) }
     it { is_expected.to have_many(:pending_invitations) }
+
+    it {
+      expect(subject).to have_many(:subgroups)
+        .class_name("Group").with_foreign_key(:parent_group_id).dependent(:destroy)
+    }
+  end
+
+  describe "subgroups" do
+    before do
+      @parent = FactoryBot.create(:group, primary_mentor: @primary_mentor)
+    end
+
+    it "is created under a top-level group and inherits the primary mentor" do
+      subgroup = described_class.create!(name: "Team A", parent_group: @parent)
+      expect(subgroup).to be_subgroup
+      expect(subgroup.primary_mentor).to eq(@primary_mentor)
+    end
+
+    it "overrides a supplied primary mentor with the parent's" do
+      other_mentor = FactoryBot.create(:user)
+      subgroup = described_class.create!(name: "Team A", parent_group: @parent,
+                                         primary_mentor: other_mentor)
+      expect(subgroup.primary_mentor).to eq(@primary_mentor)
+    end
+
+    it "rejects nesting more than one level deep" do
+      subgroup = described_class.create!(name: "Team A", parent_group: @parent)
+      nested   = described_class.new(name: "Team A1", parent_group: subgroup)
+      expect(nested).not_to be_valid
+      expect(nested.errors[:parent_group]).to be_present
+    end
+
+    it "rejects duplicate subgroup names within the same parent" do
+      described_class.create!(name: "Team A", parent_group: @parent)
+      duplicate = described_class.new(name: "team a", parent_group: @parent)
+      expect(duplicate).not_to be_valid
+    end
+
+    it "allows the same subgroup name under different parents" do
+      other_parent = FactoryBot.create(:group, name: "Other", primary_mentor: @primary_mentor)
+      described_class.create!(name: "Team A", parent_group: @parent)
+      expect(described_class.new(name: "Team A", parent_group: other_parent)).to be_valid
+    end
+
+    it "excludes subgroups from the top_level scope" do
+      subgroup = described_class.create!(name: "Team A", parent_group: @parent)
+      expect(described_class.top_level).to include(@parent)
+      expect(described_class.top_level).not_to include(subgroup)
+    end
+
+    it "destroys subgroups when the parent group is destroyed" do
+      subgroup = described_class.create!(name: "Team A", parent_group: @parent)
+      expect { @parent.destroy }.to change(described_class, :count).by(-2)
+      expect(described_class.exists?(subgroup.id)).to be(false)
+    end
+
+    it "does not send a creation mail for subgroups" do
+      expect_any_instance_of(described_class).not_to receive(:send_creation_mail)
+      described_class.create!(name: "Team A", parent_group: @parent)
+    end
   end
 
   describe "callbacks" do

--- a/spec/requests/api/v1/subgroups_controller/create_spec.rb
+++ b/spec/requests/api/v1/subgroups_controller/create_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::SubgroupsController, "#create", type: :request do
+  describe "create a subgroup" do
+    let!(:mentor) { FactoryBot.create(:user) }
+    let!(:group) { FactoryBot.create(:group, primary_mentor: mentor) }
+
+    context "when not authenticated" do
+      before { post "/api/v1/groups/#{group.id}/subgroups", as: :json }
+
+      it "returns unauthenticated" do
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "when a regular member tries to create a subgroup" do
+      before do
+        member = FactoryBot.create(:user)
+        FactoryBot.create(:group_member, group: group, user: member)
+        token = get_auth_token(member)
+        post "/api/v1/groups/#{group.id}/subgroups",
+             headers: { Authorization: "Token #{token}" },
+             params: { subgroup: { name: "Team A" } }, as: :json
+      end
+
+      it "returns forbidden" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "when the mentor creates a subgroup with valid params" do
+      before do
+        token = get_auth_token(mentor)
+        post "/api/v1/groups/#{group.id}/subgroups",
+             headers: { Authorization: "Token #{token}" },
+             params: { subgroup: { name: "Team A" } }, as: :json
+      end
+
+      it "creates the subgroup and inherits the primary mentor" do
+        expect(response).to have_http_status(:created)
+        subgroup = Group.find(response.parsed_body["data"]["id"])
+        expect(subgroup.parent_group).to eq(group)
+        expect(subgroup.primary_mentor).to eq(mentor)
+      end
+    end
+
+    context "when the mentor submits an invalid (duplicate) name" do
+      before do
+        FactoryBot.create(:group, name: "Team A", parent_group: group)
+        token = get_auth_token(mentor)
+        post "/api/v1/groups/#{group.id}/subgroups",
+             headers: { Authorization: "Token #{token}" },
+             params: { subgroup: { name: "Team A" } }, as: :json
+      end
+
+      it "returns unprocessable entity with errors" do
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body).to have_jsonapi_errors
+      end
+    end
+
+    context "when the target group is itself a subgroup" do
+      before do
+        subgroup = FactoryBot.create(:group, name: "Team A", parent_group: group)
+        token = get_auth_token(mentor)
+        post "/api/v1/groups/#{subgroup.id}/subgroups",
+             headers: { Authorization: "Token #{token}" },
+             params: { subgroup: { name: "Nested" } }, as: :json
+      end
+
+      it "returns forbidden (no nesting)" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/subgroups_controller/destroy_spec.rb
+++ b/spec/requests/api/v1/subgroups_controller/destroy_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::SubgroupsController, "#destroy", type: :request do
+  describe "delete a subgroup" do
+    let!(:mentor) { FactoryBot.create(:user) }
+    let!(:group) { FactoryBot.create(:group, primary_mentor: mentor) }
+    let!(:subgroup) { FactoryBot.create(:group, name: "Team A", parent_group: group) }
+
+    context "when not authenticated" do
+      before { delete "/api/v1/subgroups/#{subgroup.id}", as: :json }
+
+      it "returns unauthenticated" do
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "when a regular member tries to delete the subgroup" do
+      before do
+        member = FactoryBot.create(:user)
+        FactoryBot.create(:group_member, group: group, user: member)
+        token = get_auth_token(member)
+        delete "/api/v1/subgroups/#{subgroup.id}",
+               headers: { Authorization: "Token #{token}" }, as: :json
+      end
+
+      it "returns forbidden and keeps the subgroup" do
+        expect(response).to have_http_status(:forbidden)
+        expect(Group.exists?(subgroup.id)).to be(true)
+      end
+    end
+
+    context "when the mentor deletes the subgroup" do
+      before do
+        token = get_auth_token(mentor)
+        delete "/api/v1/subgroups/#{subgroup.id}",
+               headers: { Authorization: "Token #{token}" }, as: :json
+      end
+
+      it "deletes the subgroup" do
+        expect(response).to have_http_status(:no_content)
+        expect(Group.exists?(subgroup.id)).to be(false)
+      end
+    end
+
+    context "when the id belongs to a top-level group" do
+      before do
+        token = get_auth_token(mentor)
+        delete "/api/v1/subgroups/#{group.id}",
+               headers: { Authorization: "Token #{token}" }, as: :json
+      end
+
+      it "returns not found" do
+        expect(response).to have_http_status(:not_found)
+        expect(Group.exists?(group.id)).to be(true)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/subgroups_controller/index_spec.rb
+++ b/spec/requests/api/v1/subgroups_controller/index_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::SubgroupsController, "#index", type: :request do
+  describe "list subgroups of a group" do
+    let!(:mentor) { FactoryBot.create(:user) }
+    let!(:group) { FactoryBot.create(:group, primary_mentor: mentor) }
+    let!(:subgroup) { FactoryBot.create(:group, name: "Team A", parent_group: group) }
+
+    context "when not authenticated" do
+      before { get "/api/v1/groups/#{group.id}/subgroups", as: :json }
+
+      it "returns unauthenticated" do
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "when a non-member requests the subgroups" do
+      before do
+        token = get_auth_token(FactoryBot.create(:user))
+        get "/api/v1/groups/#{group.id}/subgroups",
+            headers: { Authorization: "Token #{token}" }, as: :json
+      end
+
+      it "returns forbidden" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "when the mentor requests the subgroups" do
+      before do
+        token = get_auth_token(mentor)
+        get "/api/v1/groups/#{group.id}/subgroups",
+            headers: { Authorization: "Token #{token}" }, as: :json
+      end
+
+      it "returns the subgroups" do
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["data"].first["id"]).to eq(subgroup.id.to_s)
+        expect(response.parsed_body["data"].first["attributes"]["name"]).to eq(subgroup.name)
+        expect(response.parsed_body["data"].first["attributes"]["parent_group_id"]).to eq(group.id)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/subgroups_controller/show_spec.rb
+++ b/spec/requests/api/v1/subgroups_controller/show_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::SubgroupsController, "#show", type: :request do
+  describe "show a subgroup" do
+    let!(:mentor) { FactoryBot.create(:user) }
+    let!(:group) { FactoryBot.create(:group, primary_mentor: mentor) }
+    let!(:subgroup) { FactoryBot.create(:group, name: "Team A", parent_group: group) }
+
+    context "when not authenticated" do
+      before { get "/api/v1/subgroups/#{subgroup.id}", as: :json }
+
+      it "returns unauthenticated" do
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "when the mentor requests the subgroup" do
+      before do
+        token = get_auth_token(mentor)
+        get "/api/v1/subgroups/#{subgroup.id}",
+            headers: { Authorization: "Token #{token}" }, as: :json
+      end
+
+      it "returns the subgroup details" do
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["data"]["attributes"]["name"]).to eq("Team A")
+        expect(response.parsed_body["data"]["attributes"]["parent_group_id"]).to eq(group.id)
+      end
+    end
+
+    context "when a non-member requests the subgroup" do
+      before do
+        token = get_auth_token(FactoryBot.create(:user))
+        get "/api/v1/subgroups/#{subgroup.id}",
+            headers: { Authorization: "Token #{token}" }, as: :json
+      end
+
+      it "returns forbidden" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "when the id belongs to a top-level group" do
+      before do
+        token = get_auth_token(mentor)
+        get "/api/v1/subgroups/#{group.id}",
+            headers: { Authorization: "Token #{token}" }, as: :json
+      end
+
+      it "returns not found" do
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/subgroups_controller/update_members_spec.rb
+++ b/spec/requests/api/v1/subgroups_controller/update_members_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::SubgroupsController, "#update_members", type: :request do
+  describe "sync subgroup members" do
+    let!(:mentor) { FactoryBot.create(:user) }
+    let!(:group) { FactoryBot.create(:group, primary_mentor: mentor) }
+    let!(:subgroup) { FactoryBot.create(:group, name: "Team A", parent_group: group) }
+    let!(:student_a) { FactoryBot.create(:user) }
+    let!(:student_b) { FactoryBot.create(:user) }
+
+    before do
+      FactoryBot.create(:group_member, group: group, user: student_a)
+      FactoryBot.create(:group_member, group: group, user: student_b)
+    end
+
+    context "when the mentor sets the membership" do
+      before do
+        token = get_auth_token(mentor)
+        patch "/api/v1/subgroups/#{subgroup.id}/members",
+              headers: { Authorization: "Token #{token}" },
+              params: { user_ids: [student_a.id, student_b.id] }, as: :json
+      end
+
+      it "adds the selected parent members" do
+        expect(response).to have_http_status(:accepted)
+        expect(subgroup.reload.group_members.pluck(:user_id))
+          .to contain_exactly(student_a.id, student_b.id)
+      end
+    end
+
+    context "when a user is submitted who is not in the parent group" do
+      before do
+        outsider = FactoryBot.create(:user)
+        token = get_auth_token(mentor)
+        patch "/api/v1/subgroups/#{subgroup.id}/members",
+              headers: { Authorization: "Token #{token}" },
+              params: { user_ids: [outsider.id, student_a.id] }, as: :json
+      end
+
+      it "ignores the outsider" do
+        expect(subgroup.reload.group_members.pluck(:user_id)).to contain_exactly(student_a.id)
+      end
+    end
+
+    context "when a submitted user already holds a mentor row in the subgroup" do
+      before do
+        FactoryBot.create(:group_member, group: subgroup, user: student_a, mentor: true)
+        token = get_auth_token(mentor)
+        patch "/api/v1/subgroups/#{subgroup.id}/members",
+              headers: { Authorization: "Token #{token}" },
+              params: { user_ids: [student_a.id, student_b.id] }, as: :json
+      end
+
+      it "does not duplicate the row" do
+        expect(response).to have_http_status(:accepted)
+        expect(subgroup.reload.group_members.where(user_id: student_a.id).count).to eq(1)
+      end
+    end
+
+    context "when a regular member tries to change membership" do
+      before do
+        token = get_auth_token(student_a)
+        patch "/api/v1/subgroups/#{subgroup.id}/members",
+              headers: { Authorization: "Token #{token}" },
+              params: { user_ids: [student_b.id] }, as: :json
+      end
+
+      it "returns forbidden" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+end

--- a/spec/requests/subgroups_spec.rb
+++ b/spec/requests/subgroups_spec.rb
@@ -132,6 +132,26 @@ describe SubgroupsController, type: :request do
       expect(@subgroup.reload.group_members.pluck(:user_id))
         .to contain_exactly(@student.id)
     end
+
+    it "does not duplicate or demote a user who is already a subgroup mentor" do
+      FactoryBot.create(:group_member, group: @subgroup, user: @student, mentor: true)
+      patch update_members_group_subgroup_path(@group, @subgroup),
+            params: { user_ids: [@student.id, @other_student.id] }
+      expect(response).to redirect_to(group_path(@subgroup))
+      rows = @subgroup.reload.group_members.where(user_id: @student.id)
+      expect(rows.count).to eq(1)
+      expect(rows.first.mentor).to be(true)
+      expect(@subgroup.group_members.pluck(:user_id))
+        .to contain_exactly(@student.id, @other_student.id)
+    end
+
+    it "keeps mentor rows when their checkbox is not submitted" do
+      FactoryBot.create(:group_member, group: @subgroup, user: @student, mentor: true)
+      patch update_members_group_subgroup_path(@group, @subgroup),
+            params: { user_ids: [@other_student.id] }
+      expect(@subgroup.reload.group_members.mentor.pluck(:user_id))
+        .to contain_exactly(@student.id)
+    end
   end
 
   describe "invite token" do

--- a/spec/requests/subgroups_spec.rb
+++ b/spec/requests/subgroups_spec.rb
@@ -1,0 +1,201 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe SubgroupsController, type: :request do
+  before do
+    @primary_mentor = FactoryBot.create(:user)
+    @group = FactoryBot.create(:group, primary_mentor: @primary_mentor)
+    @student = FactoryBot.create(:user)
+    FactoryBot.create(:group_member, group: @group, user: @student)
+  end
+
+  describe "#create" do
+    context "when signed in as the primary mentor" do
+      before { sign_in @primary_mentor }
+
+      it "creates a subgroup under the group" do
+        expect do
+          post group_subgroups_path(@group), params: { group: { name: "Team A" } }
+        end.to change(Group, :count).by(1)
+        expect(response).to redirect_to(group_path(@group))
+        subgroup = Group.order(:created_at).last
+        expect(subgroup.parent_group).to eq(@group)
+        expect(subgroup.primary_mentor).to eq(@primary_mentor)
+      end
+
+      it "rejects a duplicate subgroup name with an alert" do
+        FactoryBot.create(:group, name: "Team A", parent_group: @group)
+        expect do
+          post group_subgroups_path(@group), params: { group: { name: "Team A" } }
+        end.not_to change(Group, :count)
+        expect(flash[:alert]).to be_present
+      end
+    end
+
+    context "when signed in as a group mentor" do
+      before do
+        mentor = FactoryBot.create(:user)
+        FactoryBot.create(:group_member, group: @group, user: mentor, mentor: true)
+        sign_in mentor
+      end
+
+      it "creates a subgroup" do
+        expect do
+          post group_subgroups_path(@group), params: { group: { name: "Team A" } }
+        end.to change(Group, :count).by(1)
+      end
+    end
+
+    context "when signed in as a regular member" do
+      before { sign_in @student }
+
+      it "is not authorized" do
+        expect do
+          post group_subgroups_path(@group), params: { group: { name: "Team A" } }
+        end.not_to change(Group, :count)
+      end
+    end
+
+    context "when the target group is itself a subgroup" do
+      before { sign_in @primary_mentor }
+
+      it "is not authorized (no nesting)" do
+        subgroup = FactoryBot.create(:group, name: "Team A", parent_group: @group)
+        expect do
+          post group_subgroups_path(subgroup), params: { group: { name: "Nested" } }
+        end.not_to change(Group, :count)
+      end
+    end
+  end
+
+  describe "#destroy" do
+    before do
+      @subgroup = FactoryBot.create(:group, name: "Team A", parent_group: @group)
+    end
+
+    context "when signed in as the primary mentor" do
+      before { sign_in @primary_mentor }
+
+      it "deletes the subgroup" do
+        expect do
+          delete group_subgroup_path(@group, @subgroup)
+        end.to change(Group, :count).by(-1)
+        expect(response).to redirect_to(group_path(@group))
+      end
+    end
+
+    context "when signed in as a regular member" do
+      before { sign_in @student }
+
+      it "is not authorized" do
+        expect do
+          delete group_subgroup_path(@group, @subgroup)
+        end.not_to change(Group, :count)
+      end
+    end
+  end
+
+  describe "#update_members" do
+    before do
+      @subgroup = FactoryBot.create(:group, name: "Team A", parent_group: @group)
+      @other_student = FactoryBot.create(:user)
+      FactoryBot.create(:group_member, group: @group, user: @other_student)
+      @outsider = FactoryBot.create(:user)
+      sign_in @primary_mentor
+    end
+
+    it "adds selected parent members to the subgroup" do
+      patch update_members_group_subgroup_path(@group, @subgroup),
+            params: { user_ids: [@student.id, @other_student.id] }
+      expect(@subgroup.reload.group_members.pluck(:user_id))
+        .to contain_exactly(@student.id, @other_student.id)
+    end
+
+    it "removes deselected members from the subgroup" do
+      FactoryBot.create(:group_member, group: @subgroup, user: @student)
+      patch update_members_group_subgroup_path(@group, @subgroup),
+            params: { user_ids: [@other_student.id] }
+      expect(@subgroup.reload.group_members.pluck(:user_id))
+        .to contain_exactly(@other_student.id)
+    end
+
+    it "clears membership when no users are submitted" do
+      FactoryBot.create(:group_member, group: @subgroup, user: @student)
+      patch update_members_group_subgroup_path(@group, @subgroup), params: {}
+      expect(@subgroup.reload.group_members.count).to eq(0)
+    end
+
+    it "ignores users who are not members of the parent group" do
+      patch update_members_group_subgroup_path(@group, @subgroup),
+            params: { user_ids: [@outsider.id, @student.id] }
+      expect(@subgroup.reload.group_members.pluck(:user_id))
+        .to contain_exactly(@student.id)
+    end
+  end
+
+  describe "invite token" do
+    it "cannot be generated for a subgroup" do
+      subgroup = FactoryBot.create(:group, name: "Team A", parent_group: @group)
+      sign_in @primary_mentor
+      put generate_token_group_path(subgroup)
+      expect(response).to have_http_status(:forbidden)
+      expect(subgroup.reload.token_expires_at).to be_nil
+    end
+  end
+
+  describe "group pages with subgroups" do
+    before do
+      @subgroup = FactoryBot.create(:group, name: "Team Alpha", parent_group: @group)
+    end
+
+    context "when the mentor views the parent group" do
+      it "renders the subgroups section with manage controls" do
+        sign_in @primary_mentor
+        get group_path(@group)
+        expect(response.body).to include("SUBGROUPS:")
+        expect(response.body).to include("Team Alpha")
+        expect(response.body).to include("createsubgroupModal")
+      end
+    end
+
+    context "when a student not in any subgroup views the parent group" do
+      it "does not list other teams and shows no manage controls" do
+        sign_in @student
+        get group_path(@group)
+        expect(response.body).not_to include("Team Alpha")
+        expect(response.body).not_to include("createsubgroupModal")
+      end
+    end
+
+    context "when a subgroup member views the parent group" do
+      it "lists their subgroup" do
+        FactoryBot.create(:group_member, group: @subgroup, user: @student)
+        sign_in @student
+        get group_path(@group)
+        expect(response.body).to include("Team Alpha")
+      end
+    end
+
+    context "when the mentor views the subgroup page" do
+      it "shows the parent breadcrumb and the manage-members modal instead of invites" do
+        sign_in @primary_mentor
+        get group_path(@subgroup)
+        expect(response.body).to include("Subgroup of:")
+        expect(response.body).to include("managesubgroupmembersModal")
+        expect(response.body).not_to include("addmemberModal")
+        expect(response.body).not_to include("createsubgroupModal")
+      end
+    end
+
+    context "when a subgroup member views the subgroup page" do
+      it "renders without manage controls" do
+        FactoryBot.create(:group_member, group: @subgroup, user: @student)
+        sign_in @student
+        get group_path(@subgroup)
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include("managesubgroupmembersModal")
+      end
+    end
+  end
+end

--- a/spec/support/api/schemas/group.json
+++ b/spec/support/api/schemas/group.json
@@ -13,6 +13,7 @@
             "primary_mentor_name": { "type": "string" },
             "name": { "type": "string" },
             "primary_mentor_id": { "type": "integer" },
+            "parent_group_id": { "type": ["integer", "null"] },
             "created_at": { "type": "string" },
             "updated_at": { "type": "string" }
           },

--- a/spec/support/api/schemas/groups.json
+++ b/spec/support/api/schemas/groups.json
@@ -15,6 +15,7 @@
               "primary_mentor_name": { "type": "string" },
               "name": { "type": "string" },
               "primary_mentor_id": { "type": "integer" },
+            "parent_group_id": { "type": ["integer", "null"] },
               "created_at": { "type": "string" },
               "updated_at": { "type": "string" }
             },

--- a/spec/support/api/schemas/groups_with_assignments.json
+++ b/spec/support/api/schemas/groups_with_assignments.json
@@ -15,6 +15,7 @@
               "primary_mentor_name": { "type": "string" },
               "name": { "type": "string" },
               "primary_mentor_id": { "type": "integer" },
+            "parent_group_id": { "type": ["integer", "null"] },
               "created_at": { "type": "string" },
               "updated_at": { "type": "string" }
             },

--- a/spec/support/api/schemas/groups_with_members.json
+++ b/spec/support/api/schemas/groups_with_members.json
@@ -15,6 +15,7 @@
               "primary_mentor_name": { "type": "string" },
               "name": { "type": "string" },
               "primary_mentor_id": { "type": "integer" },
+            "parent_group_id": { "type": ["integer", "null"] },
               "created_at": { "type": "string" },
               "updated_at": { "type": "string" }
             },


### PR DESCRIPTION
### Describe the changes you have made in this PR

Adds **subgroups (teams) within a group**, so an instructor can split a
class into smaller working groups. A subgroup is modelled as a `Group`
with a `parent_group_id`, which lets assignments, membership, grades,
notifications and policies reuse the existing group machinery unchanged.

**Data layer**
- New nullable column `groups.parent_group_id` (self-referential FK + index).
  Two migrations following the repo's `strong_migrations` pattern used for
  the organization FK: concurrent index first, then FK with `validate: false`
  (column is new / all-NULL).
- `Group`: `parent_group` / `subgroups` associations, `top_level` scope,
  one-level-nesting validation, per-parent case-insensitive name uniqueness,
  primary-mentor inheritance, and no creation mail for subgroups.
- `GroupMember`: a subgroup member must already belong to the parent group;
  no welcome mail when sorting a class into teams; mirrors the unique DB
  index as a validation.

**Web UI & controller** (`SubgroupsController`)
- Group page gains a **Subgroups** section. Mentors can create/delete teams
  and sync membership from the parent roster via a checkbox modal. Students
  only see the teams they belong to.
- Subgroup pages show a "Subgroup of …" breadcrumb, swap the email/invite
  member modal for roster-based **Manage Members**, and cannot generate
  invite tokens (membership is instructor-assigned only).
- Assignments created inside a subgroup are visible only to that subgroup —
  no `Assignment` changes were needed, since it already `belongs_to :group`.
- Dashboards and API group listings are scoped to top-level groups.

**REST API (`/api/v1`)**
- `GET/POST /api/v1/groups/:group_id/subgroups`
- `GET/DELETE /api/v1/subgroups/:id`
- `PATCH /api/v1/subgroups/:id/members`
- Authorization reuses `GroupPolicy`; `GroupSerializer` exposes
  `parent_group_id`.

All actions are gated on `GroupPolicy#manage_subgroups?` (primary mentor or
group mentor of the parent), so only instructors/admins can manage subgroup
membership.

### Testing

Model, request and policy specs cover creation rules, nesting limits,
membership constraints, per-role page rendering, the duplicate-member fix,
and every API endpoint. Existing group/assignment/API contract specs pass
unchanged.

### Out of scope for this PR (follow-ups)

- Cross-subgroup grade aggregation on class-wide assignments
- Auto-created shared team projects


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added subgroup support across the app, including creating, viewing, updating members, and deleting subgroups.
  * Group pages now show subgroup listings and subgroup-specific controls.
  * API responses now include parent-group information for groups and subgroups.

* **Bug Fixes**
  * Restricted invite/token generation for subgroups.
  * Group lists now consistently show top-level groups where appropriate.
  * Added validation to prevent invalid subgroup nesting and duplicate subgroup names within the same parent.

* **Chores**
  * Updated localized messages and API schema definitions to match the new subgroup experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->