### PR TITLE
fix: toggle behavior of Getting Started and User dropdowns (#7332)

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -36,7 +36,6 @@
               class="nav-link dropdown-toggle navbar-item navbar-text"
               type="button"
               data-bs-toggle="dropdown"
-              data-bs-auto-close="true"
               aria-haspopup="true"
               aria-expanded="false"
               aria-label="<%= t('layout.getting_started_dropdown') %>">
@@ -67,7 +66,6 @@
                 id="navbar-dropdown-2"
                 type="button"
                 data-bs-toggle="dropdown"
-                data-bs-auto-close="true"
                 aria-haspopup="true"
                 aria-expanded="false"
                 aria-label="<%= current_user.name %>">


### PR DESCRIPTION
Fixes #7332

#### Describe the changes you have made in this PR -
Removed `data-bs-auto-close="true"` from the 'Getting Started' and User profile dropdown buttons in `app/views/layouts/_header.html.erb` to prevent conflicts with Bootstrap 5 dropdown toggle event handling.

### Screenshots of the UI changes (If any) -
N/A

---

## Code Understanding and AI Usage

**Did you use AI generated code (ChatGPT, Claude, Copilot, etc.) in any part of this PR? **
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Removing `data-bs-auto-close="true"` ensures that clicking the dropdown trigger button toggles the dropdown open/closed consistently in Bootstrap 5 without firing a premature auto-close event on the second click.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] My code follows the project's style guidelines and conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved header dropdown behavior by allowing menus to remain open during relevant interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->