### PR TITLE
feat(layout): use official CircuitVerse SVG logo favicon across layouts (#7699)

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,8 @@
                           title: yield(:title).presence || "CircuitVerse - Digital Circuit Simulator" %>
     <meta name="keywords"
       content="Digital circuits, logisim, online, educational platform, karnaugh map, kmap, electronic devices and circuits,digital electronics basics,introduction to digital electronics, simple electronics projects for students,electric circuit analysis, logic circuits, logic simulation, digital logic circuits, boolean logic">
-    <%= favicon_link_tag "favicon.ico" %>
+    <%= favicon_link_tag "CircuitVerse-cropped.svg", rel: "icon", type: "image/svg+xml" %>
+    <%= favicon_link_tag "favicon.ico", rel: "alternate icon", type: "image/x-icon" %>
 
     <%= stylesheet_link_tag "application", media: "all", "data-turbolinks-track": "reload" %>
     <link rel="preconnect" href="https://fonts.gstatic.com">

--- a/app/views/layouts/simulator.html.erb
+++ b/app/views/layouts/simulator.html.erb
@@ -8,7 +8,8 @@
     <%= vite_javascript_tag "jquery" %>
     <%= vite_javascript_tag "bootstrap" %>
     <%= vite_javascript_tag "simulator" %>
-    <%= favicon_link_tag "favicon.ico" %>
+    <%= favicon_link_tag "CircuitVerse-cropped.svg", rel: "icon", type: "image/svg+xml" %>
+    <%= favicon_link_tag "favicon.ico", rel: "alternate icon", type: "image/x-icon" %>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <%= render "layouts/google_analytics" %>
   </head>

--- a/app/views/layouts/testbench.html.erb
+++ b/app/views/layouts/testbench.html.erb
@@ -6,7 +6,8 @@
     <script src="/js/pace.js"></script>
     <%= javascript_include_tag "testbench", "data-turbolinks-track": "reload" %>
     <%= stylesheet_link_tag "testbench", media: "all", "data-turbolinks-track": "reload" %>
-    <%= favicon_link_tag "favicon.ico" %>
+    <%= favicon_link_tag "CircuitVerse-cropped.svg", rel: "icon", type: "image/svg+xml" %>
+    <%= favicon_link_tag "favicon.ico", rel: "alternate icon", type: "image/x-icon" %>
 
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <%= render partial: "layouts/google_analytics" if Rails.env.production? %>


### PR DESCRIPTION
### Description

Adds the official CircuitVerse SVG logo favicon (`CircuitVerse-cropped.svg`) across application, simulator, and testbench layout templates so modern high-DPI screens render the official logo instead of falling back to default browser globe icons.

#### Changes made:
- Updated `app/views/layouts/application.html.erb` with SVG logo favicon link tag.
- Updated `app/views/layouts/simulator.html.erb` with SVG logo favicon link tag.
- Updated `app/views/layouts/testbench.html.erb` with SVG logo favicon link tag.
- Retained legacy `.ico` link tag with `rel="alternate icon"` fallback.

### Related issue

- Fixes #7699

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated browser tab icons across the application, simulator, and testbench.
  * Added the SVG icon as the primary favicon with the ICO icon available as an alternative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->