### PR TITLE
fix(simulator): automatically dismiss dimmed overlay after final hint in guided tour (#7713)

### DIFF
--- a/simulator/src/tutorials.js
+++ b/simulator/src/tutorials.js
@@ -174,6 +174,14 @@ const animatedTourDriver = new Driver({
     opacity: 0.8,
     padding: 5,
     showButtons: true,
+    allowClose: true,
+    doneBtnText: 'Done',
+    onReset: () => {
+        const overlay = document.getElementById('driver-page-overlay');
+        if (overlay) {
+            overlay.remove();
+        }
+    },
 });
 
 export function showTourGuide() {


### PR DESCRIPTION
### Description

Fixes #7713 where the dimmed screen overlay remains active after reaching and advancing past the final hint in the simulator's guided tutorial tour.

#### Changes made:
- Added `allowClose: true` and `doneBtnText: 'Done'` to `animatedTourDriver` in `simulator/src/tutorials.js`.
- Implemented `onReset` callback handler to explicitly remove `#driver-page-overlay` from the DOM when completing or dismissing the tutorial.

### Related Issue

Fixes #7713

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added the ability to close the tutorial walkthrough.
  * Renamed the completion button to “Done.”
  * Removed the page overlay when restarting the tutorial.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->