### PR TITLE
fix: resolve rubocop lint offenses in spec files

### DIFF
--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -12,7 +12,7 @@ describe ProjectsController, type: :request do
       before do
         @project = FactoryBot.create(:project, author: @author, project_access_type: "Public")
         @visit = FactoryBot.create(:ahoy_visit)
-        allow(ProjectsController).to receive(:new).and_wrap_original do |m, *args, **kwargs|
+        allow(described_class).to receive(:new).and_wrap_original do |m, *args, **kwargs|
           controller = m.call(*args, **kwargs)
           allow(controller).to receive(:current_visit).and_return(@visit)
           controller

--- a/spec/models/featured_circuit_spec.rb
+++ b/spec/models/featured_circuit_spec.rb
@@ -8,10 +8,12 @@ RSpec.describe FeaturedCircuit, type: :model do
   end
 
   describe "associations" do
-    subject { FactoryBot.build(:featured_circuit) }
+    subject { featured_circuit }
+
+    let(:featured_circuit) { FactoryBot.build(:featured_circuit) }
 
     before do
-      allow(subject).to receive(:project_public)
+      allow(featured_circuit).to receive(:project_public)
     end
 
     it { is_expected.to belong_to(:project) }

--- a/spec/models/grade_spec.rb
+++ b/spec/models/grade_spec.rb
@@ -12,10 +12,14 @@ RSpec.describe Grade, type: :model do
   end
 
   describe "associations" do
-    subject { FactoryBot.build(:grade, assignment: @assignment, project: @assignment_project, grader: @primary_mentor) }
+    subject { grade }
+
+    let(:grade) do
+      FactoryBot.build(:grade, assignment: @assignment, project: @assignment_project, grader: @primary_mentor)
+    end
 
     before do
-      allow(subject).to receive(:assignment).and_return(@assignment)
+      allow(grade).to receive(:assignment).and_return(@assignment)
     end
 
     it { is_expected.to belong_to(:project) }

--- a/spec/requests/api/v1/projects_controller/update_circuit_spec.rb
+++ b/spec/requests/api/v1/projects_controller/update_circuit_spec.rb
@@ -90,7 +90,8 @@ RSpec.describe Api::V1::ProjectsController, "#update_circuit", type: :request do
       context "when project saving fails" do
         before do
           token = get_auth_token(user)
-          allow(Project).to receive_message_chain(:friendly, :find).and_return(project)
+          friendly_finder = class_double(Project, find: project)
+          allow(Project).to receive(:friendly).and_return(friendly_finder)
           allow(project).to receive(:save).and_return(false)
           patch "/api/v1/projects/update_circuit",
                 headers: { Authorization: "Token #{token}" },


### PR DESCRIPTION
Fixes #7723 

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -
This PR resolves the `Ruby on Rails CI / lint` failure on `master` caused by 4 pre-existing Rubocop offenses:

- `spec/controllers/projects_controller_spec.rb` — `RSpec/DescribedClass`: replaced `ProjectsController` with `described_class`
- `spec/models/featured_circuit_spec.rb` — `RSpec/SubjectStub`: introduced a named `let(:featured_circuit)` instead of stubbing `subject` directly
- `spec/models/grade_spec.rb` — `RSpec/SubjectStub`: introduced a named `let(:grade)` instead of stubbing `subject` directly
- `spec/requests/api/v1/projects_controller/update_circuit_spec.rb` — `RSpec/MessageChain`: replaced `receive_message_chain(:friendly, :find)` with a `class_double(Project, find: project)` stub on `Project.friendly`

No production code was changed — only spec files, to make them Rubocop-compliant without altering test intent or coverage.

Verified locally:
`bundle exec rubocop --parallel`

### Screenshots of the UI changes (If any) -
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI generated code (ChatGPT, Claude, Copilot, etc.) in any part of this PR? **
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Each offense needed a different fix to satisfy Rubocop without changing what the test actually verifies:
- `RSpec/DescribedClass` was a straightforward auto-correct (`rubocop -A`).
- `RSpec/SubjectStub` flags stubbing methods directly on `subject`. The fix extracts the built object into a named `let`, keeps `subject` pointing at it, and stubs the named reference instead  behavior is identical, only the reference used for stubbing changes.
- `RSpec/MessageChain` flags `receive_message_chain`, which is discouraged because it can hide real interface mismatches. I replaced it with `class_double(Project, find: project)`, a verifying double, so the stub only works if `Project` genuinely responds to `find` as a class method  which it does via ActiveRecord.

I ran `bundle exec rubocop -parallel` and `bundle exec rspec` on all 4 affected files to confirm zero offenses and no broken behavior before opening this PR.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test clarity and maintainability across project, featured circuit, and grade specs.
  * Updated test setup to use explicit subjects and more focused stubs.
  * Preserved existing behavior and assertions while making request failure scenarios more robust.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->