### PR TITLE
fix(controller): respond with JSON error for non-member leave requests (#7729)

### DIFF
--- a/app/controllers/organization_members_controller.rb
+++ b/app/controllers/organization_members_controller.rb
@@ -59,7 +59,10 @@ class OrganizationMembersController < ApplicationController
     @organization_member = @organization.organization_members.find_by(user: current_user)
 
     if @organization_member.nil?
-      redirect_to organizations_path, alert: t(".not_a_member")
+      respond_to do |format|
+        format.html { redirect_to organizations_path, alert: t(".not_a_member") }
+        format.json { render json: { error: t(".not_a_member") }, status: :unprocessable_content }
+      end
       return
     end
 

--- a/spec/controllers/organization_members_controller_spec.rb
+++ b/spec/controllers/organization_members_controller_spec.rb
@@ -160,5 +160,24 @@ RSpec.describe OrganizationMembersController, type: :controller do
         expect(response).to have_http_status(:forbidden)
       end
     end
+
+    context "when user is not a member" do
+      let(:non_member_user) { create(:user) }
+
+      before do
+        sign_in non_member_user
+      end
+
+      it "redirects to organizations list for HTML request" do
+        delete :leave, params: { organization_id: organization.id }
+        expect(response).to redirect_to(organizations_path)
+      end
+
+      it "returns unprocessable content JSON error for JSON request" do
+        delete :leave, params: { organization_id: organization.id }, format: :json
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(JSON.parse(response.body)["error"]).to eq(I18n.t("organization_members.leave.not_a_member"))
+      end
+    end
   end
 end


### PR DESCRIPTION
### Summary of Changes

Fixes #7729 where `DELETE /organizations/:id/leave.json` sent a bare 302 HTML redirect to JSON clients when the requesting user was not a member of the organization.

#### Changes made:
- Wrapped the early return guard in `OrganizationMembersController#leave` inside a `respond_to` block handling both `format.html` (302 redirect) and `format.json` (422 unprocessable content with JSON error message).
- Added controller spec test cases in `spec/controllers/organization_members_controller_spec.rb` verifying HTML redirect and JSON error response when a non-member attempts to leave an organization.

### Related Issue

- Fixes #7729

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when a non-member attempts to leave an organization.
  * HTML requests continue to redirect appropriately, while JSON requests now return a clear error with HTTP 422 status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->