### PR TITLE
feat(organizations): add organization creation page

### DIFF
--- a/app/assets/stylesheets/organizations.scss
+++ b/app/assets/stylesheets/organizations.scss
@@ -50,6 +50,7 @@
 .org-dash-info-desc {
   max-width: 640px;
   font-size: 15px;
+  overflow-wrap: break-word;
 }
 
 .org-dash-social {

--- a/app/assets/stylesheets/organizations.scss
+++ b/app/assets/stylesheets/organizations.scss
@@ -124,6 +124,47 @@
   font-size: 36px;
 }
 
+.org-new {
+  max-width: 720px;
+}
+
+.org-form-icon {
+  color: $primary-green;
+}
+
+.org-upload-zone {
+  border: 2px dashed var(--bs-gray-400);
+  border-radius: 8px;
+  padding: 24px;
+  text-align: center;
+  cursor: pointer;
+  transition: border-color 0.15s, background-color 0.15s;
+}
+
+.org-upload-zone:hover,
+.org-upload-zone--active,
+.org-upload-zone:focus-visible {
+  border-color: $primary-green;
+  background-color: $light-green-bg;
+}
+
+.org-upload-zone:focus-visible {
+  outline: 2px solid $primary-green;
+  outline-offset: 2px;
+}
+
+.org-upload-zone__icon {
+  font-size: 28px;
+  color: $primary-green;
+  margin-bottom: 8px;
+}
+
+.org-settings-logo-preview {
+  width: 48px;
+  height: 48px;
+  object-fit: cover;
+}
+
 @media (max-width: 600px) {
   .org-dash-logo {
     width: 96px;

--- a/app/component/organization_form_component.html.erb
+++ b/app/component/organization_form_component.html.erb
@@ -48,7 +48,7 @@
     <div class="input-group">
       <span class="input-group-text"><i class="fa fa-map-marker-alt org-form-icon" aria-hidden="true"></i></span>
       <%= form.text_field :location, id: "organization_location", class: "form-control",
-            placeholder: t("organizations.form.location_placeholder"), maxlength: 30 %>
+            placeholder: t("organizations.form.location_placeholder"), maxlength: 50 %>
     </div>
     <div class="text-end"><small id="org-location-counter" class="form-text"></small></div>
   </div>
@@ -128,6 +128,6 @@
   <%# Actions %>
   <div class="d-flex justify-content-end gap-2 border-top pt-3 mt-4">
     <%= link_to t("cancel"), cancel_path, class: "btn btn-outline-secondary" %>
-    <%= form.submit t("organizations.form.submit"), class: "btn primary-button" %>
+    <%= form.submit organization.persisted? ? t("organizations.form.update") : t("organizations.form.submit"), class: "btn primary-button" %>
   </div>
 <% end %>

--- a/app/component/organization_form_component.html.erb
+++ b/app/component/organization_form_component.html.erb
@@ -96,10 +96,10 @@
   <div class="mb-3">
     <%= form.label :logo, t("organizations.form.logo_label"), class: "form-label fw-semibold" %>
     <div class="form-text mt-0 mb-2"><%= t("organizations.form.logo_hint") %></div>
-    <% if @organization.logo.attached? %>
+    <% if @organization.persisted? && @organization.logo.attached? %>
       <div class="d-flex align-items-center gap-3 p-2 mb-2 border rounded bg-light">
         <%= image_tag @organization.logo, class: "rounded border org-settings-logo-preview",
-              alt: t("organizations.form.current_logo_alt", organization: @organization.name) %>
+          alt: t("organizations.form.current_logo_alt", organization: @organization.name) %>
         <div class="d-flex flex-column">
           <span class="fw-semibold small"><%= t("organizations.form.current_logo") %></span>
           <span class="text-secondary small"><%= t("organizations.form.replace_logo_hint") %></span>

--- a/app/component/organization_form_component.html.erb
+++ b/app/component/organization_form_component.html.erb
@@ -96,9 +96,9 @@
   <div class="mb-3">
     <%= form.label :logo, t("organizations.form.logo_label"), class: "form-label fw-semibold" %>
     <div class="form-text mt-0 mb-2"><%= t("organizations.form.logo_hint") %></div>
-    <% if @organization.persisted? && @organization.logo.attached? %>
+    <% if persisted_logo %>
       <div class="d-flex align-items-center gap-3 p-2 mb-2 border rounded bg-light">
-        <%= image_tag @organization.logo, class: "rounded border org-settings-logo-preview",
+        <%= image_tag persisted_logo, class: "rounded border org-settings-logo-preview",
           alt: t("organizations.form.current_logo_alt", organization: @organization.name) %>
         <div class="d-flex flex-column">
           <span class="fw-semibold small"><%= t("organizations.form.current_logo") %></span>

--- a/app/component/organization_form_component.html.erb
+++ b/app/component/organization_form_component.html.erb
@@ -1,0 +1,133 @@
+<%= form_with(model: @organization, local: true,
+              html: { enctype: "multipart/form-data", id: "organization-form" },
+              data: { controller: "organization-form" }) do |form| %>
+  <% if @organization.errors.any? %>
+    <div class="alert alert-danger d-flex align-items-start gap-2" role="alert">
+      <i class="fa fa-exclamation-circle mt-1" aria-hidden="true"></i>
+      <ul class="list-unstyled mb-0">
+        <% @organization.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="border-bottom pb-3 mb-4">
+    <h2 class="h5 fw-semibold mb-1"><%= t("organizations.form.details_heading") %></h2>
+    <p class="text-secondary small mb-0"><%= t("organizations.form.details_subheading") %></p>
+  </div>
+
+  <%# Name %>
+  <div class="mb-3">
+    <label class="form-label fw-semibold" for="organization_name">
+      <%= t("organizations.form.name_label") %> <span class="text-danger">*</span>
+    </label>
+    <div class="form-text mt-0 mb-2"><%= t("organizations.form.name_hint") %></div>
+    <div class="input-group">
+      <span class="input-group-text"><i class="fa fa-building org-form-icon" aria-hidden="true"></i></span>
+      <%= form.text_field :name, id: "organization_name", class: "form-control",
+            placeholder: t("organizations.form.name_placeholder"), required: true, maxlength: 50 %>
+    </div>
+    <div class="text-end"><small id="org-name-counter" class="form-text"></small></div>
+  </div>
+
+  <%# Description %>
+  <div class="mb-3">
+    <%= form.label :description, t("organizations.form.description_label"),
+          class: "form-label fw-semibold", for: "org-description-input" %>
+    <div class="form-text mt-0 mb-2"><%= t("organizations.form.description_hint") %></div>
+    <%= form.text_area :description, class: "form-control", id: "org-description-input",
+          maxlength: 160, rows: 3, placeholder: t("organizations.form.description_placeholder") %>
+    <div class="text-end"><small id="org-description-counter" class="form-text"></small></div>
+  </div>
+
+  <%# Location %>
+  <div class="mb-3">
+    <label class="form-label fw-semibold" for="organization_location"><%= t("organizations.form.location_label") %></label>
+    <div class="form-text mt-0 mb-2"><%= t("organizations.form.location_hint") %></div>
+    <div class="input-group">
+      <span class="input-group-text"><i class="fa fa-map-marker-alt org-form-icon" aria-hidden="true"></i></span>
+      <%= form.text_field :location, id: "organization_location", class: "form-control",
+            placeholder: t("organizations.form.location_placeholder"), maxlength: 30 %>
+    </div>
+    <div class="text-end"><small id="org-location-counter" class="form-text"></small></div>
+  </div>
+
+  <%# Visibility %>
+  <div class="mb-3">
+    <%= form.label :private, t("organizations.form.visibility_label"), class: "form-label fw-semibold" %>
+    <div class="form-text mt-0 mb-2"><%= t("organizations.form.visibility_hint") %></div>
+    <%= form.select :private,
+          [[t("organizations.form.visibility_private"), true], [t("organizations.form.visibility_public"), false]],
+          {}, { id: "organization_private", class: "form-select" } %>
+  </div>
+
+  <%# External Links %>
+  <div class="mb-3">
+    <label class="form-label fw-semibold"><%= t("organizations.form.links_label") %></label>
+    <div class="form-text mt-0 mb-2"><%= t("organizations.form.links_hint") %></div>
+    <div id="organizations-links-container" class="d-flex flex-column gap-2 mb-2"
+     data-logo-github="<%= helpers.asset_path('logos/github-logo-circle.png') %>"
+     data-logo-x="<%= helpers.asset_path('logos/twitter-x.png') %>"
+     data-logo-linkedin="<%= helpers.asset_path('logos/linkedin-logo.png') %>"
+     data-logo-facebook="<%= helpers.asset_path('logos/facebook-logo.png') %>"
+     data-logo-youtube="<%= helpers.asset_path('logos/youtube-logo.png') %>"
+     data-logo-default="<%= helpers.asset_path('logos/link-logo.png') %>">
+      <% (existing_links.presence || [nil]).each do |link| %>
+        <div class="input-group organizations-link-item">
+          <span class="input-group-text"><img class="organizations-input-icon org-social-icon" src="<%= helpers.asset_path('logos/link-logo.png') %>" alt=""></span>
+          <input type="url" name="organization[links][]" class="form-control"
+                 value="<%= link %>" placeholder="<%= t('organizations.form.links_placeholder') %>"
+                 aria-label="<%= t('organizations.form.link_aria_label') %>">
+          <button type="button" class="btn organizations-remove-link-btn"
+                  aria-label="<%= t('organizations.form.remove_link') %>" style="display: none;">
+            <i class="fa fa-times" aria-hidden="true"></i>
+          </button>
+        </div>
+      <% end %>
+    </div>
+    <button type="button" id="organizations-add-link-btn" class="btn btn-sm btn-outline-success"
+            aria-label="<%= t('organizations.form.add_link') %>">
+      <i class="fa fa-plus me-1" aria-hidden="true"></i> <%= t("organizations.form.add_link") %>
+    </button>
+  </div>
+
+  <%# Logo %>
+  <div class="mb-3">
+    <%= form.label :logo, t("organizations.form.logo_label"), class: "form-label fw-semibold" %>
+    <div class="form-text mt-0 mb-2"><%= t("organizations.form.logo_hint") %></div>
+    <% if @organization.logo.attached? %>
+      <div class="d-flex align-items-center gap-3 p-2 mb-2 border rounded bg-light">
+        <%= image_tag @organization.logo, class: "rounded border org-settings-logo-preview",
+              alt: t("organizations.form.current_logo_alt", organization: @organization.name) %>
+        <div class="d-flex flex-column">
+          <span class="fw-semibold small"><%= t("organizations.form.current_logo") %></span>
+          <span class="text-secondary small"><%= t("organizations.form.replace_logo_hint") %></span>
+        </div>
+      </div>
+      <div class="form-check mb-2">
+        <%= form.check_box :remove_logo, class: "form-check-input", id: "organization_remove_logo" %>
+        <%= form.label :remove_logo, t("organizations.form.remove_logo"), class: "form-check-label small", for: "organization_remove_logo" %>
+      </div>
+    <% end %>
+    <div class="org-upload-zone" id="organization-upload-zone" role="button" tabindex="0"
+         onclick="document.getElementById('organization_logo').click()"
+         onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}">
+      <i class="fa fa-cloud-upload-alt org-upload-zone__icon" aria-hidden="true"></i>
+      <p class="mb-1">
+        <span class="text-success fw-semibold"><%= t("organizations.form.upload_click") %></span>
+        <%= t("organizations.form.upload_drag") %>
+      </p>
+      <p class="text-secondary small mb-0"><%= t("organizations.form.upload_hint") %></p>
+      <%= form.file_field :logo, id: "organization_logo", class: "d-none",
+            accept: "image/png,image/jpeg,image/svg+xml" %>
+    </div>
+    <p class="text-success small fw-semibold mt-2 mb-0" id="organization-upload-filename"></p>
+  </div>
+
+  <%# Actions %>
+  <div class="d-flex justify-content-end gap-2 border-top pt-3 mt-4">
+    <%= link_to t("cancel"), cancel_path, class: "btn btn-outline-secondary" %>
+    <%= form.submit t("organizations.form.submit"), class: "btn primary-button" %>
+  </div>
+<% end %>

--- a/app/component/organization_form_component.rb
+++ b/app/component/organization_form_component.rb
@@ -23,6 +23,7 @@ class OrganizationFormComponent < ViewComponent::Base
         organizations_path
       end
     end
+
     def persisted_logo
       return unless organization.persisted?
       return unless organization.logo_attachment&.persisted?

--- a/app/component/organization_form_component.rb
+++ b/app/component/organization_form_component.rb
@@ -23,4 +23,10 @@ class OrganizationFormComponent < ViewComponent::Base
         organizations_path
       end
     end
+    def persisted_logo
+      return unless organization.persisted?
+      return unless organization.logo_attachment&.persisted?
+
+      organization.logo
+    end
 end

--- a/app/component/organization_form_component.rb
+++ b/app/component/organization_form_component.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class OrganizationFormComponent < ViewComponent::Base
+  def initialize(organization:)
+    super()
+    @organization = organization
+  end
+
+  private
+
+    attr_reader :organization
+
+    def existing_links
+      return [] unless organization.links.is_a?(Array)
+
+      organization.links.compact_blank
+    end
+
+    def cancel_path
+      if organization.persisted?
+        overview_organization_path(organization)
+      else
+        organizations_path
+      end
+    end
+end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -13,6 +13,7 @@ import ProjectsController from './projects_controller';
 import SearchBarController from './search_bar_controller';
 import SearchSortingController from './search_sorting_controller';
 import SearchFiltersController from './search_filters_controller';
+import OrganizationFormController from "./organization_form_controller";
 
 application.register('assignment', AssignmentController);
 application.register('contest', ContestController);
@@ -23,3 +24,4 @@ application.register('projects', ProjectsController);
 application.register('search-bar', SearchBarController);
 application.register('search-sorting', SearchSortingController);
 application.register('search-filters', SearchFiltersController);
+application.register("organization-form", OrganizationFormController);

--- a/app/javascript/controllers/organization_form_controller.js
+++ b/app/javascript/controllers/organization_form_controller.js
@@ -60,6 +60,15 @@ export default class extends Controller {
             }
         });
 
+        this.listen(this.linksContainer, 'change', (e) => {
+            if (e.target.tagName === 'INPUT' && e.target.type === 'url') {
+                const value = e.target.value.trim();
+                if (value && !/^https?:\/\//i.test(value)) {
+                    e.target.value = `https://${value}`;
+                }
+            }
+        });
+
         this.linksContainer.querySelectorAll('input[type="url"]').forEach((field) => {
             this.updateLinkIcon(field);
         });

--- a/app/javascript/controllers/organization_form_controller.js
+++ b/app/javascript/controllers/organization_form_controller.js
@@ -5,15 +5,28 @@ const MAX_LINKS = 5;
 
 export default class extends Controller {
     connect() {
+        this.listeners = [];
         this.setupCounters();
         this.setupLinks();
         this.setupLogo();
     }
 
+    disconnect() {
+        this.listeners.forEach(({ element, eventName, handler }) => {
+            element.removeEventListener(eventName, handler);
+        });
+        this.listeners = [];
+    }
+
+    listen(element, eventName, handler) {
+        element.addEventListener(eventName, handler);
+        this.listeners.push({ element, eventName, handler });
+    }
+
     setupCounters() {
         this.bindCounter('organization_name', 'org-name-counter', 50);
         this.bindCounter('org-description-input', 'org-description-counter', 160);
-        this.bindCounter('organization_location', 'org-location-counter', 30);
+        this.bindCounter('organization_location', 'org-location-counter', 50);
     }
 
     bindCounter(inputId, counterId, maxLen) {
@@ -26,7 +39,7 @@ export default class extends Controller {
             counter.classList.toggle('text-danger', remaining <= Math.floor(maxLen * 0.15));
         };
         update();
-        el.addEventListener('input', update);
+        this.listen(el, 'input', update);
     }
 
     setupLinks() {
@@ -41,7 +54,7 @@ export default class extends Controller {
             if (templateField) templateField.value = '';
         }
 
-        this.linksContainer.addEventListener('input', (e) => {
+        this.listen(this.linksContainer, 'input', (e) => {
             if (e.target.tagName === 'INPUT' && e.target.type === 'url') {
                 this.updateLinkIcon(e.target);
             }
@@ -53,7 +66,7 @@ export default class extends Controller {
 
         this.updateRemoveButtons();
 
-        this.addLinkBtn.addEventListener('click', () => {
+        this.listen(this.addLinkBtn, 'click', () => {
             const items = this.linksContainer.querySelectorAll('.organizations-link-item');
             if (items.length < MAX_LINKS && this.linkTemplate) {
                 const newItem = this.linkTemplate.cloneNode(true);
@@ -65,7 +78,7 @@ export default class extends Controller {
             }
         });
 
-        this.linksContainer.addEventListener('click', (e) => {
+        this.listen(this.linksContainer, 'click', (e) => {
             const removeBtn = e.target.closest('.organizations-remove-link-btn');
             if (removeBtn) {
                 removeBtn.closest('.organizations-link-item').remove();
@@ -114,24 +127,26 @@ export default class extends Controller {
         const zone = document.getElementById('organization-upload-zone');
         const input = document.getElementById('organization_logo');
         const label = document.getElementById('organization-upload-filename');
+
         if (input) {
-            input.addEventListener('change', function () {
+            this.listen(input, 'change', function () {
                 if (this.files && this.files[0]) label.textContent = this.files[0].name;
             });
         }
+
         if (zone) {
             ['dragover', 'dragenter'].forEach((evt) => {
-                zone.addEventListener(evt, (e) => {
+                this.listen(zone, evt, (e) => {
                     e.preventDefault();
                     zone.classList.add('org-upload-zone--active');
                 });
             });
             ['dragleave', 'drop'].forEach((evt) => {
-                zone.addEventListener(evt, () => {
+                this.listen(zone, evt, () => {
                     zone.classList.remove('org-upload-zone--active');
                 });
             });
-            zone.addEventListener('drop', (e) => {
+            this.listen(zone, 'drop', (e) => {
                 e.preventDefault();
                 if (e.dataTransfer.files && e.dataTransfer.files[0]) {
                     input.files = e.dataTransfer.files;

--- a/app/javascript/controllers/organization_form_controller.js
+++ b/app/javascript/controllers/organization_form_controller.js
@@ -1,0 +1,143 @@
+/* eslint-disable class-methods-use-this */
+import { Controller } from 'stimulus';
+
+const MAX_LINKS = 5;
+
+export default class extends Controller {
+    connect() {
+        this.setupCounters();
+        this.setupLinks();
+        this.setupLogo();
+    }
+
+    setupCounters() {
+        this.bindCounter('organization_name', 'org-name-counter', 50);
+        this.bindCounter('org-description-input', 'org-description-counter', 160);
+        this.bindCounter('organization_location', 'org-location-counter', 30);
+    }
+
+    bindCounter(inputId, counterId, maxLen) {
+        const el = document.getElementById(inputId);
+        const counter = document.getElementById(counterId);
+        if (!el || !counter) return;
+        const update = () => {
+            const remaining = maxLen - el.value.length;
+            counter.textContent = `${remaining} characters remaining`;
+            counter.classList.toggle('text-danger', remaining <= Math.floor(maxLen * 0.15));
+        };
+        update();
+        el.addEventListener('input', update);
+    }
+
+    setupLinks() {
+        this.linksContainer = document.getElementById('organizations-links-container');
+        this.addLinkBtn = document.getElementById('organizations-add-link-btn');
+        if (!this.linksContainer || !this.addLinkBtn) return;
+
+        const firstItem = this.linksContainer.querySelector('.organizations-link-item');
+        if (firstItem) {
+            this.linkTemplate = firstItem.cloneNode(true);
+            const templateField = this.linkTemplate.querySelector('input');
+            if (templateField) templateField.value = '';
+        }
+
+        this.linksContainer.addEventListener('input', (e) => {
+            if (e.target.tagName === 'INPUT' && e.target.type === 'url') {
+                this.updateLinkIcon(e.target);
+            }
+        });
+
+        this.linksContainer.querySelectorAll('input[type="url"]').forEach((field) => {
+            this.updateLinkIcon(field);
+        });
+
+        this.updateRemoveButtons();
+
+        this.addLinkBtn.addEventListener('click', () => {
+            const items = this.linksContainer.querySelectorAll('.organizations-link-item');
+            if (items.length < MAX_LINKS && this.linkTemplate) {
+                const newItem = this.linkTemplate.cloneNode(true);
+                const field = newItem.querySelector('input');
+                field.value = '';
+                this.linksContainer.appendChild(newItem);
+                this.updateRemoveButtons();
+                this.updateLinkIcon(field);
+            }
+        });
+
+        this.linksContainer.addEventListener('click', (e) => {
+            const removeBtn = e.target.closest('.organizations-remove-link-btn');
+            if (removeBtn) {
+                removeBtn.closest('.organizations-link-item').remove();
+                this.updateRemoveButtons();
+            }
+        });
+    }
+
+    updateRemoveButtons() {
+        const items = this.linksContainer.querySelectorAll('.organizations-link-item');
+        items.forEach((item) => {
+            const btn = item.querySelector('.organizations-remove-link-btn');
+            if (btn) btn.style.display = 'block';
+        });
+        this.addLinkBtn.style.display = items.length >= MAX_LINKS ? 'none' : 'inline-block';
+    }
+
+    updateLinkIcon(field) {
+        const item = field.closest('.organizations-link-item');
+        const img = item.querySelector('.organizations-input-icon');
+        if (!img) return;
+        const logos = this.linksContainer.dataset;
+        const urlString = field.value.trim();
+        if (!urlString) {
+            img.src = logos.logoDefault;
+            return;
+        }
+        let hostname = '';
+        try {
+            const parsed = new URL(urlString.startsWith('http') ? urlString : `https://${urlString}`);
+            hostname = parsed.hostname.toLowerCase().replace(/^www\./, '');
+        } catch (e) {
+            img.src = logos.logoDefault;
+            return;
+        }
+        const is = (host, domain) => host === domain || host.endsWith(`.${domain}`);
+        if (is(hostname, 'github.com')) img.src = logos.logoGithub;
+        else if (is(hostname, 'twitter.com') || is(hostname, 'x.com')) img.src = logos.logoX;
+        else if (is(hostname, 'linkedin.com')) img.src = logos.logoLinkedin;
+        else if (is(hostname, 'facebook.com')) img.src = logos.logoFacebook;
+        else if (is(hostname, 'youtube.com') || is(hostname, 'youtu.be')) img.src = logos.logoYoutube;
+        else img.src = logos.logoDefault;
+    }
+
+    setupLogo() {
+        const zone = document.getElementById('organization-upload-zone');
+        const input = document.getElementById('organization_logo');
+        const label = document.getElementById('organization-upload-filename');
+        if (input) {
+            input.addEventListener('change', function () {
+                if (this.files && this.files[0]) label.textContent = this.files[0].name;
+            });
+        }
+        if (zone) {
+            ['dragover', 'dragenter'].forEach((evt) => {
+                zone.addEventListener(evt, (e) => {
+                    e.preventDefault();
+                    zone.classList.add('org-upload-zone--active');
+                });
+            });
+            ['dragleave', 'drop'].forEach((evt) => {
+                zone.addEventListener(evt, () => {
+                    zone.classList.remove('org-upload-zone--active');
+                });
+            });
+            zone.addEventListener('drop', (e) => {
+                e.preventDefault();
+                if (e.dataTransfer.files && e.dataTransfer.files[0]) {
+                    input.files = e.dataTransfer.files;
+                    label.textContent = e.dataTransfer.files[0].name;
+                }
+            });
+        }
+    }
+}

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -19,6 +19,7 @@ class Organization < ApplicationRecord
   validates :name, presence: true, uniqueness: { case_sensitive: false }, length: { minimum: 2, maximum: 50 }
   validates :slug, presence: true, uniqueness: { case_sensitive: false }
   validates :location, length: { maximum: 50 }, allow_blank: true
+  validates :description, length: { maximum: 160 }, allow_blank: true
   validate :links_count_within_limit
   validate :links_must_be_valid_http_urls
   validate :logo_must_be_valid_image

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -21,6 +21,7 @@ class Organization < ApplicationRecord
   validates :location, length: { maximum: 50 }, allow_blank: true
   validate :links_count_within_limit
   validate :links_must_be_valid_http_urls
+  validate :logo_must_be_valid_image
 
   before_destroy :purge_logo
 
@@ -54,5 +55,14 @@ class Organization < ApplicationRecord
       return if links.blank?
 
       errors.add(:links, "cannot have more than #{MAX_LINKS} links") if links.size > MAX_LINKS
+    end
+
+    def logo_must_be_valid_image
+      return unless logo.attached?
+
+      acceptable_types = ["image/png", "image/jpeg", "image/svg+xml"]
+      errors.add(:logo, "must be a PNG, JPEG, or SVG image") unless acceptable_types.include?(logo.content_type)
+
+      errors.add(:logo, "must be smaller than 2 MB") if logo.byte_size > 2.megabytes
     end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -18,7 +18,7 @@ class Organization < ApplicationRecord
 
   validates :name, presence: true, uniqueness: { case_sensitive: false }, length: { minimum: 2, maximum: 50 }
   validates :slug, presence: true, uniqueness: { case_sensitive: false }
-  validates :location, length: { maximum: 100 }, allow_blank: true
+  validates :location, length: { maximum: 50 }, allow_blank: true
   validate :links_count_within_limit
   validate :links_must_be_valid_http_urls
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -48,21 +48,21 @@ class Organization < ApplicationRecord
       rescue URI::InvalidURIError
         false
       end
-      errors.add(:links, "must be valid http or https URLs") if invalid.any?
+      errors.add(:links, :invalid_urls) if invalid.any?
     end
 
     def links_count_within_limit
       return if links.blank?
 
-      errors.add(:links, "cannot have more than #{MAX_LINKS} links") if links.size > MAX_LINKS
+      errors.add(:links, :too_many, count: MAX_LINKS) if links.size > MAX_LINKS
     end
 
     def logo_must_be_valid_image
       return unless logo.attached?
 
       acceptable_types = ["image/png", "image/jpeg", "image/svg+xml"]
-      errors.add(:logo, "must be a PNG, JPEG, or SVG image") unless acceptable_types.include?(logo.content_type)
+      errors.add(:logo, :invalid_content_type) unless acceptable_types.include?(logo.content_type)
 
-      errors.add(:logo, "must be smaller than 2 MB") if logo.byte_size > 2.megabytes
+      errors.add(:logo, :file_size_exceeded) if logo.byte_size > 2.megabytes
     end
 end

--- a/app/views/organizations/new.html.erb
+++ b/app/views/organizations/new.html.erb
@@ -1,0 +1,8 @@
+<% content_for :title, t("organizations.new.page_title") %>
+<div class="org-new mx-auto text-body pt-4 px-3 pb-5">
+  <div class="mb-4">
+    <h1 class="org-new-heading fw-semibold mb-2 fs-4"><%= t("organizations.new.heading") %></h1>
+    <p class="text-secondary mb-0"><%= t("organizations.new.subheading") %></p>
+  </div>
+  <%= render(OrganizationFormComponent.new(organization: @organization)) %>
+</div>

--- a/config/locales/models/organizations/en.yml
+++ b/config/locales/models/organizations/en.yml
@@ -1,0 +1,12 @@
+en:
+  activerecord:
+    errors:
+      models:
+        organization:
+          attributes:
+            logo:
+              invalid_content_type: "must be a PNG, JPEG, or SVG image"
+              file_size_exceeded: "must not exceed 2 MB"
+            links:
+              invalid_urls: "must be valid http or https URLs"
+              too_many: "cannot have more than %{count} links"

--- a/config/locales/views/organizations/en.yml
+++ b/config/locales/views/organizations/en.yml
@@ -26,6 +26,42 @@ en:
       page_title: "Members - %{organization}"
     settings:
       page_title: "Settings - %{organization}"
+    form:
+      details_heading: "Organization Details"
+      details_subheading: "Basic information about your organization."
+      name_label: "Name"
+      name_hint: "The name of your organization."
+      name_placeholder: "e.g. Indian Institute Of Technology"
+      description_label: "Description"
+      description_hint: "A short description of your organization."
+      description_placeholder: "What is your organization about?"
+      location_label: "Location"
+      location_hint: "Where is your organization based?"
+      location_placeholder: "e.g. India, Delhi"
+      visibility_label: "Visibility"
+      visibility_hint: "Control who can view your organization."
+      visibility_private: "Private"
+      visibility_public: "Public"
+      links_label: "External Links"
+      links_hint: "Add up to 5 links to your organization's website or social profiles."
+      links_placeholder: "https://example.com"
+      add_link: "Add link"
+      remove_link: "Remove link"
+      logo_label: "Logo"
+      logo_hint: "Upload a square image for best results."
+      current_logo: "Current Logo"
+      current_logo_alt: "%{organization} logo"
+      replace_logo_hint: "Upload a new image below to replace"
+      remove_logo: "Remove current logo"
+      upload_click: "Click to upload"
+      upload_drag: "or drag and drop"
+      upload_hint: "PNG, JPG or SVG"
+      link_aria_label: "External link"
+      submit: "Create Organization"
+    new:
+      page_title: "Create Organization"
+      heading: "Create a new organization"
+      subheading: "Set up your organization to manage groups, assignments, and members."
   organization_members:
     create:
       success: "Member was successfully added."
@@ -36,4 +72,3 @@ en:
     leave:
       success: "You have successfully left the organization."
       not_a_member: "You are not a member of this organization."
-      

--- a/config/locales/views/organizations/en.yml
+++ b/config/locales/views/organizations/en.yml
@@ -58,6 +58,7 @@ en:
       upload_hint: "PNG, JPG or SVG"
       link_aria_label: "External link"
       submit: "Create Organization"
+      update: "Save changes"
     new:
       page_title: "Create Organization"
       heading: "Create a new organization"


### PR DESCRIPTION

Fixes #7738 

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -
Adds an organization creation page at /organizations/new. The form collects name, description, location, visibility (public/private), external links, and a logo. On submit, the organization is created and the creator is automatically added as an admin, then redirected to the new organization's overview.

Introduces a reusable OrganizationFormComponent (shared with the future settings/edit page) with client-side interactivity: character counters, live provider-logo detection for links, and drag-and-drop logo upload.

### Screenshots of the UI changes (If any) -



https://github.com/user-attachments/assets/c64c2e66-0375-4a09-8d8c-6243021e3609




---

## Code Understanding and AI Usage

**Did you use AI generated code (ChatGPT, Claude, Copilot, etc.) in any part of this PR? **
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The new and create controller actions already existed, but there was no page to actually create an organization, so I added the form.

I built the form as a reusable component rather than inline so the settings/edit page can reuse it later. form_with(model:) already handles POST vs PATCH depending on whether the org is new or existing, and I added a small cancel_path helper so Cancel goes to the org overview when editing or the orgs list when creating.

Creation happens inside a transaction that saves the org and adds the creator as an admin together, so an org is never left without an admin. The Stimulus controller handles the live stuff in the form  the character counters, the link icons that update as you type, and the drag-and-drop logo upload. For the link icons I match the domain with an endsWith check so real subdomains work but something like github.com.evil.com doesn't get treated as GitHub.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added organization creation and settings forms for details, visibility, external links, and logos.
- Added drag-and-drop logo uploads with previews, removal controls, accessible interactions, and filename feedback.
- Added dynamic social-link fields with provider-specific icons and support for up to five links.
- Added validation feedback, character counters, localized guidance, and creation-page content.

## Style
- Added responsive form styling, upload-zone states, icons, text wrapping, and fixed-size logo previews.

## Bug Fixes
- Reduced the maximum organization location length to 50 characters.
- Added logo validation for supported image formats and a 2 MB file-size limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->