### PR TITLE
feat(organizations): allow org admins to view groups in their org

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -111,7 +111,11 @@ class GroupsController < ApplicationController
     end
 
     def check_show_access
-      authorize @group, :show_access?
+      if @group.organization
+        authorize @group, :view?, policy_class: OrganizationGroupPolicy
+      else
+        authorize @group, :show_access?
+      end
     end
 
     def check_edit_access

--- a/app/policies/organization_group_policy.rb
+++ b/app/policies/organization_group_policy.rb
@@ -5,6 +5,10 @@ class OrganizationGroupPolicy < ApplicationPolicy
     org_admin? || assigned_mentor? || user.admin?
   end
 
+  def view?
+    org_admin? || assigned_mentor? || group_member? || user.admin?
+  end
+
   private
 
     def org_membership
@@ -21,5 +25,9 @@ class OrganizationGroupPolicy < ApplicationPolicy
       org_membership&.role == "mentor" &&
         (record.primary_mentor_id == user.id ||
          record.group_members.exists?(user_id: user.id, mentor: true))
+    end
+
+    def group_member?
+      record.group_members.exists?(user_id: user.id)
     end
 end


### PR DESCRIPTION
Fixes #7741

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -
Org group access is now aware of organization roles. Previously, group access was checked only by GroupPolicy#show_access?, which considers group-level membership (primary mentor, group members, site admin) but not org roles, so an org admin could edit/delete a group but not open it.

This adds a view? method to OrganizationGroupPolicy and routes org-owned groups through it for view access, mirroring how edit/delete already route through OrganizationGroupPolicy#manage?. Org admins can now view any group in their org; org mentors and members keep access only to groups they're assigned to or members of. Groups without an organization are unaffected and still use GroupPolicy#show_access?.

### Screenshots of the UI changes (If any) -
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI generated code (ChatGPT, Claude, Copilot, etc.) in any part of this PR? **
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The problem was that an org admin could manage (edit/delete) a group but couldn't open it, because entering a group used GroupPolicy#show_access?, which only checks group-level membership and doesn't know about org roles.

Instead of adding org logic into the shared GroupPolicy (which is also used by standalone groups), I added a view? method to OrganizationGroupPolicy and made the controller route org-owned groups to it, keeping non-org groups on the original policy. This matches the pattern already used for edit/delete, which route through OrganizationGroupPolicy#manage?. The view? rule allows org admins to view any group in the org, mentors only groups they're assigned to, and members only groups they belong to, while preserving existing group-member and site-admin access.

I kept this scoped to view access. Letting org admins manage group internals (members, mentors, assignments) is a bigger change that I'll do in a separate PR.


## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access to organization-associated groups for authorized viewers.
  * Organization administrators, assigned mentors, group members, and administrators can now view eligible group records.
  * Preserved existing access rules for other group types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->