### PR TITLE
fix(policy): permit org admins to view and manage groups in their organization (#7741)

### DIFF
--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -6,7 +6,7 @@ class GroupPolicy < ApplicationPolicy
   def initialize(user, group)
     @user = user
     @group = group
-    @admin_access = (group.primary_mentor_id == user.id) || user.admin?
+    @admin_access = (group.primary_mentor_id == user.id) || user.admin? || org_admin?
   end
 
   def show_access?
@@ -20,4 +20,12 @@ class GroupPolicy < ApplicationPolicy
   def mentor_access?
     @admin_access || @group.group_members.exists?(user_id: user.id, mentor: true)
   end
+
+  private
+
+    def org_admin?
+      return false unless group.organization_id.present?
+
+      group.organization.organization_members.exists?(user_id: user.id, role: :admin)
+    end
 end

--- a/spec/policies/group_policy_spec.rb
+++ b/spec/policies/group_policy_spec.rb
@@ -54,4 +54,20 @@ describe GroupPolicy do
     it { is_expected.not_to permit(:admin_access) }
     it { is_expected.not_to permit(:mentor_access) }
   end
+
+  context "when the user is an organization admin" do
+    before do
+      @organization = FactoryBot.create(:organization)
+      @org_admin = FactoryBot.create(:user)
+      FactoryBot.create(:organization_member, organization: @organization, user: @org_admin, role: :admin)
+      @group.update!(organization: @organization)
+    end
+
+    let(:user) { @org_admin }
+    let(:group) { @group }
+
+    it { is_expected.to permit(:show_access) }
+    it { is_expected.to permit(:admin_access) }
+    it { is_expected.to permit(:mentor_access) }
+  end
 end


### PR DESCRIPTION
### Summary of Changes

Fixes #7741 where organization admins were unable to view/open groups created within their organization unless they were assigned as the primary mentor or a group member.

#### Changes made:
- **`app/policies/group_policy.rb`**: Added `org_admin?` private helper method to check if the current user is an admin of the group's organization, and incorporated `org_admin?` into `@admin_access`.
- **`spec/policies/group_policy_spec.rb`**: Added policy spec test cases for organization admins verifying `show_access`, `admin_access`, and `mentor_access` permissions.

### Related Issue

- Fixes #7741

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organization administrators can now access groups associated with their organization.
  * Organization administrators can view, manage, and mentor within eligible groups.

* **Bug Fixes**
  * Corrected group access permissions for organization administrators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->