### PR TITLE
fix(simulator): route Report an Issue link to public Slack invite URL (#7750)

### DIFF
--- a/app/views/simulator/edit.html.erb
+++ b/app/views/simulator/edit.html.erb
@@ -753,7 +753,7 @@
         <%# TEMPORARY %>
         <center>
         Bug reporting from here will be back soon, until then help make CircuitVerse better by reporting simulator issues to us on Slack.
-        <br><br><a href="https://circuitverse-team.slack.com/archives/C010HK6TWQG" style="color: blue;">Click Here to report an issue</a><br><br>
+        <br><br><a href="<%= Rails.configuration.slack_url %>" target="_blank" rel="noopener" style="color: blue;">Click Here to report an issue</a><br><br>
         Thank you for your time.
         </center>
         <%# /TEMPORARY %>


### PR DESCRIPTION
### Summary of Changes

Fixes #7750 where the "Report an issue" panel in the simulator linked out to a private Slack workspace channel URL (`https://circuitverse-team.slack.com/archives/...`), causing anonymous and non-member users to land on a generic Slack sign-in wall.

#### Changes made:
- Updated `app/views/simulator/edit.html.erb` to use `Rails.configuration.slack_url` (`https://circuitverse.org/slack`) with `target="_blank" rel="noopener"` so users are properly directed to the public community Slack invite link.

### Related Issue

- Fixes #7750

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Issue-reporting links now use the configured destination, ensuring reports are sent to the correct support channel.
  * Improved external-link security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->