### PR TITLE
fix(controller): restrict LTI score passback to percent grading scale assignments (#7749)

### DIFF
--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -26,9 +26,9 @@ class GradesController < ApplicationController
       project = Project.find(grade_params[:project_id])
       assignment = Assignment.find(grade_params[:assignment_id])
 
-      # Only attempt LTI score submission if required parameters are present
-      if session[:lis_outcome_service_url].present? && project.lis_result_sourced_id.present?
-        score = grade.to_f / 100 # conversion to 0-0.100 scale as per IMS Global specification
+      # Only attempt LTI score submission if required parameters are present and assignment uses percent scale
+      if session[:lis_outcome_service_url].present? && project.lis_result_sourced_id.present? && assignment.percent_scale?
+        score = grade.to_f / 100 # conversion to 0-1.0 scale as per IMS Global specification
         LtiScoreSubmission.new(
           assignment: assignment,
           lis_result_sourced_id: project.lis_result_sourced_id,

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -50,6 +50,20 @@ describe GradesController, type: :request do
           expect(response.parsed_body["error"]).to eq("Grade is invalid")
         end
       end
+
+      context "when LTI integration is enabled" do
+        before do
+          Flipper.enable(:lms_integration)
+          @assignment_project.update!(lis_result_sourced_id: "sourced_id_123")
+        end
+
+        it "does not submit LTI score for letter grading scale" do
+          expect(LtiScoreSubmission).not_to receive(:new)
+
+          post grades_path, params: create_params,
+                            session: { is_lti: true, lis_outcome_service_url: "http://example.com/outcome" }
+        end
+      end
     end
 
     context "when a mentor is singed in" do


### PR DESCRIPTION
### Summary of Changes

Fixes #7749 where saving letter grades (e.g. `A`–`F`) on LTI-integrated assignments resulted in `grade.to_f / 100` evaluating to `0.0` and submitting `0%` scores to the LMS via LTI outcome passback.

#### Changes made:
- Updated `GradesController#create` to check `assignment.percent_scale?` before triggering `LtiScoreSubmission`.
- Added controller spec test cases in `spec/controllers/grades_controller_spec.rb` verifying LTI score submission is omitted for non-percent grading scale assignments.

### Related Issue

- Fixes #7749

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * LTI score submissions now occur only when required outcome details are available and the assignment uses a percentage grading scale.
  * Letter-grade submissions no longer initiate an LTI score submission when percentage-based scoring is not applicable.

* **Tests**
  * Added coverage to verify the updated LTI score submission behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->