### PR TITLE
feat(lti): add Lti::LineItem for gradebook columns

### DIFF
--- a/app/services/lti/line_item.rb
+++ b/app/services/lti/line_item.rb
@@ -15,7 +15,7 @@ module Lti
       def find_or_create(lineitems_url, access_token, resource_id:, label:, score_maximum:)
         existing(lineitems_url, access_token, resource_id) ||
           create(lineitems_url, access_token, resource_id, label, score_maximum)
-      rescue HTTP::Error, JSON::ParserError, KeyError => e
+      rescue HTTP::Error, JSON::ParserError => e
         raise Error, e.message
       end
 
@@ -23,7 +23,10 @@ module Lti
 
         def existing(url, token, resource_id)
           items = parse(client(token, CONTAINER_TYPE).get(url, params: { resource_id: resource_id }))
-          items.first["id"] if items.is_a?(Array) && items.any?
+          raise Error, "line item container was not a list" unless items.is_a?(Array)
+          return if items.empty?
+
+          item_url(items.first)
         end
 
         def create(url, token, resource_id, label, score_maximum)
@@ -31,7 +34,17 @@ module Lti
           response = client(token, ITEM_TYPE)
                      .headers("Content-Type" => ITEM_TYPE)
                      .post(url, body: body.to_json)
-          parse(response).fetch("id")
+          item_url(parse(response))
+        end
+
+        # A line item we cannot address is worse than none at all: returning nil
+        # here would fall through to create and add a second gradebook column
+        # for a resource the platform already holds one for.
+        def item_url(item)
+          id = item["id"] if item.is_a?(Hash)
+          raise Error, "line item carried no id" unless id.is_a?(String) && id.present?
+
+          id
         end
 
         def client(token, accept)

--- a/app/services/lti/line_item.rb
+++ b/app/services/lti/line_item.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Lti
+  class LineItem
+    SCOPE = "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem"
+    CONTAINER_TYPE = "application/vnd.ims.lis.v2.lineitemcontainer+json"
+    ITEM_TYPE = "application/vnd.ims.lis.v2.lineitem+json"
+    TIMEOUT = 5
+
+    class Error < StandardError; end
+
+    class << self
+      # Returns the URL of the gradebook column for this resource, creating one
+      # only when the platform does not already hold it.
+      def find_or_create(lineitems_url, access_token, resource_id:, label:, score_maximum:)
+        existing(lineitems_url, access_token, resource_id) ||
+          create(lineitems_url, access_token, resource_id, label, score_maximum)
+      rescue HTTP::Error, JSON::ParserError, KeyError => e
+        raise Error, e.message
+      end
+
+      private
+
+        def existing(url, token, resource_id)
+          items = parse(client(token, CONTAINER_TYPE).get(url, params: { resource_id: resource_id }))
+          items.first["id"] if items.is_a?(Array) && items.any?
+        end
+
+        def create(url, token, resource_id, label, score_maximum)
+          body = { scoreMaximum: score_maximum, label: label, resourceId: resource_id }
+          response = client(token, ITEM_TYPE)
+                     .headers("Content-Type" => ITEM_TYPE)
+                     .post(url, body: body.to_json)
+          parse(response).fetch("id")
+        end
+
+        def client(token, accept)
+          HTTP.timeout(TIMEOUT).auth("Bearer #{token}").headers("Accept" => accept)
+        end
+
+        def parse(response)
+          raise Error, "line item request failed: #{response.status}" unless response.status.success?
+
+          JSON.parse(response.body.to_s)
+        end
+    end
+  end
+end

--- a/spec/services/lti/line_item_spec.rb
+++ b/spec/services/lti/line_item_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Lti::LineItem do
         expect { find_or_create }.to raise_error(described_class::Error)
       end
 
-      it "raises when the created line item's url is not a string" do
+      it "raises when the created line item id is not a string" do
         stub_http(get_body: [], post_body: { id: { href: item_url } })
         expect { find_or_create }.to raise_error(described_class::Error, /no id/)
       end

--- a/spec/services/lti/line_item_spec.rb
+++ b/spec/services/lti/line_item_spec.rb
@@ -87,6 +87,32 @@ RSpec.describe Lti::LineItem do
         expect { find_or_create }.to raise_error(described_class::Error)
       end
 
+      it "raises when the created line item's url is not a string" do
+        stub_http(get_body: [], post_body: { id: { href: item_url } })
+        expect { find_or_create }.to raise_error(described_class::Error, /no id/)
+      end
+
+      it "raises rather than duplicating the column when an existing item has no id" do
+        client = stub_http(get_body: [{ label: "Half Adder" }])
+
+        expect { find_or_create }.to raise_error(described_class::Error, /no id/)
+        expect(client).not_to have_received(:post)
+      end
+
+      it "raises rather than duplicating the column when an existing id is blank" do
+        client = stub_http(get_body: [{ id: "" }])
+
+        expect { find_or_create }.to raise_error(described_class::Error, /no id/)
+        expect(client).not_to have_received(:post)
+      end
+
+      it "raises when the container is not a list" do
+        client = stub_http(get_body: { id: item_url })
+
+        expect { find_or_create }.to raise_error(described_class::Error, /not a list/)
+        expect(client).not_to have_received(:post)
+      end
+
       it "raises when the response is not json" do
         html = instance_double(HTTP::Response, body: "<html>",
                                                status: instance_double(HTTP::Response::Status,

--- a/spec/services/lti/line_item_spec.rb
+++ b/spec/services/lti/line_item_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Lti::LineItem do
+  let(:lineitems_url) { "https://canvas.example.com/api/lti/courses/1/line_items" }
+  let(:token)         { "tok-1" }
+  let(:item_url)      { "#{lineitems_url}/42" }
+  let(:requests)      { [] }
+
+  def stub_http(get_body:, post_body: { id: item_url }, get_ok: true, post_ok: true, get_status: 200)
+    client = instance_double(HTTP::Client)
+    allow(HTTP).to receive(:timeout).and_return(client)
+    allow(client).to receive_messages(auth: client, headers: client)
+
+    allow(client).to receive(:get) do |url, options|
+      requests << [:get, url, options]
+      response(get_body, get_ok, get_status)
+    end
+    allow(client).to receive(:post) do |url, options|
+      requests << [:post, url, options]
+      response(post_body, post_ok, 201)
+    end
+    client
+  end
+
+  def response(body, success, status)
+    instance_double(HTTP::Response, body: body.to_json,
+                                    status: instance_double(HTTP::Response::Status,
+                                                            success?: success, to_s: status.to_s))
+  end
+
+  def find_or_create
+    described_class.find_or_create(lineitems_url, token,
+                                   resource_id: "assignment-7", label: "Half Adder",
+                                   score_maximum: 10)
+  end
+
+  describe ".find_or_create" do
+    context "when the platform already holds a line item for the resource" do
+      it "returns the existing column and creates nothing" do
+        client = stub_http(get_body: [{ id: item_url, label: "Half Adder" }])
+
+        expect(find_or_create).to eq(item_url)
+        expect(client).not_to have_received(:post)
+      end
+
+      it "filters the lookup by resource_id" do
+        stub_http(get_body: [{ id: item_url }])
+        find_or_create
+
+        expect(requests.first).to match([:get, lineitems_url, hash_including(
+          params: { resource_id: "assignment-7" }
+        )])
+      end
+    end
+
+    context "when the platform holds no line item yet" do
+      it "creates one and returns its url" do
+        stub_http(get_body: [])
+        expect(find_or_create).to eq(item_url)
+      end
+
+      it "posts the label, maximum score and resource id" do
+        stub_http(get_body: [])
+        find_or_create
+
+        posted = JSON.parse(requests.last[2][:body])
+        expect(posted).to eq("scoreMaximum" => 10, "label" => "Half Adder",
+                             "resourceId" => "assignment-7")
+      end
+    end
+
+    context "when the platform rejects the request" do
+      it "raises when the lookup fails" do
+        stub_http(get_body: {}, get_ok: false, get_status: 403)
+        expect { find_or_create }.to raise_error(described_class::Error, /403/)
+      end
+
+      it "raises when creation fails" do
+        stub_http(get_body: [], post_body: {}, post_ok: false)
+        expect { find_or_create }.to raise_error(described_class::Error)
+      end
+
+      it "raises when the created line item carries no url" do
+        stub_http(get_body: [], post_body: { label: "Half Adder" })
+        expect { find_or_create }.to raise_error(described_class::Error)
+      end
+
+      it "raises when the response is not json" do
+        html = instance_double(HTTP::Response, body: "<html>",
+                                               status: instance_double(HTTP::Response::Status,
+                                                                       success?: true))
+        client = instance_double(HTTP::Client)
+        allow(HTTP).to receive(:timeout).and_return(client)
+        allow(client).to receive_messages(auth: client, headers: client, get: html)
+
+        expect { find_or_create }.to raise_error(described_class::Error)
+      end
+
+      it "raises when the platform is unreachable" do
+        client = instance_double(HTTP::Client)
+        allow(HTTP).to receive(:timeout).and_return(client)
+        allow(client).to receive_messages(auth: client, headers: client)
+        allow(client).to receive(:get).and_raise(HTTP::ConnectionError, "connection refused")
+
+        expect { find_or_create }.to raise_error(described_class::Error, /refused/)
+      end
+    end
+  end
+end


### PR DESCRIPTION

Fixes part of #7407

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -

### Screenshots of the UI changes (If any) -
none
---

## Code Understanding and AI Usage

**Did you use AI generated code (ChatGPT, Claude, Copilot, etc.) in any part of this PR? **
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Describe in your own words:
- What problem does your code solve?
Currently  a score cant be posted directly it has to target a line item which is the platform's object for one gradebook column, identified by a URL. Before CircuitVerse can pass back a grade, it needs that URL
this can lead to duplication at times, when a new line item on every grade submission doesn't duplicated it just creates another column each time. 

- What alternative approaches did you consider?
Always POST and ignore duplicates: Store the line item URL locally after creating it once, and reuse it without asking the platform Simple but creates the same issue. When an instructor deletes the column in Canvas, and every subsequent score POST 404 with no way to recover
Fetch all line items and filter client-side by label:The labels aren't unique and it means paging through the whole container just to find one row.

- Why did you choose this specific implementation?
find_or_create asks the platform first filtered by resource_id, and only posts if nothing comes back ,thus making repeated grading idempotent without storing any state locally.
Any failure raises a single Lti::LineItem::Error, so callers rescue one type instead of four.
---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for finding or creating LTI gradebook line items.
  * Configures line items with scoring details and returns their usable URL.

* **Bug Fixes**
  * Provides clear error handling for failed requests, invalid responses, connection issues, and incomplete data.

* **Tests**
  * Added comprehensive coverage for existing-item lookup, item creation, successful responses, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->