### PR TITLE
feat(lti): add the deep linking content picker

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -398,7 +398,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
-    json (2.20.0)
+    json (2.21.2)
     json-jwt (1.17.1)
       activesupport (>= 4.2)
       aes_key_wrap
@@ -406,8 +406,6 @@ GEM
       bindata
       faraday (~> 2.0)
       faraday-follow_redirects
-    json (2.21.1)
-    json (2.21.2)
     json-schema (6.2.0)
       addressable (~> 2.8)
       bigdecimal (>= 3.1, < 5)

--- a/app/controllers/lti_controller.rb
+++ b/app/controllers/lti_controller.rb
@@ -4,8 +4,18 @@ class LtiController < ApplicationController
   skip_before_action :verify_authenticity_token, only: :launch # for lti integration
   before_action :set_group_and_assignment, only: %i[launch]
   before_action :set_lti_params, only: %i[launch]
-  before_action :verify_lti_advantage_enabled, only: %i[jwks tool_config]
+  before_action :verify_lti_advantage_enabled, only: %i[jwks tool_config deep_link]
+  before_action :authenticate_user!, only: %i[deep_link]
   after_action :allow_iframe_lti, only: %i[launch]
+
+  PICKER_LIMIT = 50
+
+  def deep_link
+    @projects = current_user.projects.order(updated_at: :desc).limit(PICKER_LIMIT)
+    @assignments = Assignment.joins(:group)
+                             .where(groups: { primary_mentor_id: current_user.id })
+                             .limit(PICKER_LIMIT)
+  end
 
   def jwks
     render json: { keys: [Lti::KeyManager.public_jwk] }

--- a/app/controllers/lti_controller.rb
+++ b/app/controllers/lti_controller.rb
@@ -15,6 +15,8 @@ class LtiController < ApplicationController
     @assignments = Assignment.joins(:group)
                              .where(groups: { primary_mentor_id: current_user.id })
                              .reorder(updated_at: :desc).limit(PICKER_LIMIT)
+    @templates = Project.joins(:featured_circuit).where.not(author: current_user)
+                        .order(updated_at: :desc).limit(PICKER_LIMIT)
   end
 
   def jwks

--- a/app/controllers/lti_controller.rb
+++ b/app/controllers/lti_controller.rb
@@ -14,7 +14,7 @@ class LtiController < ApplicationController
     @projects = current_user.projects.order(updated_at: :desc).limit(PICKER_LIMIT)
     @assignments = Assignment.joins(:group)
                              .where(groups: { primary_mentor_id: current_user.id })
-                             .limit(PICKER_LIMIT)
+                             .reorder(updated_at: :desc).limit(PICKER_LIMIT)
   end
 
   def jwks

--- a/app/views/lti/deep_link.html.erb
+++ b/app/views/lti/deep_link.html.erb
@@ -30,6 +30,18 @@
       <p><%= t("deep_link.no_assignments") %></p>
     <% end %>
 
+    <h3><%= t("deep_link.templates") %></h3>
+    <% if @templates.any? %>
+      <% @templates.each do |template| %>
+        <div class="form-check">
+          <%= radio_button_tag :content, "project:#{template.id}", false, class: "form-check-input" %>
+          <%= label_tag "content_project:#{template.id}", template.name, class: "form-check-label" %>
+        </div>
+      <% end %>
+    <% else %>
+      <p><%= t("deep_link.no_templates") %></p>
+    <% end %>
+
     <%= form.submit t("deep_link.embed"), class: "btn primary-button mt-3" %>
   <% end %>
 </div>

--- a/app/views/lti/deep_link.html.erb
+++ b/app/views/lti/deep_link.html.erb
@@ -42,6 +42,9 @@
       <p><%= t("deep_link.no_templates") %></p>
     <% end %>
 
-    <%= form.submit t("deep_link.embed"), class: "btn primary-button mt-3" %>
+    <%# The response endpoint that receives this selection lands in a follow-up
+        PR; until it is routed there is nowhere for the form to post. %>
+    <%= form.submit t("deep_link.embed"), class: "btn primary-button mt-3", disabled: true %>
+    <p class="mt-2"><%= t("deep_link.embed_unavailable") %></p>
   <% end %>
 </div>

--- a/app/views/lti/deep_link.html.erb
+++ b/app/views/lti/deep_link.html.erb
@@ -6,7 +6,7 @@
   <%= form_with url: deep_link_path, method: :post do |form| %>
     <%= hidden_field_tag :settings, params[:settings] %>
 
-    <h4><%= t("deep_link.circuits") %></h4>
+    <h3><%= t("deep_link.circuits") %></h3>
     <% if @projects.any? %>
       <% @projects.each do |project| %>
         <div class="form-check">
@@ -18,7 +18,7 @@
       <p><%= t("deep_link.no_circuits") %></p>
     <% end %>
 
-    <h4><%= t("deep_link.assignments") %></h4>
+    <h3><%= t("deep_link.assignments") %></h3>
     <% if @assignments.any? %>
       <% @assignments.each do |assignment| %>
         <div class="form-check">

--- a/app/views/lti/deep_link.html.erb
+++ b/app/views/lti/deep_link.html.erb
@@ -1,0 +1,35 @@
+<% content_for :title, t("deep_link.title") %>
+<div class="container">
+  <h2 class="main-heading"><%= t("deep_link.title") %></h2>
+  <p class="main-description"><%= t("deep_link.description") %></p>
+
+  <%= form_with url: deep_link_path, method: :post do |form| %>
+    <%= hidden_field_tag :settings, params[:settings] %>
+
+    <h4><%= t("deep_link.circuits") %></h4>
+    <% if @projects.any? %>
+      <% @projects.each do |project| %>
+        <div class="form-check">
+          <%= radio_button_tag :content, "project:#{project.id}", false, class: "form-check-input" %>
+          <%= label_tag "content_project:#{project.id}", project.name, class: "form-check-label" %>
+        </div>
+      <% end %>
+    <% else %>
+      <p><%= t("deep_link.no_circuits") %></p>
+    <% end %>
+
+    <h4><%= t("deep_link.assignments") %></h4>
+    <% if @assignments.any? %>
+      <% @assignments.each do |assignment| %>
+        <div class="form-check">
+          <%= radio_button_tag :content, "assignment:#{assignment.id}", false, class: "form-check-input" %>
+          <%= label_tag "content_assignment:#{assignment.id}", assignment.name, class: "form-check-label" %>
+        </div>
+      <% end %>
+    <% else %>
+      <p><%= t("deep_link.no_assignments") %></p>
+    <% end %>
+
+    <%= form.submit t("deep_link.embed"), class: "btn primary-button mt-3" %>
+  <% end %>
+</div>

--- a/config/locales/views/lti/en.yml
+++ b/config/locales/views/lti/en.yml
@@ -13,6 +13,7 @@ en:
     no_templates: "No featured circuits are available yet."
     no_assignments: "You are not mentoring any assignments yet."
     embed: "Embed"
+    embed_unavailable: "Embedding becomes available once the response step is enabled."
   open_incv:
     notice_wait_in_open_incv: "Please wait while we open this assignment in CircuitVerse..."
     notice_redirection_error: "If it doesn't work, please click the button below."

--- a/config/locales/views/lti/en.yml
+++ b/config/locales/views/lti/en.yml
@@ -3,6 +3,14 @@ en:
     title: "CircuitVerse - LTI Error"
     main-heading: "Content not available"
     main-description: "The content you are requesting is not available at this moment, or you are not authorized to access the content."
+  deep_link:
+    title: "Add CircuitVerse content"
+    description: "Choose what to embed in your course."
+    circuits: "Circuits"
+    assignments: "Assignments"
+    no_circuits: "You have no circuits yet."
+    no_assignments: "You are not mentoring any assignments yet."
+    embed: "Embed"
   open_incv:
     notice_wait_in_open_incv: "Please wait while we open this assignment in CircuitVerse..."
     notice_redirection_error: "If it doesn't work, please click the button below."

--- a/config/locales/views/lti/en.yml
+++ b/config/locales/views/lti/en.yml
@@ -8,7 +8,9 @@ en:
     description: "Choose what to embed in your course."
     circuits: "Circuits"
     assignments: "Assignments"
+    templates: "Templates"
     no_circuits: "You have no circuits yet."
+    no_templates: "No featured circuits are available yet."
     no_assignments: "You are not mentoring any assignments yet."
     embed: "Embed"
   open_incv:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -146,6 +146,7 @@ Rails.application.routes.draw do
     match 'launch', to: 'lti#launch', via: [:get, :post]
     get 'jwks', to: 'lti#jwks'
     get 'tool_config', to: 'lti#tool_config'
+    get 'deep_link', to: 'lti#deep_link'
   end
 
   mount Commontator::Engine => "/commontator"

--- a/spec/requests/lti_spec.rb
+++ b/spec/requests/lti_spec.rb
@@ -223,6 +223,18 @@ describe LtiController, type: :request do
       expect(response.body).to include("Week 1 Lab", "assignment:#{assignment.id}")
     end
 
+    it "offers the most recently updated assignments first" do
+      group = FactoryBot.create(:group, primary_mentor: instructor)
+      FactoryBot.create(:assignment, group: group, name: "Older", deadline: 1.day.from_now,
+                                     updated_at: 2.days.ago)
+      FactoryBot.create(:assignment, group: group, name: "Newer", deadline: 9.days.from_now,
+                                     updated_at: 1.minute.ago)
+      sign_in instructor
+      get "/lti/deep_link", params: { settings: settings }
+
+      expect(response.body.index("Newer")).to be < response.body.index("Older")
+    end
+
     it "does not offer another author's circuits" do
       FactoryBot.create(:project, author: FactoryBot.create(:user), name: "Someone Elses")
       sign_in instructor

--- a/spec/requests/lti_spec.rb
+++ b/spec/requests/lti_spec.rb
@@ -184,4 +184,67 @@ describe LtiController, type: :request do
       end
     end
   end
+
+  describe "LTI 1.3 deep linking picker" do
+    let(:instructor) { FactoryBot.create(:user) }
+    let(:settings) { "signed-deep-linking-settings" }
+
+    before { Flipper.enable(:lti_advantage) }
+
+    after { Flipper.disable(:lti_advantage) }
+
+    it "returns not found when the flag is disabled" do
+      Flipper.disable(:lti_advantage)
+      sign_in instructor
+      get "/lti/deep_link", params: { settings: settings }
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "sends an anonymous instructor to sign in" do
+      get "/lti/deep_link", params: { settings: settings }
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "lists the instructor's own circuits" do
+      project = FactoryBot.create(:project, author: instructor, name: "Half Adder")
+      sign_in instructor
+      get "/lti/deep_link", params: { settings: settings }
+
+      expect(response.body).to include("Half Adder", "project:#{project.id}")
+    end
+
+    it "lists assignments the instructor mentors" do
+      group = FactoryBot.create(:group, primary_mentor: instructor)
+      assignment = FactoryBot.create(:assignment, group: group, name: "Week 1 Lab")
+      sign_in instructor
+      get "/lti/deep_link", params: { settings: settings }
+
+      expect(response.body).to include("Week 1 Lab", "assignment:#{assignment.id}")
+    end
+
+    it "does not offer another author's circuits" do
+      FactoryBot.create(:project, author: FactoryBot.create(:user), name: "Someone Elses")
+      sign_in instructor
+      get "/lti/deep_link", params: { settings: settings }
+
+      expect(response.body).not_to include("Someone Elses")
+    end
+
+    it "does not offer assignments from groups the instructor does not mentor" do
+      other_group = FactoryBot.create(:group, primary_mentor: FactoryBot.create(:user))
+      FactoryBot.create(:assignment, group: other_group, name: "Not Mine")
+      sign_in instructor
+      get "/lti/deep_link", params: { settings: settings }
+
+      expect(response.body).not_to include("Not Mine")
+    end
+
+    it "carries the settings through to the submission" do
+      sign_in instructor
+      get "/lti/deep_link", params: { settings: settings }
+
+      expect(response.body).to include(settings)
+    end
+  end
 end

--- a/spec/requests/lti_spec.rb
+++ b/spec/requests/lti_spec.rb
@@ -235,6 +235,31 @@ describe LtiController, type: :request do
       expect(response.body.index("Newer")).to be < response.body.index("Older")
     end
 
+    it "offers featured circuits as templates" do
+      featured = FactoryBot.create(:featured_circuit)
+      sign_in instructor
+      get "/lti/deep_link", params: { settings: settings }
+
+      expect(response.body).to include(featured.project.name, "project:#{featured.project.id}")
+    end
+
+    it "does not offer an unfeatured public circuit as a template" do
+      FactoryBot.create(:project, :public, author: FactoryBot.create(:user), name: "Not Featured")
+      sign_in instructor
+      get "/lti/deep_link", params: { settings: settings }
+
+      expect(response.body).not_to include("Not Featured")
+    end
+
+    it "does not repeat the instructor's own featured circuit under templates" do
+      own = FactoryBot.create(:project, :public, author: instructor, name: "My Featured")
+      FactoryBot.create(:featured_circuit, project: own)
+      sign_in instructor
+      get "/lti/deep_link", params: { settings: settings }
+
+      expect(response.body.scan(%(value="project:#{own.id}")).size).to eq(1)
+    end
+
     it "does not offer another author's circuits" do
       FactoryBot.create(:project, author: FactoryBot.create(:user), name: "Someone Elses")
       sign_in instructor

--- a/spec/requests/lti_spec.rb
+++ b/spec/requests/lti_spec.rb
@@ -277,6 +277,13 @@ describe LtiController, type: :request do
       expect(response.body).not_to include("Not Mine")
     end
 
+    it "does not offer a submit while the response endpoint is unrouted" do
+      sign_in instructor
+      get "/lti/deep_link", params: { settings: settings }
+
+      expect(response.body).to match(/name="commit"[^>]*disabled/)
+    end
+
     it "carries the settings through to the submission" do
       sign_in instructor
       get "/lti/deep_link", params: { settings: settings }


### PR DESCRIPTION
Fixes part of #7408

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -

### Screenshots of the UI changes (If any) -
<img width="1500" height="875" alt="Screenshot 2026-08-11 at 3 31 47 PM" src="https://github.com/user-attachments/assets/a8d6cd2c-2043-4681-be3d-ad47bce550e0" />


This  demonstrates :
- The lti flag is on otherwise the page would display 404
- Both content types are offered including Circuits and Assignments as separate sections
- The listings are created from the signed in user's own data
---

## Code Understanding and AI Usage

**Did you use AI generated code (ChatGPT, Claude, Copilot, etc.) in any part of this PR? **
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

- What problem does your code solve?
Deep linking is the process where an instructor embeds a specific CircuitVerse content into a course like. a circuit or assignment rather than dropping in a link to the tool. When a platform sends a deep linking request, the tool has to show the instructor something to choose from. This is what this pr does

- What alternative approaches did you consider?
Build it as a ViewComponent: this is used in other places in Circuitverse but this is a single-purpose page with nothing to reuse yet so a component would add a class, template, and preview for no current benefit
Offer all public circuits with search: An instructor might want to embed a circuit from the library rather than their own work. I did not go with that because majorly the instructor would want their own circuits or assignments

- Why did you choose this specific implementation?
It displays exactly all the circuits and assignments created by the signed in user as a single option radio button to choose from all managed as long as the lti flag is kept on and verified with specs

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added LTI deep-linking support for selecting and embedding circuits, assignments, and featured templates.
  - Added a picker displaying recently updated circuits and mentor-associated assignments.
  - Added localized instructions, selection controls, empty-state messages, and preserved configuration settings.
  - Added authentication and feature-access controls for the picker.

- **Bug Fixes**
  - Restricted displayed resources to authorized content and prevented duplicate selections.
  - Added ordering by recent updates for relevant content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->