### PR TITLE
fix(api): rescue ActiveRecord::RecordNotUnique on thread subscriptions (#7770)

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -40,6 +40,10 @@ class Api::V1::BaseController < ActionController::API
     api_error(status: 422, errors: "resource invalid!")
   end
 
+  rescue_from ActiveRecord::RecordNotUnique do
+    api_error(status: 409, errors: "resource already exists")
+  end
+
   rescue_from Commontator::SecurityTransgression do
     api_error(status: 403, errors: "not authorized for this action")
   end

--- a/app/controllers/api/v1/comments_controller.rb
+++ b/app/controllers/api/v1/comments_controller.rb
@@ -18,7 +18,11 @@ class Api::V1::CommentsController < Api::V1::BaseController
   def create
     if @comment.save
       sub = @commontator_thread.config.thread_subscription.to_sym
-      @commontator_thread.subscribe(current_user) if %i[a b].include? sub
+      begin
+        @commontator_thread.subscribe(current_user) if %i[a b].include? sub
+      rescue ActiveRecord::RecordNotUnique
+        # ignore duplicate subscription from concurrent request
+      end
       Commontator::Subscription.comment_created(@comment)
       render json: Api::V1::CommentSerializer.new(@comment, @options), status: :created
     else

--- a/app/controllers/api/v1/threads_controller.rb
+++ b/app/controllers/api/v1/threads_controller.rb
@@ -31,6 +31,8 @@ class Api::V1::ThreadsController < Api::V1::BaseController
     else
       api_error(status: 409, errors: "thread already subscribed")
     end
+  rescue ActiveRecord::RecordNotUnique
+    api_error(status: 409, errors: "thread already subscribed")
   end
 
   # PUT /api/v1/threads/:id/unsubscribe

--- a/spec/requests/api/v1/threads_controller/subscribe_spec.rb
+++ b/spec/requests/api/v1/threads_controller/subscribe_spec.rb
@@ -42,5 +42,19 @@ RSpec.describe Api::V1::ThreadsController, "#subscribe", type: :request do
         expect(response.parsed_body["message"]).to eq("thread subscribed")
       end
     end
+
+    context "when a duplicate subscription race condition occurs" do
+      before do
+        allow_any_instance_of(Commontator::Thread).to receive(:subscribe).and_raise(ActiveRecord::RecordNotUnique)
+        token = get_auth_token(user)
+        put "/api/v1/threads/#{project.commontator_thread.id}/subscribe",
+            headers: { Authorization: "Token #{token}" }, as: :json
+      end
+
+      it "returns status conflict & 'thread already subscribed' error" do
+        expect(response).to have_http_status(:conflict)
+        expect(response.parsed_body).to have_jsonapi_error("thread already subscribed")
+      end
+    end
   end
 end


### PR DESCRIPTION
### Summary of Changes

Fixes Sentry exception `ActiveRecord::RecordNotUnique` (`index_commontator_subscriptions_on_s_id_and_s_type_and_t_id`) triggered when duplicate thread subscription requests occur concurrently or during automatic comment subscription.

#### Changes made:
- **`app/controllers/api/v1/base_controller.rb`**: Added `rescue_from ActiveRecord::RecordNotUnique` returning HTTP 409 Conflict (`resource already exists`).
- **`app/controllers/api/v1/comments_controller.rb`**: Wrapped `commontator_thread.subscribe(current_user)` in a `rescue ActiveRecord::RecordNotUnique` block on comment creation to safely ignore duplicate auto-subscriptions.
- **`app/controllers/api/v1/threads_controller.rb`**: Rescued `ActiveRecord::RecordNotUnique` in `subscribe` action returning HTTP 409 Conflict error.
- **`spec/requests/api/v1/threads_controller/subscribe_spec.rb`**: Added request spec test case for duplicate subscription race conditions.

### Related Issue

- Fixes #7770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of duplicate subscriptions during concurrent requests.
  * APIs now return clear conflict responses when a resource or thread already exists.
  * Comment creation no longer fails when a duplicate subscription occurs.

* **Tests**
  * Added coverage for duplicate thread subscription conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->