### PR TITLE
feat(lti): add Lti::Membership to read a course roster

### DIFF
--- a/app/services/lti/membership.rb
+++ b/app/services/lti/membership.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Lti
+  class Membership
+    SCOPE = "https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly"
+    MEDIA_TYPE = "application/vnd.ims.lti-nrps.v2.membershipcontainer+json"
+    LEARNER = "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner"
+    INSTRUCTOR = "http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor"
+    TIMEOUT = 5
+    MAX_PAGES = 50
+
+    class Error < StandardError; end
+
+    class << self
+      # Returns every member the platform reports, inactive ones included, since
+      # a roster sync has to see who left as well as who is there.
+      def fetch(memberships_url, access_token)
+        members = []
+        url = memberships_url
+
+        MAX_PAGES.times do
+          response = request(url, access_token)
+          members.concat(Array(parse(response)["members"]))
+          url = next_page(response)
+          break if url.blank?
+        end
+
+        members
+      rescue HTTP::Error, JSON::ParserError => e
+        raise Error, e.message
+      end
+
+      private
+
+        def request(url, token)
+          HTTP.timeout(TIMEOUT).auth("Bearer #{token}").headers("Accept" => MEDIA_TYPE).get(url)
+        end
+
+        def parse(response)
+          raise Error, "membership request failed: #{response.status}" unless response.status.success?
+
+          JSON.parse(response.body.to_s)
+        end
+
+        def next_page(response)
+          response.headers["Link"].to_s[/<([^>]+)>\s*;\s*rel="next"/, 1]
+        end
+    end
+  end
+end

--- a/app/services/lti/membership.rb
+++ b/app/services/lti/membership.rb
@@ -20,10 +20,11 @@ module Lti
 
         MAX_PAGES.times do
           response = request(url, access_token)
-          members.concat(Array(parse(response)["members"]))
-          url = next_page(response)
+          members.concat(page_members(parse(response)))
+          url = next_page(response, url)
           break if url.blank?
         end
+        raise Error, "roster did not end within #{MAX_PAGES} pages" if url.present?
 
         members
       rescue HTTP::Error, JSON::ParserError => e
@@ -42,8 +43,34 @@ module Lti
           JSON.parse(response.body.to_s)
         end
 
-        def next_page(response)
-          response.headers["Link"].to_s[/<([^>]+)>\s*;\s*rel="next"/, 1]
+        # An empty roster is "members": []. A page without the list is a broken
+        # response, and treating it as empty would tell a full-replace sync that
+        # the whole class has left.
+        def page_members(payload)
+          members = payload["members"] if payload.is_a?(Hash)
+          raise Error, "roster page carried no members list" unless members.is_a?(Array)
+
+          members
+        end
+
+        # RFC 8288 allows the relation as a bare token or a quoted string, more
+        # than one relation per link, other parameters alongside it, and a
+        # relative target that has to be resolved against the page it came from.
+        def next_page(response, current_url)
+          target = link_entries(response).find { |_target, params| relations(params).include?("next") }&.first
+          return if target.blank?
+
+          URI.join(current_url, target).to_s
+        rescue URI::InvalidURIError
+          nil
+        end
+
+        def link_entries(response)
+          response.headers["Link"].to_s.scan(/<([^>]*)>((?:\s*;[^,<]*)*)/)
+        end
+
+        def relations(params)
+          params[/;\s*rel\s*=\s*("[^"]*"|'[^']*'|[^;,\s]*)/i, 1].to_s.delete(%q("')).downcase.split
         end
     end
   end

--- a/app/services/lti/membership.rb
+++ b/app/services/lti/membership.rb
@@ -21,7 +21,7 @@ module Lti
         MAX_PAGES.times do
           response = request(url, access_token)
           members.concat(page_members(parse(response)))
-          url = next_page(response, url)
+          url = next_page(response, url, memberships_url)
           break if url.blank?
         end
         raise Error, "roster did not end within #{MAX_PAGES} pages" if url.present?
@@ -56,17 +56,36 @@ module Lti
         # RFC 8288 allows the relation as a bare token or a quoted string, more
         # than one relation per link, other parameters alongside it, and a
         # relative target that has to be resolved against the page it came from.
-        def next_page(response, current_url)
+        def next_page(response, current_url, origin_url)
           target = link_entries(response).find { |_target, params| relations(params).include?("next") }&.first
           return if target.blank?
 
-          URI.join(current_url, target).to_s
-        rescue URI::InvalidURIError
-          nil
+          resolve_next(target, current_url, origin_url)
         end
 
+        # A link we cannot follow must not read as the end of the roster, or a
+        # full-replace sync treats the members we never fetched as departed.
+        # The bearer token rides on every page, so a target that leaves the
+        # platform's origin is refused rather than requested.
+        def resolve_next(target, current_url, origin_url)
+          resolved = URI.join(current_url, target)
+          origin = URI.parse(origin_url)
+          raise Error, "roster next link left the platform origin: #{resolved}" unless same_origin?(resolved, origin)
+
+          resolved.to_s
+        rescue URI::InvalidURIError, ArgumentError
+          raise Error, "roster next link could not be resolved: #{target}"
+        end
+
+        def same_origin?(resolved, origin)
+          resolved.scheme == origin.scheme && resolved.host == origin.host &&
+            resolved.port == origin.port
+        end
+
+        # A parameter value may itself contain a comma, so entries are split on
+        # the angle-bracketed target rather than on the separator.
         def link_entries(response)
-          response.headers["Link"].to_s.scan(/<([^>]*)>((?:\s*;[^,<]*)*)/)
+          response.headers["Link"].to_s.scan(/<([^>]*)>([^<]*)/)
         end
 
         def relations(params)

--- a/spec/services/lti/membership_spec.rb
+++ b/spec/services/lti/membership_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Lti::Membership do
+  let(:url)   { "https://canvas.example.com/api/lti/courses/1/names_and_roles" }
+  let(:token) { "tok-1" }
+  let(:requested) { [] }
+
+  def member(id, roles: [described_class::LEARNER], status: "Active")
+    { "user_id" => id, "roles" => roles, "status" => status,
+      "name" => "User #{id}", "email" => "#{id}@example.com" }
+  end
+
+  def page(members, next_url: nil, success: true, status: 200, body: nil)
+    headers = next_url ? { "Link" => %(<#{next_url}>; rel="next") } : {}
+    instance_double(HTTP::Response,
+                    body: (body || { "members" => members }).to_json,
+                    headers: headers,
+                    status: instance_double(HTTP::Response::Status,
+                                            success?: success, to_s: status.to_s))
+  end
+
+  def stub_pages(*pages)
+    client = instance_double(HTTP::Client)
+    allow(HTTP).to receive(:timeout).and_return(client)
+    allow(client).to receive_messages(auth: client, headers: client)
+    allow(client).to receive(:get) do |requested_url|
+      requested << requested_url
+      pages[requested.size - 1] || pages.last
+    end
+    client
+  end
+
+  describe ".fetch" do
+    it "returns the members the platform reports" do
+      stub_pages(page([member("u1"), member("u2")]))
+
+      expect(described_class.fetch(url, token).pluck("user_id")).to eq(%w[u1 u2])
+    end
+
+    it "keeps roles and status so the caller can tell learners from staff" do
+      stub_pages(page([member("u1", roles: [described_class::INSTRUCTOR], status: "Inactive")]))
+
+      expect(described_class.fetch(url, token).first)
+        .to include("roles" => [described_class::INSTRUCTOR], "status" => "Inactive")
+    end
+
+    it "follows the next link until the platform stops sending one" do
+      stub_pages(page([member("u1")], next_url: "#{url}?page=2"),
+                 page([member("u2")], next_url: "#{url}?page=3"),
+                 page([member("u3")]))
+
+      expect(described_class.fetch(url, token).pluck("user_id")).to eq(%w[u1 u2 u3])
+      expect(requested).to eq([url, "#{url}?page=2", "#{url}?page=3"])
+    end
+
+    it "stops rather than looping when a platform keeps pointing at itself" do
+      stub_pages(page([member("u1")], next_url: url))
+
+      expect(described_class.fetch(url, token).size).to eq(described_class::MAX_PAGES)
+    end
+
+    it "sends the bearer token and the nrps media type" do
+      client = stub_pages(page([]))
+      described_class.fetch(url, token)
+
+      expect(client).to have_received(:auth).with("Bearer tok-1")
+      expect(client).to have_received(:headers).with("Accept" => described_class::MEDIA_TYPE)
+    end
+
+    it "tolerates a page with no members" do
+      stub_pages(page(nil, body: { "id" => url }))
+
+      expect(described_class.fetch(url, token)).to eq([])
+    end
+
+    it "raises when the platform refuses the request" do
+      stub_pages(page([], success: false, status: 403))
+
+      expect { described_class.fetch(url, token) }.to raise_error(described_class::Error, /403/)
+    end
+
+    it "raises when the response is not json" do
+      client = instance_double(HTTP::Client)
+      allow(HTTP).to receive(:timeout).and_return(client)
+      allow(client).to receive_messages(auth: client, headers: client,
+                                        get: instance_double(HTTP::Response, body: "<html>",
+                                                                             headers: {},
+                                                                             status: instance_double(
+                                                                               HTTP::Response::Status, success?: true
+                                                                             )))
+
+      expect { described_class.fetch(url, token) }.to raise_error(described_class::Error)
+    end
+
+    it "raises when the platform is unreachable" do
+      client = instance_double(HTTP::Client)
+      allow(HTTP).to receive(:timeout).and_return(client)
+      allow(client).to receive_messages(auth: client, headers: client)
+      allow(client).to receive(:get).and_raise(HTTP::ConnectionError, "connection refused")
+
+      expect { described_class.fetch(url, token) }.to raise_error(described_class::Error, /refused/)
+    end
+  end
+end

--- a/spec/services/lti/membership_spec.rb
+++ b/spec/services/lti/membership_spec.rb
@@ -55,10 +55,39 @@ RSpec.describe Lti::Membership do
       expect(requested).to eq([url, "#{url}?page=2", "#{url}?page=3"])
     end
 
-    it "stops rather than looping when a platform keeps pointing at itself" do
+    it "raises rather than returning a partial roster when a platform never stops paginating" do
       stub_pages(page([member("u1")], next_url: url))
 
-      expect(described_class.fetch(url, token).size).to eq(described_class::MAX_PAGES)
+      expect { described_class.fetch(url, token) }
+        .to raise_error(described_class::Error, /did not end within/)
+    end
+
+    it "follows a next link given as a bare token relation" do
+      first = page([member("u1")])
+      allow(first).to receive(:headers).and_return({ "Link" => "<#{url}?page=2>; rel=next" })
+      stub_pages(first, page([member("u2")]))
+
+      expect(described_class.fetch(url, token).pluck("user_id")).to eq(%w[u1 u2])
+    end
+
+    it "finds the next link among other relations and parameters" do
+      first = page([member("u1")])
+      allow(first).to receive(:headers).and_return(
+        { "Link" => %(<#{url}?page=1>; rel="first", <#{url}?page=2>; type="application/json"; rel="next") }
+      )
+      stub_pages(first, page([member("u2")]))
+      described_class.fetch(url, token)
+
+      expect(requested.last).to eq("#{url}?page=2")
+    end
+
+    it "resolves a relative next link against the page it came from" do
+      first = page([member("u1")])
+      allow(first).to receive(:headers).and_return({ "Link" => %(</api/lti/courses/1/nrps?page=2>; rel="next") })
+      stub_pages(first, page([member("u2")]))
+      described_class.fetch(url, token)
+
+      expect(requested.last).to eq("https://canvas.example.com/api/lti/courses/1/nrps?page=2")
     end
 
     it "sends the bearer token and the nrps media type" do
@@ -69,10 +98,24 @@ RSpec.describe Lti::Membership do
       expect(client).to have_received(:headers).with("Accept" => described_class::MEDIA_TYPE)
     end
 
-    it "tolerates a page with no members" do
-      stub_pages(page(nil, body: { "id" => url }))
+    it "reads an empty roster as no members" do
+      stub_pages(page([]))
 
       expect(described_class.fetch(url, token)).to eq([])
+    end
+
+    it "raises rather than reading a page with no members list as an empty class" do
+      stub_pages(page(nil, body: { "id" => url }))
+
+      expect { described_class.fetch(url, token) }
+        .to raise_error(described_class::Error, /no members list/)
+    end
+
+    it "raises when the page is not an object" do
+      stub_pages(page(nil, body: [{ "user_id" => "u1" }]))
+
+      expect { described_class.fetch(url, token) }
+        .to raise_error(described_class::Error, /no members list/)
     end
 
     it "raises when the platform refuses the request" do

--- a/spec/services/lti/membership_spec.rb
+++ b/spec/services/lti/membership_spec.rb
@@ -81,6 +81,38 @@ RSpec.describe Lti::Membership do
       expect(requested.last).to eq("#{url}?page=2")
     end
 
+    it "finds the next link when another parameter contains a comma" do
+      first = page([member("u1")])
+      allow(first).to receive(:headers).and_return(
+        { "Link" => %(<#{url}?page=2>; title="page, two"; rel="next") }
+      )
+      stub_pages(first, page([member("u2")]))
+      described_class.fetch(url, token)
+
+      expect(requested.last).to eq("#{url}?page=2")
+    end
+
+    it "refuses to carry the token to a next link on another origin" do
+      first = page([member("u1")])
+      allow(first).to receive(:headers).and_return(
+        { "Link" => %(<https://attacker.example.com/roster>; rel="next") }
+      )
+      stub_pages(first, page([member("u2")]))
+
+      expect { described_class.fetch(url, token) }
+        .to raise_error(described_class::Error, /left the platform origin/)
+      expect(requested).to eq([url])
+    end
+
+    it "raises rather than ending the roster on a next link it cannot resolve" do
+      first = page([member("u1")])
+      allow(first).to receive(:headers).and_return({ "Link" => %(<http://exa mple.com/%%>; rel="next") })
+      stub_pages(first, page([member("u2")]))
+
+      expect { described_class.fetch(url, token) }
+        .to raise_error(described_class::Error, /could not be resolved/)
+    end
+
     it "resolves a relative next link against the page it came from" do
       first = page([member("u1")])
       allow(first).to receive(:headers).and_return({ "Link" => %(</api/lti/courses/1/nrps?page=2>; rel="next") })


### PR DESCRIPTION
Fixes part of #7406

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -

### Screenshots of the UI changes (If any) -
none

---

## Code Understanding and AI Usage

**Did you use AI generated code (ChatGPT, Claude, Copilot, etc.) in any part of this PR? **
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Describe in your own words:
- What problem does your code solve?
The roster service needs to know who all are participating in a course this is done using the names and roster service (nrps) which is basically an endpoint that returs the member with their roles and status. Canvas returns rosters a page at a time so if only one page is read the remaining data is lost

- What alternative approaches did you consider?
Read the first page and stop: this gets rid of any class larger than one page leading to missing students in the roster list
Filter to active learners inside the client: drop handling needs to see the members who are left. If this class discards inactive members, that feature can't be built without changing it

- Why did you choose this specific implementation?
Memberships URL and access token are parameters, not things the class fetches itself and it keeps independent of the token service, lets specs drive it directly, and matches the AGS services from the earlier phase so the whole LTI service layer reads consistently.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added support for retrieving complete LTI membership lists, including inactive members.
- Automatically follows paginated membership results and resolves linked pages.
- Preserves membership roles and statuses.
- Supports authenticated requests using standard LTI membership formats.

## Bug Fixes
- Improved handling of unsuccessful responses, malformed data, invalid pagination links, connection failures, and pagination limits.
- Added clearer errors when membership responses are empty or invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->