### PR TITLE
Fix broken hero image rendering in welcome email template

### DIFF
--- a/app/views/user_mailer/welcome_email.html.erb
+++ b/app/views/user_mailer/welcome_email.html.erb
@@ -2,7 +2,7 @@
   <h2 class="mailer-heading">Welcome to CircuitVerse, <%= @user.name %></h2>
   
   <div class="mailer-hero-image">
-    <%= inline_svg_tag "homepage/new_homepage_sketch.png", alt: "Welcome", class: "mailer-group-image" %>
+    <%= image_tag "homepage/new_homepage_sketch.png", alt: "Welcome", class: "mailer-group-image" %>
   </div>
 
   <p class="mailer-welcome-text mailer-text">
@@ -20,7 +20,7 @@
   <div class="mailer-showcase-container">
     <div class="mailer-showcase-card">
       <div class="mailer-showcase-icon">
-        <%= inline_svg_tag "pngs/features.png", alt: "Features", class: "mailer-showcase-card-image" %>
+        <%= image_tag "pngs/features.png", alt: "Features", class: "mailer-showcase-card-image" %>
       </div>
       <h3 class="mailer-showcase-heading">Features</h3>
       <p class="mailer-text mailer-showcase-text">
@@ -34,7 +34,7 @@
 
     <div class="mailer-showcase-card">
       <div class="mailer-showcase-icon">
-        <%= inline_svg_tag "pngs/design.png", alt: "Design", class: "mailer-showcase-card-image" %>
+        <%= image_tag "pngs/design.png", alt: "Design", class: "mailer-showcase-card-image" %>
       </div>
       <h3 class="mailer-showcase-heading">Design</h3>
       <p class="mailer-text mailer-showcase-text">
@@ -48,7 +48,7 @@
 
     <div class="mailer-showcase-card">
       <div class="mailer-showcase-icon">
-        <%= inline_svg_tag "pngs/learn.png", alt: "Learn", class: "mailer-showcase-card-image" %>
+        <%= image_tag "pngs/learn.png", alt: "Learn", class: "mailer-showcase-card-image" %>
       </div>
       <h3 class="mailer-showcase-heading">Learn</h3>
       <p class="mailer-text mailer-showcase-text">


### PR DESCRIPTION
Fixes #5984

**Description**
The welcome email was using `inline_svg_tag` to render PNG images, which caused the images (including the hero image) to break and not appear in the preview/email clients. 

This PR replaces `inline_svg_tag` with `image_tag` for all PNG icons and sketches in the welcome email template so that the PNGs render correctly.

**Changes:**
- Replaced `inline_svg_tag` with `image_tag` for `homepage/new_homepage_sketch.png`.
- Replaced `inline_svg_tag` with `image_tag` for `pngs/features.png`.
- Replaced `inline_svg_tag` with `image_tag` for `pngs/design.png`.
- Replaced `inline_svg_tag` with `image_tag` for `pngs/learn.png`.

Tested locally using ActionMailer preview. No functionality changes; purely visual/styling fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved image rendering in welcome emails by updating the hero and showcase images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->