### PR TITLE
fix(adapter): strip null bytes from search queries to prevent ArgumentError (#7782)

### DIFF
--- a/app/lib/adapters/pg_adapter.rb
+++ b/app/lib/adapters/pg_adapter.rb
@@ -49,11 +49,19 @@ module Adapters
       end
 
       def base_project_results(relation, query_params)
-        query_params[:q].present? ? relation.text_search(query_params[:q]) : Project.public_and_not_forked
+        query = sanitize_query(query_params[:q])
+        query.present? ? relation.text_search(query) : Project.public_and_not_forked
       end
 
       def base_user_results(relation, query_params)
-        query_params[:q].present? ? relation.text_search(query_params[:q]) : User.all
+        query = sanitize_query(query_params[:q])
+        query.present? ? relation.text_search(query) : User.all
+      end
+
+      def sanitize_query(query)
+        return nil if query.blank?
+
+        query.to_s.delete("\u0000")
       end
 
       def apply_sorting(relation, query_params, type)

--- a/spec/lib/adapters/pg_adapter_spec.rb
+++ b/spec/lib/adapters/pg_adapter_spec.rb
@@ -34,6 +34,20 @@ RSpec.describe Adapters::PgAdapter do
       end
     end
 
+    context "with search query containing null bytes" do
+      let(:query_params) { { q: "test\u0000query", page: 1 } }
+
+      it "strips null bytes from search query" do
+        allow(project_relation).to receive(:text_search).with("testquery").and_return(mock_results)
+        allow(mock_results).to receive(:includes).with(:tags, :author).and_return(mock_results)
+        allow(mock_results).to receive(:paginate).with(page: 1, per_page: 9).and_return(paginated_results)
+
+        result = adapter.search_project(project_relation, query_params)
+
+        expect(result).to eq(paginated_results)
+      end
+    end
+
     context "without search query" do
       let(:query_params) { { page: 1 } }
 


### PR DESCRIPTION
### Summary of Changes

Fixes Sentry exception `ArgumentError: string contains null byte` triggered when search queries containing `\u0000` (`\0`) characters are passed to Postgres `text_search`.

#### Changes made:
- **`app/lib/adapters/pg_adapter.rb`**: Added `sanitize_query` helper method to strip null bytes (`\u0000`) from search inputs before executing `text_search`.
- **`spec/lib/adapters/pg_adapter_spec.rb`**: Added unit test verifying null byte stripping during project search.

### Related Issue

- Fixes #7782

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project and user search handling by removing invalid null characters from search queries.
  * Preserved existing behavior for blank searches, pagination, and result handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->