### PR TITLE
feat(search): add preloaded popular tags quick selection under search filter navigation (#7775)

### DIFF
--- a/app/assets/stylesheets/navbar.scss
+++ b/app/assets/stylesheets/navbar.scss
@@ -433,6 +433,37 @@ display: block;
     }
   }
 
+  .suggested-tags {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 4px;
+    margin-top: 6px;
+  }
+
+  .suggested-tag-label {
+    font-size: 12px;
+    color: lighten($navbar-dark-grey, 20%);
+    font-weight: 500;
+  }
+
+  .suggested-tag-btn {
+    background-color: transparent;
+    border: 1px dashed $shadow-grey;
+    border-radius: 12px;
+    color: $navbar-dark-grey;
+    cursor: pointer;
+    font-size: 11px;
+    padding: 2px 8px;
+    transition: all 0.2s ease;
+
+    &:hover {
+      background-color: $light-green-bg;
+      border-color: $primary-green;
+      color: $primary-green;
+    }
+  }
+
   .filter-select-wrapper {
     position: relative;
     display: inline-block;

--- a/app/components/search/search_bar_component.html.erb
+++ b/app/components/search/search_bar_component.html.erb
@@ -44,6 +44,14 @@
                 <div class="tag-input-container">
                   <input class="tag-input" type="text" placeholder="<%= filter_labels["projects"]["tags"]["placeholder"] %>" data-search-filters-target="tagInput">
                 </div>
+                <div class="suggested-tags">
+                  <span class="suggested-tag-label">Popular:</span>
+                  <% %w[CPU RAM ALU Gate FlipFlop Counter Adder Multiplexer].each do |suggested_tag| %>
+                    <button type="button" class="suggested-tag-btn" data-action="click->search-filters#addSuggestedTag" data-tag="<%= suggested_tag %>">
+                      + <%= suggested_tag %>
+                    </button>
+                  <% end %>
+                </div>
                 <input type="hidden" name="tag" id="filter_tag" value="<%= current_filter_values["tag"] %>" data-search-filters-target="tagHidden">
               </div>
             </div>

--- a/app/javascript/controllers/search_filters_controller.js
+++ b/app/javascript/controllers/search_filters_controller.js
@@ -114,6 +114,19 @@ export default class extends Controller {
         this.tagInputTarget.value = '';
     }
 
+    addSuggestedTag(event) {
+        event.preventDefault();
+        event.stopPropagation();
+        const tagText = event.currentTarget.dataset.tag;
+        if (!tagText) return;
+
+        const currentTags = this.getCurrentTags();
+        if (!currentTags.includes(tagText)) {
+            currentTags.push(tagText);
+            this.updateTags(currentTags);
+        }
+    }
+
     removeTag(tagToRemove) {
         if (!this.hasTagHiddenTarget || !this.hasTagsDisplayTarget) return;
 


### PR DESCRIPTION
### Summary of Changes

Implements #7775 by adding preloaded popular tag buttons (`CPU`, `RAM`, `ALU`, `Gate`, `FlipFlop`, `Counter`, `Adder`, `Multiplexer`) under the search filter navigation panel, allowing users to quickly click to select common tags without having to manually type them out.

#### Changes made:
- **`app/components/search/search_bar_component.html.erb`**: Rendered `.suggested-tags` chip container beneath project tag filter input.
- **`app/javascript/controllers/search_filters_controller.js`**: Added `addSuggestedTag(event)` Stimulus action handler to append selected quick-tag chips to active filter tags.
- **`app/assets/stylesheets/navbar.scss`**: Added styling for `.suggested-tags` and `.suggested-tag-btn`.

### Related Issue

- Fixes #7775

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Popular” section to project tag filters with suggested tags such as CPU, RAM, ALU, Gate, and more.
  - Suggested tags can be added with a single click and are not duplicated if already selected.

- **Style**
  - Added a responsive layout and visual styling for suggested tags, including hover feedback and dashed borders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->