### PR TITLE
fix(simulator): correct tunnel identifier property name and extend length limit (#7788)

### DIFF
--- a/simulator/src/modules/Tunnel.js
+++ b/simulator/src/modules/Tunnel.js
@@ -334,9 +334,9 @@ Tunnel.prototype.overrideDirectionRotation = true;
  */
 Tunnel.prototype.mutableProperties = {
     identifier: {
-        name: "Debug Flag identifier",
+        name: "Tunnel identifier",
         type: "text",
-        maxlength: "5",
+        maxlength: "32",
         func: "setIdentifier",
     },
 };


### PR DESCRIPTION
### Summary of Changes

Fixes part of CircuitVerse/cv-frontend-vue#1225 (Defect 12: Tunnel identifiers cap at 5 characters):
- Corrected the property label in `Tunnel.prototype.mutableProperties` from `"Debug Flag identifier"` (copy-paste artifact) to `"Tunnel identifier"`.
- Extended the `maxlength` limitation from `5` to `32` characters to allow descriptive signal/bus names (e.g. `data_bus`, `clk_out`, `reg_write`) across modules and imported designs.

### Related Issue

- Fixes part of CircuitVerse/cv-frontend-vue#1225

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the Tunnel identifier field with a clearer label.
  - Increased the allowed identifier length from 5 to 32 characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->