### PR TITLE
fix: ensure clean test database before running rspec suite (#5863)

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,10 +14,11 @@ User.create(name: "Admin",
             email: "admin@circuitverse.org",
             password: "password",
             admin: true,
-            confirmed_at: Time.now
+            locale: "en",
+            confirmed_at: Time.current
 )
-users = User.create([{ name: "user1", email: "user1@circuitverse.org", password: "password" },
-                     { name: "user2", email: "user2@circuitverse.org", password: "password" }])
+users = User.create([{ name: "user1", email: "user1@circuitverse.org", password: "password", locale: "en", confirmed_at: Time.current },
+                     { name: "user2", email: "user2@circuitverse.org", password: "password", locale: "en", confirmed_at: Time.current }])
 
 # private,public,limited access
 Rails.logger.debug "Creating Projects"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -56,10 +56,11 @@ Project.create([{ name: "Full Adder",
                   project_access_type: "Public",
                   description: "description" }])
 
-# groups
-Rails.logger.debug "Creating Groups"
-group = Group.create(name: "group1",
-                     primary_mentor_id: users.first.id)
+#groups
+puts "Creating Groups"
+group = Group.create(name: 'group1',
+  primary_mentor_id: users.first.id,
+)
 GroupMember.create(group_id: group.id,
                    user_id: users.second.id)
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,10 +15,13 @@ User.create(name: "Admin",
             password: "password",
             admin: true,
             locale: "en",
-            confirmed_at: Time.current
-)
-users = User.create([{ name: "user1", email: "user1@circuitverse.org", password: "password", locale: "en", confirmed_at: Time.current },
-                     { name: "user2", email: "user2@circuitverse.org", password: "password", locale: "en", confirmed_at: Time.current }])
+            confirmed_at: Time.current)
+users = User.create([
+                      { name: "user1", email: "user1@circuitverse.org", password: "password", locale: "en",
+                        confirmed_at: Time.current },
+                      { name: "user2", email: "user2@circuitverse.org", password: "password", locale: "en",
+                        confirmed_at: Time.current }
+                    ])
 
 # private,public,limited access
 Rails.logger.debug "Creating Projects"
@@ -53,11 +56,10 @@ Project.create([{ name: "Full Adder",
                   project_access_type: "Public",
                   description: "description" }])
 
-#groups
-puts "Creating Groups"
-group = Group.create(name: 'group1',
-  primary_mentor_id: users.first.id,
-)
+# groups
+Rails.logger.debug "Creating Groups"
+group = Group.create(name: "group1",
+                     primary_mentor_id: users.first.id)
 GroupMember.create(group_id: group.id,
                    user_id: users.second.id)
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -47,6 +47,10 @@ RSpec.configure do |config|
 
   config.include SystemTestHelpers, type: :system
 
+  config.before(:suite) do
+    ActiveRecord::Tasks::DatabaseTasks.truncate_all
+  end
+
   config.before do
     Flipper.adapter.features.each { |name| Flipper[name].remove }
     Flipper.enable(:contests)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -48,7 +48,7 @@ RSpec.configure do |config|
   config.include SystemTestHelpers, type: :system
 
   config.before(:suite) do
-    ActiveRecord::Tasks::DatabaseTasks.truncate_all
+    ActiveRecord::Tasks::DatabaseTasks.truncate_all if Rails.env.test?
   end
 
   config.before do


### PR DESCRIPTION
Fixes #5863

#### Describe the changes you have made in this PR -
- Added `ActiveRecord::Tasks::DatabaseTasks.truncate_all if Rails.env.test?` in `spec/rails_helper.rb` within `config.before(:suite)` to truncate all test database tables once at the start of the RSpec suite.
  - This guarantees that local test runs always start with a clean test database (identical to GitHub CI), resolving local RSpec failures caused by leftover data (such as from `rails db:seed` or `rails db:setup`).
  - This uses Rails's built-in `DatabaseTasks.truncate_all` without reintroducing third-party gems like `DatabaseCleaner`.
  - Guarded with `if Rails.env.test?` to prevent accidental execution in non-test environments.
- In `db/seeds.rb`, explicitly set `locale: "en"` and `confirmed_at: Time.current` on seeded users for data consistency.

---

### Before vs After Reproduction Logs

#### ❌ Before (Local Reproduction on Seeded / Dirty Test DB):
```text
CustomMailsController
  admin is signed in
    #create -> creates a new custom mail
    #show -> shows the mail
    #update -> updates mails
    #send_mail -> sends all mails (FAILED - 1)
    #send_mail_self -> sends mail to send only
    #index -> shows the list of custom views
  user is not admin -> returns not authorized for all routes
CustomMailsHelper
  #send_mail_in_batches -> sends mails to all subscribed users (FAILED - 2)
Api::V1::ProjectsController#index
  list all projects
    when not authenticated -> returns all public projects (FAILED - 3)
    when not authenticated and includes author details -> returns all public projects including author details (FAILED - 4)
    when projects sorted by views -> passes
    when authenticated with user who has authored a project -> returns all public projects in addition to authored (FAILED - 5)
    when authenticated with user who hasn't authored a project -> returns only all public projects (FAILED - 6)
Api::V1::ProjectsController#search
  list projects based on query
    when query is empty -> returns projects list (FAILED - 7)
    when query is not empty -> returns projects list (FAILED - 8)
Api::V1::UsersController#index
  list all users
    when authenticated -> returns the correct users (FAILED - 9)

Failures:
  1) CustomMailsController admin is signed in #send_mail sends all mails: expected to enqueue exactly 1 jobs, got 4
  2) CustomMailsHelper#send_mail_in_batches: expected to enqueue exactly 2 jobs, got 5
  3) Api::V1::ProjectsController#index: expected: 2, got: 6
  4) Api::V1::ProjectsController#index with author details: expected: 2, got: 6
  5) Api::V1::ProjectsController#index authored: expected: 3, got: 7
  6) Api::V1::ProjectsController#index not authored: expected: 2, got: 6
  7) Api::V1::ProjectsController#search query empty: expected: 3, got: 7
  8) Api::V1::ProjectsController#search query not empty: expected: 2, got: 3
  9) Api::V1::UsersController#index: JSON::Schema::ValidationError

Finished in 1.44 seconds
19 examples, 9 failures
```

#### ✅ After (With Fix):
```text
CustomMailsController -> all examples passed
CustomMailsHelper -> all examples passed
Api::V1::ProjectsController#index -> all examples passed
Api::V1::ProjectsController#search -> all examples passed
Api::V1::UsersController#index -> all examples passed

Finished in 1.41 seconds
19 examples, 0 failures

Full backend suite:
843 examples, 0 failures
```

---

## Code Understanding and AI Usage

**Did you use AI generated code (ChatGPT, Claude, Copilot, etc.) in any part of this PR? **
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
1. **Problem**: RSpec runs with `config.use_transactional_fixtures = true`, which rolls back changes made during individual examples. However, if the local test database contains rows committed before RSpec runs (e.g. from `db:seed` or `db:setup`), those rows persist across transactions and cause count/query assertions across `CustomMailsController`, `CustomMailsHelper`, `ProjectsController`, and `UsersController` to fail locally.
2. **Alternative Approaches**: Reintroducing `DatabaseCleaner` (expressly discouraged by maintainers in #5863), or manually deleting records in `before(:suite)`.
3. **Chosen Solution**: Rails 7+ / Rails 8 provides native `ActiveRecord::Tasks::DatabaseTasks.truncate_all`, which truncates all tables for the current database configuration while preserving migration metadata tables. Placing this in `config.before(:suite)` with a `Rails.env.test?` guard ensures a clean baseline before test transactions begin.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions