### PR TITLE
fix(api): increase verilog compilation MAX_CODE_SIZE limit to 100KB (#7788)

### DIFF
--- a/app/controllers/api/v1/simulator_controller.rb
+++ b/app/controllers/api/v1/simulator_controller.rb
@@ -28,7 +28,7 @@ class Api::V1::SimulatorController < Api::V1::BaseController
   end
   # rubocop:enable Metrics/MethodLength
 
-  MAX_CODE_SIZE = 10_000 # 10KB limit
+  MAX_CODE_SIZE = 100_000 # 100KB limit
 
   # POST /api/v1/simulator/verilogcv
   def verilog_cv

--- a/spec/requests/api/v1/simulator_controller/verilog_cv_spec.rb
+++ b/spec/requests/api/v1/simulator_controller/verilog_cv_spec.rb
@@ -40,5 +40,13 @@ RSpec.describe Api::V1::SimulatorController, type: :request do
         expect(response.status).to eq(500)
       end
     end
+
+    context "when code exceeds MAX_CODE_SIZE" do
+      it "returns 413 content_too_large status" do
+        post "/api/v1/simulator/verilogcv", params: { code: "a" * (described_class::MAX_CODE_SIZE + 1) }
+        expect(response.status).to eq(413)
+        expect(response.parsed_body["message"]).to include("Code too large")
+      end
+    end
   end
 end


### PR DESCRIPTION
### Summary of Changes

Fixes part of CircuitVerse/cv-frontend-vue#1225 (Defect 4: Paste size caps at 10,000 bytes):
- Increased `MAX_CODE_SIZE` in `app/controllers/api/v1/simulator_controller.rb` from `10_000` (10KB) to `100_000` (100KB) to support importing multi-module Verilog CPU designs without requiring manual comment stripping and minification.
- Added RSpec request test covering `MAX_CODE_SIZE` validation in `spec/requests/api/v1/simulator_controller/verilog_cv_spec.rb`.

### Related Issue

- Fixes part of CircuitVerse/cv-frontend-vue#1225

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Increased the maximum accepted Verilog code size from 10,000 to 100,000 bytes.
  * Updated the corresponding error handling for oversized submissions.

* **Bug Fixes**
  * Added validation coverage to ensure code exceeding the limit returns an appropriate “Code too large” response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->