### PR TITLE
fix(verilog): preserve clk/clock ports as input pins during module import (#7788)

### DIFF
--- a/simulator/src/VerilogClasses.js
+++ b/simulator/src/VerilogClasses.js
@@ -101,12 +101,7 @@ class verilogUnaryGate{
 class verilogInput extends verilogUnaryGate {
     constructor(deviceJSON) {
         super(deviceJSON);
-        if (deviceJSON["net"] == "clk" || deviceJSON["net"] == "clock") {
-            this.element = new Clock(0, 0);
-        } 
-        else {
-            this.element = new Input(0, 0, undefined, undefined, this.bitWidth);
-        }
+        this.element = new Input(0, 0, undefined, undefined, this.bitWidth);
         this.output = this.element.output1;
         this.element.label = deviceJSON["net"];
     }


### PR DESCRIPTION
### Summary of Changes

Fixes part of CircuitVerse/cv-frontend-vue#1225 (Defect 2: A port named `clk` disappears):
- In `simulator/src/VerilogClasses.js`, updated `verilogInput` to always instantiate standard `Input` pins for input ports (including `clk` and `clock`) rather than silently converting them into standalone `Clock` oscillator generators.
- Ensures imported modules and subcircuits preserve their clock input pins on the circuit interface so parent circuits can connect and drive clock signals to them.

### Related Issue

- Fixes part of CircuitVerse/cv-frontend-vue#1225

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Inputs named `clk` or `clock` are now handled consistently as standard input signals.
  * Configured bit widths are preserved for these inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->