### PR TITLE
fix(verilog): resolve Verilog import defects and multi-module synthesis limits

### DIFF
--- a/app/controllers/api/v1/simulator_controller.rb
+++ b/app/controllers/api/v1/simulator_controller.rb
@@ -27,8 +27,9 @@ class Api::V1::SimulatorController < Api::V1::BaseController
     render json: { success: true, message: "Issue submitted successfully" }, status: :ok
   end
   # rubocop:enable Metrics/MethodLength
+  include SimulatorHelper
 
-  MAX_CODE_SIZE = 250_000 # 250KB limit
+  MAX_CODE_SIZE = SimulatorHelper::MAX_CODE_SIZE
 
   # POST /api/v1/simulator/verilogcv
   def verilog_cv

--- a/app/controllers/api/v1/simulator_controller.rb
+++ b/app/controllers/api/v1/simulator_controller.rb
@@ -28,7 +28,7 @@ class Api::V1::SimulatorController < Api::V1::BaseController
   end
   # rubocop:enable Metrics/MethodLength
 
-  MAX_CODE_SIZE = 10_000 # 10KB limit
+  MAX_CODE_SIZE = 250_000 # 250KB limit
 
   # POST /api/v1/simulator/verilogcv
   def verilog_cv

--- a/app/controllers/simulator_controller.rb
+++ b/app/controllers/simulator_controller.rb
@@ -130,7 +130,7 @@ class SimulatorController < ApplicationController
     head :ok, content_type: "text/html"
   end
 
-  MAX_CODE_SIZE = 10_000 # 10KB limit
+  MAX_CODE_SIZE = 250_000 # 250KB limit
 
   def verilog_cv
     if params[:code].to_s.bytesize > MAX_CODE_SIZE

--- a/app/controllers/simulator_controller.rb
+++ b/app/controllers/simulator_controller.rb
@@ -130,7 +130,7 @@ class SimulatorController < ApplicationController
     head :ok, content_type: "text/html"
   end
 
-  MAX_CODE_SIZE = 250_000 # 250KB limit
+  MAX_CODE_SIZE = SimulatorHelper::MAX_CODE_SIZE
 
   def verilog_cv
     if params[:code].to_s.bytesize > MAX_CODE_SIZE

--- a/app/helpers/simulator_helper.rb
+++ b/app/helpers/simulator_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module SimulatorHelper
+  MAX_CODE_SIZE = 250_000 # 250KB limit
+
   def return_image_file(data_url)
     str = data_url[("data:image/jpeg;base64,".length)..]
     if str.to_s.empty?

--- a/simulator/spec/verilog.spec.js
+++ b/simulator/spec/verilog.spec.js
@@ -84,6 +84,16 @@ describe('Verilog Import and Synthesis Fixes', () => {
         // outBitWidth < bitWidth
         const addNarrower = new yosysTypeMap.Addition({ bits: { in1: 8, in2: 8, out: 4 } });
         expect(addNarrower.outputSplitter).toBeDefined();
+
+        // outBitWidth > bitWidth + 1 (e.g. 4-bit addition with 8-bit output)
+        const addMuchWider = new yosysTypeMap.Addition({ bits: { in1: 4, in2: 4, out: 8 } });
+        expect(addMuchWider.outputSplitter).toBeDefined();
+        expect(addMuchWider.zeroConstant).toBeDefined();
+        expect(addMuchWider.zeroConstant.state).toBe('000');
+        expect(addMuchWider.outputSplitter.bitWidthSplit).toEqual([4, 1, 3]);
+        expect(addMuchWider.outputSplitter.outputs[2].connections)
+            .toContain(addMuchWider.zeroConstant.output1);
+        expect(addMuchWider.output.bitWidth).toBe(8);
     });
 
     test('YosysJSON2CV tracks subcircuit scopes in rootScope.verilogMetadata.subCircuitScopeIds', () => {

--- a/simulator/spec/verilog.spec.js
+++ b/simulator/spec/verilog.spec.js
@@ -9,12 +9,12 @@ import yosysTypeMap from '../src/VerilogClasses';
 import Input from '../src/modules/Input';
 import Tunnel from '../src/modules/Tunnel';
 import Node, { propagateBitWidth } from '../src/node';
-import { scopeList } from '../src/circuit';
+import { scopeList, newCircuit, deleteCurrentCircuit } from '../src/circuit';
 
 jest.mock('codemirror');
 
 describe('Verilog Import and Synthesis Fixes', () => {
-    CodeMirror.fromTextArea.mockReturnValueOnce({ setValue: (text) => {} });
+    CodeMirror.fromTextArea.mockReturnValueOnce({ setValue: () => {} });
     setup();
 
     test('verilogInput keeps clk and clock as Input element and retains port label', () => {
@@ -119,14 +119,32 @@ describe('Verilog Import and Synthesis Fixes', () => {
         expect(scopeList[subId]).toBeDefined();
 
         // Clean up created scopes
-        for (const id of rootScope.verilogMetadata.subCircuitScopeIds) {
+        rootScope.verilogMetadata.subCircuitScopeIds.forEach((id) => {
             delete scopeList[id];
-        }
+        });
         rootScope.verilogMetadata.subCircuitScopeIds = [];
     });
 
     test('Tunnel identifier maxlength allows long identifiers', () => {
         expect(parseInt(Tunnel.prototype.mutableProperties.identifier.maxlength, 10)).toBeGreaterThanOrEqual(50);
+    });
+
+    test('Tunnel setIdentifier synchronizes bitWidth and propagates across intermediate wire nodes', () => {
+        const t1 = new Tunnel(0, 0, globalScope, 'LEFT', 8, 'BUS_SIG');
+        const t2 = new Tunnel(100, 0, globalScope, 'RIGHT', 1, 'OTHER_SIG');
+        const inter = new Node(120, 0, 2, globalScope.root, 1);
+        t2.inp1.connect(inter);
+
+        expect(t2.bitWidth).toBe(1);
+        expect(inter.bitWidth).toBe(1);
+
+        t2.setIdentifier('BUS_SIG');
+        expect(t2.bitWidth).toBe(8);
+        expect(t2.inp1.bitWidth).toBe(8);
+        expect(inter.bitWidth).toBe(8);
+
+        t1.delete();
+        t2.delete();
     });
 
     test('propagateBitWidth propagates bitWidth across intermediate wire nodes', () => {
@@ -146,5 +164,44 @@ describe('Verilog Import and Synthesis Fixes', () => {
         expect(n1.bitWidth).toBe(8);
         expect(inter1.bitWidth).toBe(8);
         expect(inter2.bitWidth).toBe(8);
+    });
+
+    test('deleteCurrentCircuit prevents deleting the last visible circuit when it has subcircuits', () => {
+        const mainScope = newCircuit('MainVerilogCircuit', undefined, true, true);
+        const subScope = newCircuit('SubModule', undefined, true, false);
+        mainScope.verilogMetadata.subCircuitScopeIds = [subScope.id];
+
+        const originalScopeList = { ...scopeList };
+        Object.keys(scopeList).forEach((id) => {
+            if (String(id) !== String(mainScope.id) && String(id) !== String(subScope.id)) {
+                delete scopeList[id];
+            }
+        });
+
+        deleteCurrentCircuit(mainScope.id);
+
+        expect(scopeList[mainScope.id]).toBeDefined();
+        expect(scopeList[subScope.id]).toBeDefined();
+
+        Object.assign(scopeList, originalScopeList);
+        delete scopeList[mainScope.id];
+        delete scopeList[subScope.id];
+    });
+
+    test('deleteCurrentCircuit deletes main Verilog circuit and its generated subcircuits when another circuit exists', () => {
+        const extraScope = newCircuit('ExtraCircuit');
+        const mainScope = newCircuit('MainVerilogCircuit', undefined, true, true);
+        const subScope = newCircuit('SubModule', undefined, true, false);
+        mainScope.verilogMetadata.subCircuitScopeIds = [subScope.id];
+
+        window.confirm = () => true;
+
+        deleteCurrentCircuit(mainScope.id);
+
+        expect(scopeList[mainScope.id]).toBeUndefined();
+        expect(scopeList[subScope.id]).toBeUndefined();
+        expect(scopeList[extraScope.id]).toBeDefined();
+
+        delete scopeList[extraScope.id];
     });
 });

--- a/simulator/spec/verilog.spec.js
+++ b/simulator/spec/verilog.spec.js
@@ -1,0 +1,150 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import CodeMirror from 'codemirror';
+import { setup } from '../src/setup';
+import { YosysJSON2CV } from '../src/Verilog2CV';
+import yosysTypeMap from '../src/VerilogClasses';
+import Input from '../src/modules/Input';
+import Tunnel from '../src/modules/Tunnel';
+import Node, { propagateBitWidth } from '../src/node';
+import { scopeList } from '../src/circuit';
+
+jest.mock('codemirror');
+
+describe('Verilog Import and Synthesis Fixes', () => {
+    CodeMirror.fromTextArea.mockReturnValueOnce({ setValue: (text) => {} });
+    setup();
+
+    test('verilogInput keeps clk and clock as Input element and retains port label', () => {
+        const clkGate = new yosysTypeMap.Input({ net: 'clk', bits: 1 });
+        expect(clkGate.element).toBeInstanceOf(Input);
+        expect(clkGate.element.label).toBe('clk');
+
+        const clockGate = new yosysTypeMap.Input({ net: 'clock', bits: 1 });
+        expect(clockGate.element).toBeInstanceOf(Input);
+        expect(clockGate.element.label).toBe('clock');
+    });
+
+    test('verilogUnaryGate / getBitWidth handles array of net IDs correctly', () => {
+        // DigitalJS netlist array of net IDs [5, 6, 26, 27, 28, 29, 30, 31] represents an 8-bit bus
+        const input8Bit = new yosysTypeMap.Input({ net: 'data_in', bits: [5, 6, 26, 27, 28, 29, 30, 31] });
+        expect(input8Bit.bitWidth).toBe(8);
+        expect(input8Bit.element.bitWidth).toBe(8);
+
+        // Single net ID [582] represents a 1-bit signal
+        const input1Bit = new yosysTypeMap.Input({ net: 'flag', bits: [582] });
+        expect(input1Bit.bitWidth).toBe(1);
+        expect(input1Bit.element.bitWidth).toBe(1);
+
+        // Integer width 32 represents a 32-bit bus
+        const input32Bit = new yosysTypeMap.Input({ net: 'word', bits: 32 });
+        expect(input32Bit.bitWidth).toBe(32);
+    });
+
+    test('comparator gates connect inputs in correct order to ALU', () => {
+        const dummyDevice = {
+            bits: { in1: 8, in2: 8, out: 1 },
+        };
+
+        // LtGate (A < B): in1 -> inp1 (A), in2 -> inp2 (B)
+        const lt = new yosysTypeMap.Lt(dummyDevice);
+        expect(lt.alu.inp1.connections).toContain(lt.in1Splitter.inp1);
+        expect(lt.alu.inp2.connections).toContain(lt.in2Splitter.inp1);
+
+        // GtGate (A > B <=> B < A): in1 -> inp2 (B), in2 -> inp1 (A)
+        const gt = new yosysTypeMap.Gt(dummyDevice);
+        expect(lt.alu.inp1.connections).not.toContain(gt.in1Splitter.inp1);
+        expect(gt.alu.inp2.connections).toContain(gt.in1Splitter.inp1);
+        expect(gt.alu.inp1.connections).toContain(gt.in2Splitter.inp1);
+
+        // GeGate (A >= B <=> !(A < B)): in1 -> inp1 (A), in2 -> inp2 (B), notGate on output
+        const ge = new yosysTypeMap.Ge(dummyDevice);
+        expect(ge.alu.inp1.connections).toContain(ge.in1Splitter.inp1);
+        expect(ge.alu.inp2.connections).toContain(ge.in2Splitter.inp1);
+        expect(ge.notGate).toBeDefined();
+
+        // LeGate (A <= B <=> !(B < A)): in1 -> inp2 (B), in2 -> inp1 (A), notGate on output
+        const le = new yosysTypeMap.Le(dummyDevice);
+        expect(le.alu.inp2.connections).toContain(le.in1Splitter.inp1);
+        expect(le.alu.inp1.connections).toContain(le.in2Splitter.inp1);
+        expect(le.notGate).toBeDefined();
+    });
+
+    test('verilogAdditionGate handles outBitWidth <= bitWidth gracefully', () => {
+        // outBitWidth == bitWidth
+        const addSame = new yosysTypeMap.Addition({ bits: { in1: 8, in2: 8, out: 8 } });
+        expect(addSame.output).toBe(addSame.adder.sum);
+
+        // outBitWidth == bitWidth + 1
+        const addWider = new yosysTypeMap.Addition({ bits: { in1: 8, in2: 8, out: 9 } });
+        expect(addWider.outputSplitter).toBeDefined();
+
+        // outBitWidth < bitWidth
+        const addNarrower = new yosysTypeMap.Addition({ bits: { in1: 8, in2: 8, out: 4 } });
+        expect(addNarrower.outputSplitter).toBeDefined();
+    });
+
+    test('YosysJSON2CV tracks subcircuit scopes in rootScope.verilogMetadata.subCircuitScopeIds', () => {
+        const rootScope = globalScope;
+        rootScope.verilogMetadata.subCircuitScopeIds = [];
+
+        const mockYosysJSON = {
+            name: 'top_module',
+            subcircuits: {
+                sub_mod: {
+                    name: 'sub_mod',
+                    devices: {
+                        inp: { type: 'Input', net: 'in_sig', bits: 1 },
+                        outp: { type: 'Output', net: 'out_sig', bits: 1 },
+                    },
+                    connectors: [
+                        {
+                            from: { id: 'inp', port: 'out' },
+                            to: { id: 'outp', port: 'in' },
+                        },
+                    ],
+                },
+            },
+            devices: {
+                sub1: { type: 'Subcircuit', celltype: 'sub_mod' },
+            },
+            connectors: [],
+        };
+
+        YosysJSON2CV(mockYosysJSON, rootScope, 'top_module', {}, true, rootScope);
+        expect(rootScope.verilogMetadata.subCircuitScopeIds.length).toBe(1);
+        const subId = rootScope.verilogMetadata.subCircuitScopeIds[0];
+        expect(scopeList[subId]).toBeDefined();
+
+        // Clean up created scopes
+        for (const id of rootScope.verilogMetadata.subCircuitScopeIds) {
+            delete scopeList[id];
+        }
+        rootScope.verilogMetadata.subCircuitScopeIds = [];
+    });
+
+    test('Tunnel identifier maxlength allows long identifiers', () => {
+        expect(parseInt(Tunnel.prototype.mutableProperties.identifier.maxlength, 10)).toBeGreaterThanOrEqual(50);
+    });
+
+    test('propagateBitWidth propagates bitWidth across intermediate wire nodes', () => {
+        const n1 = new Node(0, 0, 0, globalScope.root, 1);
+        const inter1 = new Node(10, 0, 2, globalScope.root, 1);
+        const inter2 = new Node(20, 0, 2, globalScope.root, 1);
+        const n2 = new Node(30, 0, 1, globalScope.root, 1);
+
+        n1.connect(inter1);
+        inter1.connect(inter2);
+        inter2.connect(n2);
+
+        expect(inter1.bitWidth).toBe(1);
+        expect(inter2.bitWidth).toBe(1);
+
+        propagateBitWidth(n1, 8);
+        expect(n1.bitWidth).toBe(8);
+        expect(inter1.bitWidth).toBe(8);
+        expect(inter2.bitWidth).toBe(8);
+    });
+});

--- a/simulator/src/Verilog2CV.js
+++ b/simulator/src/Verilog2CV.js
@@ -111,7 +111,7 @@ class verilogSubCircuit {
     }
 }
 
-export function YosysJSON2CV(JSON, parentScope = globalScope, name = "verilogCircuit", subCircuitScope = {}, root = false) {
+export function YosysJSON2CV(JSON, parentScope = globalScope, name = "verilogCircuit", subCircuitScope = {}, root = false, rootScope = parentScope) {
     var parentID = (parentScope.id);
     var subScope;
     if (root) {
@@ -119,11 +119,14 @@ export function YosysJSON2CV(JSON, parentScope = globalScope, name = "verilogCir
     }
     else {
         subScope = newCircuit(name, undefined, true, false);
+        if (rootScope && rootScope.verilogMetadata && rootScope.verilogMetadata.subCircuitScopeIds) {
+            rootScope.verilogMetadata.subCircuitScopeIds.push(subScope.id);
+        }
     }
     var circuitDevices = {};
 
     for (var subCircuitName in JSON.subcircuits) {
-        var scope = YosysJSON2CV(JSON.subcircuits[subCircuitName], subScope, subCircuitName, subCircuitScope);
+        var scope = YosysJSON2CV(JSON.subcircuits[subCircuitName], subScope, subCircuitName, subCircuitScope, false, rootScope);
         subCircuitScope[subCircuitName] = scope.id;
     }
 
@@ -172,12 +175,15 @@ export default function generateVerilogCircuit(verilogCode, scope = globalScope)
         success: function (response) {
             var circuitData = response;
             scope.initialize();
-            for (var id in scope.verilogMetadata.subCircuitScopeIds)
-                delete scopeList[id];
+            if (scope.verilogMetadata && scope.verilogMetadata.subCircuitScopeIds) {
+                for (var id of scope.verilogMetadata.subCircuitScopeIds) {
+                    delete scopeList[id];
+                }
+            }
             scope.verilogMetadata.subCircuitScopeIds = [];
             scope.verilogMetadata.code = verilogCode;
             var subCircuitScope = {};
-            YosysJSON2CV(circuitData, globalScope, "verilogCircuit", subCircuitScope, true);
+            YosysJSON2CV(circuitData, scope, "verilogCircuit", subCircuitScope, true, scope);
             changeCircuitName(circuitData.name);
             showMessage('Verilog Circuit Successfully Created');
             $('#verilogOutput').empty();

--- a/simulator/src/Verilog2CV.js
+++ b/simulator/src/Verilog2CV.js
@@ -195,7 +195,7 @@ export default function generateVerilogCircuit(verilogCode, scope = globalScope)
             }
             else {
                 var errorMessage = XMLHttpRequest.responseJSON;
-                var msg = errorMessage?.message || "There is some issue with the code";
+                var msg = (errorMessage && errorMessage.message) || "There is some issue with the code";
                 showError(msg);
                 $('#verilogOutput').text(msg);
             }

--- a/simulator/src/VerilogClasses.js
+++ b/simulator/src/VerilogClasses.js
@@ -66,27 +66,26 @@ import { newCircuit, switchCircuit, changeCircuitName} from './circuit'
 import SubCircuit from './subcircuit';
 
 function getBitWidth(bitsJSON) {
-    if (typeof bitsJSON === "number") {
+    if (typeof bitsJSON === 'number') {
         return bitsJSON;
     }
     if (Array.isArray(bitsJSON)) {
         return bitsJSON.length;
     }
-    if (bitsJSON && typeof bitsJSON === "object") {
-        var widths = [];
-        for (var key in bitsJSON) {
-            var val = bitsJSON[key];
-            if (typeof val === "number") {
+    if (bitsJSON && typeof bitsJSON === 'object') {
+        const widths = [];
+        Object.values(bitsJSON).forEach((val) => {
+            if (typeof val === 'number') {
                 widths.push(val);
             } else if (Array.isArray(val)) {
                 widths.push(val.length);
             }
-        }
+        });
         return widths.length > 0 ? Math.max(...widths) : 1;
     }
-    if (typeof bitsJSON === "string") {
-        var parsed = parseInt(bitsJSON, 10);
-        return isNaN(parsed) ? 1 : parsed;
+    if (typeof bitsJSON === 'string') {
+        const parsed = parseInt(bitsJSON, 10);
+        return Number.isNaN(parsed) ? 1 : parsed;
     }
     return 1;
 }
@@ -500,21 +499,21 @@ class verilogMathGate extends verilogBinaryGate {
         this.in2BitWidth = 1;
         this.outBitWidth = 1;
 
-        if (deviceJSON["bits"]) {
-            if (deviceJSON["bits"]["in1"] !== undefined) {
-                this.in1BitWidth = getBitWidth(deviceJSON["bits"]["in1"]);
+        if (deviceJSON.bits) {
+            if (deviceJSON.bits.in1 !== undefined) {
+                this.in1BitWidth = getBitWidth(deviceJSON.bits.in1);
             }
-            if (deviceJSON["bits"]["in2"] !== undefined) {
-                this.in2BitWidth = getBitWidth(deviceJSON["bits"]["in2"]);
+            if (deviceJSON.bits.in2 !== undefined) {
+                this.in2BitWidth = getBitWidth(deviceJSON.bits.in2);
             }
-            if (deviceJSON["bits"]["out"] !== undefined) {
-                this.outBitWidth = getBitWidth(deviceJSON["bits"]["out"]);
+            if (deviceJSON.bits.out !== undefined) {
+                this.outBitWidth = getBitWidth(deviceJSON.bits.out);
             }
         }
 
         this.bitWidth = Math.max(this.in1BitWidth, this.in2BitWidth);
 
-        if(includeOutBitWidth) {
+        if (includeOutBitWidth) {
             this.bitWidth = Math.max(this.outBitWidth, this.bitWidth);
         }
 
@@ -522,12 +521,11 @@ class verilogMathGate extends verilogBinaryGate {
 
         var extraBits = this.bitWidth - this.in1BitWidth;
 
-        if(extraBits > 0) {
+        if (extraBits > 0) {
             this.in1Splitter = new Splitter(0, 0, undefined, undefined, this.bitWidth, [this.in1BitWidth, extraBits]);
             
             var zeroState = '';
-            for(var i = 0; i < extraBits; i++)
-            {
+            for (var i = 0; i < extraBits; i++) {
                 zeroState += '0';
             }
             this.in1ZeroConstant = new ConstantVal(0, 0, undefined, undefined, extraBits, zeroState);
@@ -538,11 +536,10 @@ class verilogMathGate extends verilogBinaryGate {
         }
 
         var extraBits = this.bitWidth - this.in2BitWidth;
-        if(extraBits > 0) {
+        if (extraBits > 0) {
             this.in2Splitter = new Splitter(0, 0, undefined, undefined, this.bitWidth, [this.in2BitWidth, extraBits]);
             var zeroState = '';
-            for(var i = 0; i < extraBits; i++)
-            {
+            for (var i = 0; i < extraBits; i++) {
                 zeroState += '0';
             }
 
@@ -685,8 +682,8 @@ class verilogAdditionGate extends verilogMathGate {
         super(deviceJSON, false);
 
         this.outBitWidth = this.bitWidth;
-        if (deviceJSON["bits"] && deviceJSON["bits"]["out"] !== undefined) {
-            this.outBitWidth = getBitWidth(deviceJSON["bits"]["out"]);
+        if (deviceJSON.bits && deviceJSON.bits.out !== undefined) {
+            this.outBitWidth = getBitWidth(deviceJSON.bits.out);
         }
 
         this.adder = new Adder(0, 0, undefined, undefined, this.bitWidth);
@@ -694,9 +691,9 @@ class verilogAdditionGate extends verilogMathGate {
         this.in1Splitter.inp1.connect(this.adder.inpA);
         this.in2Splitter.inp1.connect(this.adder.inpB);
 
-        if (this.outBitWidth == this.bitWidth) {
+        if (this.outBitWidth === this.bitWidth) {
             this.output = this.adder.sum;
-        } else if (this.outBitWidth == this.bitWidth + 1) {
+        } else if (this.outBitWidth === this.bitWidth + 1) {
             this.outputSplitter = new Splitter(0, 0, undefined, undefined, this.outBitWidth, [this.bitWidth, 1]);
             this.adder.sum.connect(this.outputSplitter.outputs[0]);
             this.adder.carryOut.connect(this.outputSplitter.outputs[1]);

--- a/simulator/src/VerilogClasses.js
+++ b/simulator/src/VerilogClasses.js
@@ -698,6 +698,18 @@ class verilogAdditionGate extends verilogMathGate {
             this.adder.sum.connect(this.outputSplitter.outputs[0]);
             this.adder.carryOut.connect(this.outputSplitter.outputs[1]);
             this.output = this.outputSplitter.inp1;
+        } else if (this.outBitWidth > this.bitWidth + 1) {
+            const extraZeroBits = this.outBitWidth - (this.bitWidth + 1);
+            let zeroState = '';
+            for (let i = 0; i < extraZeroBits; i++) {
+                zeroState += '0';
+            }
+            this.zeroConstant = new ConstantVal(0, 0, undefined, undefined, extraZeroBits, zeroState);
+            this.outputSplitter = new Splitter(0, 0, undefined, undefined, this.outBitWidth, [this.bitWidth, 1, extraZeroBits]);
+            this.adder.sum.connect(this.outputSplitter.outputs[0]);
+            this.adder.carryOut.connect(this.outputSplitter.outputs[1]);
+            this.zeroConstant.output1.connect(this.outputSplitter.outputs[2]);
+            this.output = this.outputSplitter.inp1;
         } else if (this.outBitWidth < this.bitWidth) {
             this.outputSplitter = new Splitter(0, 0, undefined, undefined, this.bitWidth, [this.outBitWidth, this.bitWidth - this.outBitWidth]);
             this.adder.sum.connect(this.outputSplitter.inp1);

--- a/simulator/src/VerilogClasses.js
+++ b/simulator/src/VerilogClasses.js
@@ -66,16 +66,29 @@ import { newCircuit, switchCircuit, changeCircuitName} from './circuit'
 import SubCircuit from './subcircuit';
 
 function getBitWidth(bitsJSON) {
-    if (Number.isInteger(bitsJSON)) {
+    if (typeof bitsJSON === "number") {
         return bitsJSON;
     }
-    else {
-        var ans = 1;
-        for (var i in bitsJSON) {
-            ans = Math.max(ans, bitsJSON[i]);
-        }
-        return ans;
+    if (Array.isArray(bitsJSON)) {
+        return bitsJSON.length;
     }
+    if (bitsJSON && typeof bitsJSON === "object") {
+        var widths = [];
+        for (var key in bitsJSON) {
+            var val = bitsJSON[key];
+            if (typeof val === "number") {
+                widths.push(val);
+            } else if (Array.isArray(val)) {
+                widths.push(val.length);
+            }
+        }
+        return widths.length > 0 ? Math.max(...widths) : 1;
+    }
+    if (typeof bitsJSON === "string") {
+        var parsed = parseInt(bitsJSON, 10);
+        return isNaN(parsed) ? 1 : parsed;
+    }
+    return 1;
 }
 
 
@@ -101,12 +114,7 @@ class verilogUnaryGate{
 class verilogInput extends verilogUnaryGate {
     constructor(deviceJSON) {
         super(deviceJSON);
-        if (deviceJSON["net"] == "clk" || deviceJSON["net"] == "clock") {
-            this.element = new Clock(0, 0);
-        } 
-        else {
-            this.element = new Input(0, 0, undefined, undefined, this.bitWidth);
-        }
+        this.element = new Input(0, 0, undefined, undefined, this.bitWidth);
         this.output = this.element.output1;
         this.element.label = deviceJSON["net"];
     }
@@ -488,22 +496,33 @@ class verilogMathGate extends verilogBinaryGate {
     constructor(deviceJSON, includeOutBitWidth){
         super(deviceJSON);
 
-        this.bitWidth = Math.max(deviceJSON["bits"]["in1"], deviceJSON["bits"]["in2"]);
+        this.in1BitWidth = 1;
+        this.in2BitWidth = 1;
+        this.outBitWidth = 1;
 
-        if(includeOutBitWidth) {
-            this.bitWidth = Math.max(deviceJSON["bits"]["out"], this.bitWidth);
+        if (deviceJSON["bits"]) {
+            if (deviceJSON["bits"]["in1"] !== undefined) {
+                this.in1BitWidth = getBitWidth(deviceJSON["bits"]["in1"]);
+            }
+            if (deviceJSON["bits"]["in2"] !== undefined) {
+                this.in2BitWidth = getBitWidth(deviceJSON["bits"]["in2"]);
+            }
+            if (deviceJSON["bits"]["out"] !== undefined) {
+                this.outBitWidth = getBitWidth(deviceJSON["bits"]["out"]);
+            }
         }
 
-        if (!Number.isInteger(deviceJSON["bits"])) {
-            this.in1BitWidth = deviceJSON["bits"]["in1"];
-            this.in2BitWidth = deviceJSON["bits"]["in2"];
+        this.bitWidth = Math.max(this.in1BitWidth, this.in2BitWidth);
+
+        if(includeOutBitWidth) {
+            this.bitWidth = Math.max(this.outBitWidth, this.bitWidth);
         }
 
         this.input = [];
 
         var extraBits = this.bitWidth - this.in1BitWidth;
 
-        if(extraBits != 0) {
+        if(extraBits > 0) {
             this.in1Splitter = new Splitter(0, 0, undefined, undefined, this.bitWidth, [this.in1BitWidth, extraBits]);
             
             var zeroState = '';
@@ -519,7 +538,7 @@ class verilogMathGate extends verilogBinaryGate {
         }
 
         var extraBits = this.bitWidth - this.in2BitWidth;
-        if(extraBits != 0) {
+        if(extraBits > 0) {
             this.in2Splitter = new Splitter(0, 0, undefined, undefined, this.bitWidth, [this.in2BitWidth, extraBits]);
             var zeroState = '';
             for(var i = 0; i < extraBits; i++)
@@ -613,8 +632,8 @@ class verilogGtGate extends verilogMathGate {
         this.alu = new ALU(0, 0, undefined, undefined, this.bitWidth);
         this.splitter = new Splitter(0, 0, undefined, undefined, this.bitWidth, [1]);
 
-        this.in1Splitter.inp1.connect(this.alu.inp1);
-        this.in2Splitter.inp1.connect(this.alu.inp2);
+        this.in1Splitter.inp1.connect(this.alu.inp2);
+        this.in2Splitter.inp1.connect(this.alu.inp1);
 
         this.constant7.output1.connect(this.alu.controlSignalInput);
         this.alu.output.connect(this.splitter.inp1);
@@ -650,8 +669,8 @@ class verilogLeGate extends verilogMathGate {
         this.splitter = new Splitter(0, 0, undefined, undefined, this.bitWidth, [1]);
         this.notGate = new NotGate(0, 0);
 
-        this.in1Splitter.inp1.connect(this.alu.inp1);
-        this.in2Splitter.inp1.connect(this.alu.inp2);
+        this.in1Splitter.inp1.connect(this.alu.inp2);
+        this.in2Splitter.inp1.connect(this.alu.inp1);
 
         this.constant7.output1.connect(this.alu.controlSignalInput);
         this.alu.output.connect(this.splitter.inp1);
@@ -665,23 +684,29 @@ class verilogAdditionGate extends verilogMathGate {
     constructor(deviceJSON) {
         super(deviceJSON, false);
 
-        this.outBitWidth = deviceJSON["bits"]["out"];
+        this.outBitWidth = this.bitWidth;
+        if (deviceJSON["bits"] && deviceJSON["bits"]["out"] !== undefined) {
+            this.outBitWidth = getBitWidth(deviceJSON["bits"]["out"]);
+        }
 
         this.adder = new Adder(0, 0, undefined, undefined, this.bitWidth);
 
         this.in1Splitter.inp1.connect(this.adder.inpA);
         this.in2Splitter.inp1.connect(this.adder.inpB);
 
-        if(this.outBitWidth == this.bitWidth)
-        {
+        if (this.outBitWidth == this.bitWidth) {
             this.output = this.adder.sum;
-        }
-        else if(this.outBitWidth == this.bitWidth + 1)
-        {
+        } else if (this.outBitWidth == this.bitWidth + 1) {
             this.outputSplitter = new Splitter(0, 0, undefined, undefined, this.outBitWidth, [this.bitWidth, 1]);
             this.adder.sum.connect(this.outputSplitter.outputs[0]);
             this.adder.carryOut.connect(this.outputSplitter.outputs[1]);
             this.output = this.outputSplitter.inp1;
+        } else if (this.outBitWidth < this.bitWidth) {
+            this.outputSplitter = new Splitter(0, 0, undefined, undefined, this.bitWidth, [this.outBitWidth, this.bitWidth - this.outBitWidth]);
+            this.adder.sum.connect(this.outputSplitter.inp1);
+            this.output = this.outputSplitter.outputs[0];
+        } else {
+            this.output = this.adder.sum;
         }
     }
 }

--- a/simulator/src/circuit.js
+++ b/simulator/src/circuit.js
@@ -120,8 +120,11 @@ function deleteCurrentCircuit(scopeId = globalScope.id) {
     if (confirmation) {
         if (scope.verilogMetadata.isVerilogCircuit) {
             scope.initialize();
-            for (var id in scope.verilogMetadata.subCircuitScopeIds)
-                delete scopeList[id];
+            if (scope.verilogMetadata.subCircuitScopeIds) {
+                for (var id of scope.verilogMetadata.subCircuitScopeIds) {
+                    delete scopeList[id];
+                }
+            }
         }
         $(`#${scope.id}`).remove();
         delete scopeList[scope.id];

--- a/simulator/src/circuit.js
+++ b/simulator/src/circuit.js
@@ -94,15 +94,22 @@ export function switchCircuit(id) {
  * Switched to a random circuit
   * @category circuit
 */
-function deleteCurrentCircuit(scopeId = globalScope.id) {
+export function deleteCurrentCircuit(scopeId = globalScope.id) {
     const scope = scopeList[scopeId];
-    if (Object.keys(scopeList).length <= 1) {
+    if (!scope) return;
+    const subScopeIds = (scope.verilogMetadata && scope.verilogMetadata.isVerilogCircuit && scope.verilogMetadata.subCircuitScopeIds)
+        ? scope.verilogMetadata.subCircuitScopeIds
+        : [];
+    const scopesToDelete = new Set([String(scope.id), ...subScopeIds.map(String)]);
+    const remainingScopeIds = Object.keys(scopeList).filter((id) => !scopesToDelete.has(String(id)));
+
+    if (remainingScopeIds.length === 0) {
         showError('At least 2 circuits need to be there in order to delete a circuit.');
         return;
     }
     let dependencies = '';
-    for (id in scopeList) {
-        if (id != scope.id && scopeList[id].checkDependency(scope.id)) {
+    for (const id in scopeList) {
+        if (String(id) !== String(scope.id) && !scopesToDelete.has(String(id)) && scopeList[id].checkDependency(scope.id)) {
             if (dependencies === '') {
                 dependencies = scopeList[id].name;
             } else {
@@ -118,19 +125,22 @@ function deleteCurrentCircuit(scopeId = globalScope.id) {
 
     const confirmation = confirm(`Are you sure want to close: ${scope.name}\nThis cannot be undone.`);
     if (confirmation) {
-        if (scope.verilogMetadata.isVerilogCircuit) {
+        if (scope.verilogMetadata && scope.verilogMetadata.isVerilogCircuit) {
             scope.initialize();
             if (scope.verilogMetadata.subCircuitScopeIds) {
-                for (var id of scope.verilogMetadata.subCircuitScopeIds) {
+                scope.verilogMetadata.subCircuitScopeIds.forEach((id) => {
+                    $(`#${id}`).remove();
                     delete scopeList[id];
-                }
+                });
             }
         }
         $(`#${scope.id}`).remove();
         delete scopeList[scope.id];
-        switchCircuit(Object.keys(scopeList)[0]);
+        switchCircuit(remainingScopeIds[0]);
         showMessage('Circuit was successfully closed');
-    } else { showMessage('Circuit was not closed'); }
+    } else {
+        showMessage('Circuit was not closed');
+    }
 }
 
 /**
@@ -325,7 +335,7 @@ export default class Scope {
         if (id === this.id) return true;
         for (let i = 0; i < this.SubCircuit.length; i++) { if (this.SubCircuit[i].id === id) return true; }
 
-        for (let i = 0; i < this.SubCircuit.length; i++) { if (scopeList[this.SubCircuit[i].id].checkDependency(id)) return true; }
+        for (let i = 0; i < this.SubCircuit.length; i++) { if (scopeList[this.SubCircuit[i].id] && scopeList[this.SubCircuit[i].id].checkDependency(id)) return true; }
 
         return false;
     }

--- a/simulator/src/circuitElement.js
+++ b/simulator/src/circuitElement.js
@@ -10,6 +10,7 @@ import { colors } from './themer/themer';
 import { layoutModeGet, tempBuffer } from './layoutMode';
 import { fillSubcircuitElements } from './ux';
 import { generateNodeName } from './verilogHelpers';
+import { propagateBitWidth } from './node';
 
 /**
  * Base class for circuit elements.
@@ -708,7 +709,10 @@ export default class CircuitElement {
         if (this.bitWidth === undefined) return;
         if (this.bitWidth < 1) return;
         this.bitWidth = bitWidth;
-        for (let i = 0; i < this.nodeList.length; i++) { this.nodeList[i].bitWidth = bitWidth; }
+        for (let i = 0; i < this.nodeList.length; i++) {
+            this.nodeList[i].bitWidth = bitWidth;
+            propagateBitWidth(this.nodeList[i], bitWidth);
+        }
     }
 
     /**

--- a/simulator/src/modules/Tunnel.js
+++ b/simulator/src/modules/Tunnel.js
@@ -1,5 +1,5 @@
 import CircuitElement from "../circuitElement";
-import Node, { findNode } from "../node";
+import Node, { findNode, propagateBitWidth } from "../node";
 import simulationArea from "../simulationArea";
 import { correctWidth, rect2, fillText } from "../canvasApi";
 import plotArea from "../plotArea";
@@ -309,7 +309,10 @@ export default class Tunnel extends CircuitElement {
             if (tunnel.bitWidth === undefined) continue;
             if (tunnel.bitWidth < 1) continue;
             tunnel.bitWidth = bitWidth;
-            for (let i = 0; i < tunnel.nodeList.length; i++) { tunnel.nodeList[i].bitWidth = bitWidth; }
+            for (let i = 0; i < tunnel.nodeList.length; i++) {
+                tunnel.nodeList[i].bitWidth = bitWidth;
+                propagateBitWidth(tunnel.nodeList[i], bitWidth);
+            }
         }
     }
 }
@@ -336,7 +339,7 @@ Tunnel.prototype.mutableProperties = {
     identifier: {
         name: "Debug Flag identifier",
         type: "text",
-        maxlength: "5",
+        maxlength: "50",
         func: "setIdentifier",
     },
 };

--- a/simulator/src/modules/Tunnel.js
+++ b/simulator/src/modules/Tunnel.js
@@ -182,7 +182,13 @@ export default class Tunnel extends CircuitElement {
 
         // Change the bitwidth to be same as the other elements with this.identifier
         if (this.scope.tunnelList[this.identifier] && this.scope.tunnelList[this.identifier].length > 1) {
-            this.bitWidth = this.inp1.bitWidth = this.scope.tunnelList[this.identifier][0].bitWidth;
+            const targetBitWidth = this.scope.tunnelList[this.identifier][0].bitWidth;
+            this.bitWidth = targetBitWidth;
+            this.inp1.bitWidth = targetBitWidth;
+            for (let i = 0; i < this.nodeList.length; i++) {
+                this.nodeList[i].bitWidth = targetBitWidth;
+                propagateBitWidth(this.nodeList[i], targetBitWidth);
+            }
         }
 
         const len = this.identifier.length;

--- a/simulator/src/node.js
+++ b/simulator/src/node.js
@@ -79,10 +79,11 @@ export function findNode(x) {
  */
 export function propagateBitWidth(startNode, bitWidth, visited = new Set()) {
     if (!startNode || visited.has(startNode)) return;
-    visited.add(startNode);
-    startNode.bitWidth = bitWidth;
-    for (var i = 0; i < startNode.connections.length; i++) {
-        var neighbor = startNode.connections[i];
+    const node = startNode;
+    visited.add(node);
+    node.bitWidth = bitWidth;
+    for (var i = 0; i < node.connections.length; i++) {
+        var neighbor = node.connections[i];
         if (neighbor && neighbor.type === 2) {
             propagateBitWidth(neighbor, bitWidth, visited);
         }

--- a/simulator/src/node.js
+++ b/simulator/src/node.js
@@ -72,6 +72,24 @@ export function findNode(x) {
 }
 
 /**
+ * Propagates updated bitWidth across connected intermediate wire nodes.
+ * @param {Node} startNode
+ * @param {number} bitWidth
+ * @param {Set} visited
+ */
+export function propagateBitWidth(startNode, bitWidth, visited = new Set()) {
+    if (!startNode || visited.has(startNode)) return;
+    visited.add(startNode);
+    startNode.bitWidth = bitWidth;
+    for (var i = 0; i < startNode.connections.length; i++) {
+        var neighbor = startNode.connections[i];
+        if (neighbor && neighbor.type === 2) {
+            propagateBitWidth(neighbor, bitWidth, visited);
+        }
+    }
+}
+
+/**
  * function makes a node according to data providede
  * @param {JSON} data - the data used to load a Project
  * @param {Scope} scope - scope to which node has to be loaded

--- a/spec/controllers/simulator_controller_spec.rb
+++ b/spec/controllers/simulator_controller_spec.rb
@@ -152,5 +152,54 @@ describe SimulatorController, type: :request do
         end
       end
     end
+
+    describe "#verilog_cv" do
+      let(:code) { "sample_code" }
+      let(:yosys_response) { { "data" => "response_from_yosys" } }
+
+      context "when YOSYS_PATH is valid and returns a successful response" do
+        let(:response_double) { instance_double(HTTP::Response, code: 200, to_s: yosys_response.to_json) }
+
+        before do
+          allow(ENV).to receive(:fetch).with("YOSYS_PATH", "http://127.0.0.1:3040").and_return("http://127.0.0.1:3040")
+          http_client = instance_double(HTTP::Client)
+          allow(HTTP).to receive(:timeout).and_return(http_client)
+          allow(http_client).to receive(:post).and_return(response_double)
+        end
+
+        it "returns a successful response with correct JSON" do
+          post "/simulator/verilogcv", params: { code: code }
+          expect(response.status).to eq(200)
+          expect(response.parsed_body).to eq(yosys_response.with_indifferent_access)
+        end
+      end
+
+      context "when code size is exactly MAX_CODE_SIZE (250KB)" do
+        let(:exact_limit_code) { "a" * 250_000 }
+        let(:response_double) { instance_double(HTTP::Response, code: 200, to_s: yosys_response.to_json) }
+
+        before do
+          allow(ENV).to receive(:fetch).with("YOSYS_PATH", "http://127.0.0.1:3040").and_return("http://127.0.0.1:3040")
+          http_client = instance_double(HTTP::Client)
+          allow(HTTP).to receive(:timeout).and_return(http_client)
+          allow(http_client).to receive(:post).and_return(response_double)
+        end
+
+        it "accepts the code and returns 200" do
+          post "/simulator/verilogcv", params: { code: exact_limit_code }
+          expect(response.status).to eq(200)
+        end
+      end
+
+      context "when code size exceeds MAX_CODE_SIZE" do
+        let(:too_large_code) { "a" * 250_001 }
+
+        it "returns content_too_large status" do
+          post "/simulator/verilogcv", params: { code: too_large_code }
+          expect(response.status).to eq(413)
+          expect(response.parsed_body["message"]).to include("Code too large")
+        end
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/simulator_controller/verilog_cv_spec.rb
+++ b/spec/requests/api/v1/simulator_controller/verilog_cv_spec.rb
@@ -58,6 +58,23 @@ RSpec.describe Api::V1::SimulatorController, type: :request do
       end
     end
 
+    context "when code size is exactly MAX_CODE_SIZE (250KB)" do
+      let(:exact_limit_code) { "a" * 250_000 }
+      let(:response_double) { instance_double(HTTP::Response, code: 200, to_s: yosys_response.to_json) }
+
+      before do
+        allow(ENV).to receive(:fetch).with("YOSYS_PATH", "http://127.0.0.1:3040").and_return("http://127.0.0.1:3040")
+        http_client = instance_double(HTTP::Client)
+        allow(HTTP).to receive(:timeout).and_return(http_client)
+        allow(http_client).to receive(:post).and_return(response_double)
+      end
+
+      it "accepts the code and returns 200" do
+        post "/api/v1/simulator/verilogcv", params: { code: exact_limit_code }
+        expect(response.status).to eq(200)
+      end
+    end
+
     context "when code size exceeds MAX_CODE_SIZE" do
       let(:too_large_code) { "a" * 250_001 }
 

--- a/spec/requests/api/v1/simulator_controller/verilog_cv_spec.rb
+++ b/spec/requests/api/v1/simulator_controller/verilog_cv_spec.rb
@@ -40,5 +40,32 @@ RSpec.describe Api::V1::SimulatorController, type: :request do
         expect(response.status).to eq(500)
       end
     end
+
+    context "when code size is larger than 10KB but within MAX_CODE_SIZE" do
+      let(:large_code) { "a" * 15_000 }
+      let(:response_double) { instance_double(HTTP::Response, code: 200, to_s: yosys_response.to_json) }
+
+      before do
+        allow(ENV).to receive(:fetch).with("YOSYS_PATH", "http://127.0.0.1:3040").and_return("http://127.0.0.1:3040")
+        http_client = instance_double(HTTP::Client)
+        allow(HTTP).to receive(:timeout).and_return(http_client)
+        allow(http_client).to receive(:post).and_return(response_double)
+      end
+
+      it "accepts the code and returns 200" do
+        post "/api/v1/simulator/verilogcv", params: { code: large_code }
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context "when code size exceeds MAX_CODE_SIZE" do
+      let(:too_large_code) { "a" * 250_001 }
+
+      it "returns content_too_large status" do
+        post "/api/v1/simulator/verilogcv", params: { code: too_large_code }
+        expect(response.status).to eq(413)
+        expect(response.parsed_body["message"]).to include("Code too large")
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes CircuitVerse/cv-frontend-vue#1225

#### Describe the changes you have made in this PR -

This PR fixes multiple critical defects identified in Verilog import and synthesis for multi-module digital designs (#7788) and addresses code review feedback:

1. **Array Signal Vector Width Bug in `getBitWidth` (Defects 7, 8, 9, 10)**:
   - Updated `getBitWidth` to correctly inspect array lengths (`bitsJSON.length`), numbers, objects, and strings instead of using `Math.max` across net ID values.
   - Refactored using `Object.values` and `Number.isNaN` for strict ESLint compliance.

2. **Clock Port Exposure and Subcircuit Pin Loss (Defect 2)**:
   - Preserved `Input` creation for all input ports with their respective net names rather than converting to `Clock` elements.

3. **Inverted Comparison Gate Operations (Defect 3/Logic Bugs)**:
   - Fixed ALU input wiring order in `verilogGtGate` and `verilogLeGate` to align with ALU SLT (control code 7) semantics.

4. **Addition Gate Output Bitwidth Handling**:
   - Updated `verilogAdditionGate` to safely handle `outBitWidth <= bitWidth` and unexpected widths without producing disconnected/undefined outputs.

5. **Orphaned Scope Proliferation and Safe Circuit Deletion (Defect 1)**:
   - `YosysJSON2CV` tracks generated subcircuit IDs in `rootScope.verilogMetadata.subCircuitScopeIds`.
   - Updated `deleteCurrentCircuit` in `circuit.js` to account for subcircuit scopes, preventing the deletion of the last visible circuit and cleaning up all associated child scopes and DOM tabs when valid.
   - Added null safety checks in `Scope.checkDependency`.

6. **Intermediate Wire Node & Tunnel Bitwidth Propagation (Defect 11)**:
   - Added `propagateBitWidth` to propagate width updates across connected intermediate wire nodes (`type === 2`).
   - Fixed parameter mutation in `propagateBitWidth`.
   - Added bitwidth propagation in `Tunnel.prototype.setIdentifier` when synchronizing with paired tunnels.

7. **Unified Code Paste Size Limit Expansion (Defect 4)**:
   - Centralized `MAX_CODE_SIZE = 250_000` (250KB) in `SimulatorHelper`, shared by `SimulatorController` and `Api::V1::SimulatorController`.

8. **Tunnel Identifier Length Restriction (Defect 12)**:
   - Increased `mutableProperties.identifier.maxlength` on `Tunnel` from `5` to `50`.

9. **Unit, Integration, and Controller Tests**:
   - Added comprehensive Jest unit test suite in `simulator/spec/verilog.spec.js` (including deletion regression tests and tunnel bitwidth propagation).
   - Added RSpec controller tests in `spec/controllers/simulator_controller_spec.rb` and `spec/requests/api/v1/simulator_controller/verilog_cv_spec.rb` verifying exact 250KB limits and boundary rejection.

---

### PR Artifacts:
- **Diff**: https://github.com/CircuitVerse/CircuitVerse/pull/7797.diff
- **Patch**: https://github.com/CircuitVerse/CircuitVerse/pull/7797.patch

---

## Code Understanding and AI Usage

**Did you use AI generated code (ChatGPT, Claude, Copilot, etc.) in any part of this PR? **
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The root causes were isolated by tracing synthesis output from Yosys/DigitalJS through CircuitVerse's `YosysJSON2CV` and `VerilogClasses`. The signal width mismatch was caused by treating net ID arrays as numerical values rather than vector length. Comparison bugs were fixed by aligning with CircuitVerse ALU SLT semantics (control code 7). Orphan scope accumulation and deletion issues were solved by tracking child circuit IDs and calculating remaining scope counts before confirmation. All constants and controllers are unified in `SimulatorHelper`.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Increased the maximum accepted Verilog code size to 250 KB.
  * Support tunnel identifiers up to 50 characters.
* **Bug Fixes**
  * Improved bit-width propagation across connected elements and tunnels.
  * Corrected comparison, addition, wiring, and subcircuit handling.
  * Improved Verilog input and clock labeling.
  * Improved cleanup when deleting circuits with generated subcircuits.
* **Tests**
  * Added coverage for Verilog imports, synthesis, code-size limits, bit widths, comparisons, additions, wiring, and subcircuits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->