### PR TITLE
fix(simulator): register newly created subcircuit nodes in element nodeList (#7788)

### DIFF
--- a/simulator/src/subcircuit.js
+++ b/simulator/src/subcircuit.js
@@ -286,6 +286,8 @@ export default class SubCircuit extends CircuitElement {
                 a.layout_id = subcircuitScope.Input[i].layoutProperties.id;
                 this.inputNodes.push(a);
             }
+            this.nodeList.extend(this.inputNodes);
+            this.nodeList.extend(this.outputNodes);
         }
     }
 


### PR DESCRIPTION
### Summary of Changes

Fixes part of CircuitVerse/cv-frontend-vue#1225 (Defect 10: Subcircuit nodes registration in element `nodeList`):
- In `simulator/src/subcircuit.js`, extended `this.nodeList` with `this.inputNodes` and `this.outputNodes` inside `buildCircuit()` when creating a new `SubCircuit` without saved data.
- Ensures all subcircuit input and output pins are tracked on the circuit element for correct position updates, propagation checks, and wire cleanup.

### Related Issue

- Fixes part of CircuitVerse/cv-frontend-vue#1225

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed newly created input and output nodes not being included in new subcircuits, ensuring they are available for circuit simulation and editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->