### PR TITLE
Fix transparent clock panel in embedded simulator

### DIFF
--- a/app/views/simulator/embed.html.erb
+++ b/app/views/simulator/embed.html.erb
@@ -33,7 +33,7 @@
         </div>
       </div>
 
-      <div style="position:absolute; right:10px; top:25px; z-index:100" class="clockPropertyHeader noSelect">
+      <div class="clockPropertyHeader noSelect">
         <div id="clockProperty">
         </div>
       </div>

--- a/simulator/src/css/embed.css
+++ b/simulator/src/css/embed.css
@@ -32,29 +32,20 @@
     transition: .4s;
 }
 
-#clockProperty{
-    padding: 10px;
+.clockPropertyHeader {
+    position: absolute;
+    right: 10px;
+    top: 25px;
+    z-index: 100;
 }
 
-#clockPropertyHeader{
-    border-radius: 3px;
-
-}
-#clockProperty{
+#clockProperty {
     padding: 10px;
     border-radius: 6px;
-    opacity: 0.1;
-    transition: .4s;
     height: auto;
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-
-}
-#clockProperty:hover{
-    opacity: 1;
-    -webkit-transition: .4s;
-    transition: .4s;
 }
 input:checked + .slider {
     /* background-color: #2196F3; */


### PR DESCRIPTION
Fixes #7707

The embedded simulator's clock/fullscreen panel was displayed with
`opacity: 0.1` by default and changed to `opacity: 1` on hover. This
caused circuit elements underneath the panel to remain partially visible
through the panel and created an inconsistent UI.

This PR:

- Moves the `.clockPropertyHeader` positioning from inline HTML styles
  into `embed.css`.
- Removes the `opacity: 0.1` behavior from `#clockProperty`.
- Removes the hover-based opacity transition.
- Preserves the existing theme-based background, border, and text
  styling.
- Does not modify the existing JavaScript behavior.
- Preserves the original panel position (`top: 25px`, `right: 10px`,
  `z-index: 100`).

CHANGES:
The clock panel is now fully opaque and circuit elements no longer show
through the panel.

A standalone browser test was used to manually verify the visual
behavior.


## CODE UNDERSTANDING AND AI USAGE:

Did you use AI generated code (ChatGPT, Claude, Copilot, etc.) in any part of this PR?
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

## IMPLEMENTATION APPROACH:

The issue was caused by the embedded clock property panel using
`opacity: 0.1` by default and changing to full opacity only when hovered.
Because the panel is positioned over the simulator canvas, circuit
elements underneath it could remain visible through the panel.

I considered changing the panel's position, but the existing
`position: absolute`, `right: 10px`, `top: 25px`, and `z-index: 100`
values are not the root cause of the visual issue. Therefore, the
existing positioning was preserved.

The chosen approach was to remove the opacity-based behavior and allow
the existing theme styling from `color_theme.scss` to provide the
panel's opaque background, border, and text color.

The existing inline positioning styles were also moved into the
`.clockPropertyHeader` CSS class so that the layout styling is kept in
the stylesheet.

No JavaScript behavior was changed because `embed.js` only controls the
visibility and contents of `#clockProperty` and does not depend on its
opacity or hover behavior.

The final implementation was manually verified using a standalone
browser test. The panel remained opaque, retained its position, and
circuit elements did not show through it.

## CHECKLIST BEFORE REQUESTING A REVIEW:

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [ ] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved clock property header positioning and stacking behavior.
  - Simplified clock property styling for more consistent display.
  - Removed outdated and duplicate styling rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->