### PR TITLE
fix(security): bump mail gem to 2.9.1 to patch GHSA-mvxr-6m87-mv2q

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -452,7 +452,7 @@ GEM
       view_component (>= 2.0)
       yard (~> 0.9)
       zeitwerk (~> 2.5)
-    mail (2.9.0)
+    mail (2.9.1)
       logger
       mini_mime (>= 0.1.1)
       net-imap


### PR DESCRIPTION
Fixes #7803

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -

Bumps the `mail` gem from 2.9.0 to 2.9.1 in `Gemfile.lock` to resolve GHSA-mvxr-6m87-mv2q (Medium) email address spoofing via malformed RFC 2047 encoded-words.

### Screenshots of the UI changes (If any) -
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI generated code (ChatGPT, Claude, Copilot, etc.) in any part of this PR? **
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Used `--conservative` so the update is limited to `mail` and doesn't drag
unrelated gems along, keeping the diff reviewable. There are no code changes
in this PR;

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
