### PR TITLE
fix(simulator): schedule explicit delay=0 events immediately in EventQueue

### DIFF
--- a/simulator/spec/eventQueue.spec.js
+++ b/simulator/spec/eventQueue.spec.js
@@ -1,0 +1,100 @@
+import EventQueue from '../src/eventQueue';
+
+/**
+ * Minimal stand-in for a CircuitElement, exposing only what EventQueue reads/writes.
+ */
+function makeElement(propagationDelay) {
+    return {
+        propagationDelay,
+        queueProperties: { inQueue: false, time: 0, index: 0 },
+    };
+}
+
+describe('EventQueue', () => {
+    test('schedules a new object at time 0 when delay is explicitly 0, even with a non-zero propagationDelay', () => {
+        const queue = new EventQueue(10);
+        const flipFlopOutput = makeElement(10); // default propagationDelay used by DflipFlop/JKflipFlop/TflipFlop/SRflipFlop/Buffer/Counter/Random
+
+        queue.add(flipFlopOutput, 0);
+
+        expect(flipFlopOutput.queueProperties.time).toBe(0);
+        expect(flipFlopOutput.queueProperties.inQueue).toBe(true);
+    });
+
+    test('falls back to propagationDelay only when delay is omitted (undefined)', () => {
+        const queue = new EventQueue(10);
+        const gateOutput = makeElement(10);
+
+        queue.add(gateOutput);
+
+        expect(gateOutput.queueProperties.time).toBe(10);
+    });
+
+    test('honors an explicit non-zero delay that differs from propagationDelay', () => {
+        const queue = new EventQueue(10);
+        const el = makeElement(10);
+
+        queue.add(el, 25);
+
+        expect(el.queueProperties.time).toBe(25);
+    });
+
+    test('re-scheduling an already-queued object at delay 0 moves it to the current queue time, not queue.time + propagationDelay', () => {
+        const queue = new EventQueue(10);
+        const a = makeElement(10);
+        const b = makeElement(10);
+
+        queue.add(a, 5);
+        queue.add(b); // b lands at time 10 (default propagationDelay), so it is already in queue
+
+        // Re-add b with an explicit immediate delay while it is still queued
+        queue.add(b, 0);
+
+        expect(b.queueProperties.time).toBe(0);
+    });
+
+    test('pop() returns events in ascending time order regardless of insertion order', () => {
+        const queue = new EventQueue(10);
+        const late = makeElement(10);
+        const immediate = makeElement(10);
+        const mid = makeElement(10);
+
+        queue.add(late, 20);
+        queue.add(immediate, 0);
+        queue.add(mid, 10);
+
+        expect(queue.pop()).toBe(immediate);
+        expect(queue.pop()).toBe(mid);
+        expect(queue.pop()).toBe(late);
+        expect(queue.isEmpty()).toBe(true);
+    });
+
+    test('advances queue.time to the popped event time', () => {
+        const queue = new EventQueue(10);
+        const el = makeElement(10);
+
+        queue.add(el, 0);
+        queue.pop();
+
+        expect(queue.time).toBe(0);
+    });
+
+    test('reset() clears the queue and restores time to 0', () => {
+        const queue = new EventQueue(10);
+        const el = makeElement(10);
+
+        queue.add(el, 5);
+        queue.reset();
+
+        expect(queue.isEmpty()).toBe(true);
+        expect(queue.time).toBe(0);
+        expect(el.queueProperties.inQueue).toBe(false);
+    });
+
+    test('throws when adding beyond the configured size', () => {
+        const queue = new EventQueue(1);
+        queue.add(makeElement(10), 0);
+
+        expect(() => queue.add(makeElement(10), 0)).toThrow('EventQueue size exceeded');
+    });
+});

--- a/simulator/src/eventQueue.js
+++ b/simulator/src/eventQueue.js
@@ -16,7 +16,7 @@ export default class EventQueue {
     */
     add(obj, delay) {
         if (obj.queueProperties.inQueue) {
-            obj.queueProperties.time = this.time + (delay || obj.propagationDelay);
+            obj.queueProperties.time = this.time + (delay !== undefined ? delay : obj.propagationDelay);
             let i = obj.queueProperties.index;
             while (i > 0 && obj.queueProperties.time > this.queue[i - 1].queueProperties.time) {
                 this.swap(i, i - 1);
@@ -33,7 +33,7 @@ export default class EventQueue {
         if (this.frontIndex == this.size) throw 'EventQueue size exceeded';
         this.queue[this.frontIndex] = obj;
         // obj.queueProperties.time=obj.propagationDelay;
-        obj.queueProperties.time = this.time + (delay || obj.propagationDelay);
+        obj.queueProperties.time = this.time + (delay !== undefined ? delay : obj.propagationDelay);
         obj.queueProperties.index = this.frontIndex;
         this.frontIndex++;
         obj.queueProperties.inQueue = true;


### PR DESCRIPTION
Fixes #7802

#### Describe the changes you have made in this PR -
- Fixed `EventQueue.add(obj, delay)` in `simulator/src/eventQueue.js` (lines 19 and 36) to check `delay !== undefined ? delay : obj.propagationDelay` instead of `delay || obj.propagationDelay`. This ensures an explicitly passed `delay = 0` (such as in `Scope.addInputs()`) is honored instead of incorrectly falling back to `obj.propagationDelay`.
- Added a comprehensive unit test suite in `simulator/spec/eventQueue.spec.js` covering explicit `delay = 0` scheduling, fallback to `propagationDelay` when `delay` is omitted, explicit non-zero delays, re-scheduling of queued elements, ascending time order on `pop()`, `time` advancement, `reset()`, and queue capacity limits.

### Screenshots of the UI changes (If any) -
_No response_

---

## Code Understanding and AI Usage

**Did you use AI generated code (ChatGPT, Claude, Copilot, etc.) in any part of this PR? **
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
- **Problem**: In JavaScript, `0` is falsy. When `Scope.addInputs()` calls `EventQueue.add(elem, 0)` at the start of each simulation cycle, `(delay || obj.propagationDelay)` evaluated `0` as falsy and fell back to `obj.propagationDelay` for elements with a non-zero default (e.g. flip-flops, latches, buffers, counters), causing them to be scheduled at `time = 10` instead of `time = 0`.
- **Solution**: Check `delay !== undefined` explicitly so `delay = 0` schedules immediately at `this.time + 0`, while omitted delays correctly default to `obj.propagationDelay`.
- **Testing**: Added unit tests in `simulator/spec/eventQueue.spec.js` verifying immediate scheduling at `time = 0` for elements with non-zero propagation delay, proper fallback when `delay` is omitted, priority ordering, and queue resets.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
