### PR TITLE
fix(simulator): honor explicit delay=0 in EventQueue.add (#7802)

### DIFF
--- a/simulator/spec/eventQueue.spec.js
+++ b/simulator/spec/eventQueue.spec.js
@@ -1,0 +1,41 @@
+import EventQueue from '../src/eventQueue';
+
+describe('EventQueue', () => {
+    test('schedules at delay=0 when delay is explicitly 0', () => {
+        const queue = new EventQueue(10);
+        const obj = {
+            propagationDelay: 10,
+            queueProperties: { inQueue: false }
+        };
+
+        queue.add(obj, 0);
+
+        expect(obj.queueProperties.time).toBe(0);
+    });
+
+    test('falls back to propagationDelay when delay is undefined', () => {
+        const queue = new EventQueue(10);
+        const obj = {
+            propagationDelay: 10,
+            queueProperties: { inQueue: false }
+        };
+
+        queue.add(obj);
+
+        expect(obj.queueProperties.time).toBe(10);
+    });
+
+    test('re-schedules an already queued object with explicit delay=0', () => {
+        const queue = new EventQueue(10);
+        const obj = {
+            propagationDelay: 10,
+            queueProperties: { inQueue: false }
+        };
+
+        queue.add(obj);
+        expect(obj.queueProperties.time).toBe(10);
+
+        queue.add(obj, 0);
+        expect(obj.queueProperties.time).toBe(0);
+    });
+});

--- a/simulator/src/eventQueue.js
+++ b/simulator/src/eventQueue.js
@@ -16,7 +16,7 @@ export default class EventQueue {
     */
     add(obj, delay) {
         if (obj.queueProperties.inQueue) {
-            obj.queueProperties.time = this.time + (delay || obj.propagationDelay);
+            obj.queueProperties.time = this.time + (delay !== undefined ? delay : obj.propagationDelay);
             let i = obj.queueProperties.index;
             while (i > 0 && obj.queueProperties.time > this.queue[i - 1].queueProperties.time) {
                 this.swap(i, i - 1);
@@ -33,7 +33,7 @@ export default class EventQueue {
         if (this.frontIndex == this.size) throw 'EventQueue size exceeded';
         this.queue[this.frontIndex] = obj;
         // obj.queueProperties.time=obj.propagationDelay;
-        obj.queueProperties.time = this.time + (delay || obj.propagationDelay);
+        obj.queueProperties.time = this.time + (delay !== undefined ? delay : obj.propagationDelay);
         obj.queueProperties.index = this.frontIndex;
         this.frontIndex++;
         obj.queueProperties.inQueue = true;


### PR DESCRIPTION
### Summary of Changes

Fixes #7802 where `EventQueue.add(obj, delay)` discarded explicit `delay = 0` ("schedule immediately") and fell back to `obj.propagationDelay` because `(delay || obj.propagationDelay)` evaluated `0` as falsy.

#### Changes made:
- **`simulator/src/eventQueue.js`**:
  - Updated `add()` (lines 19 and 36) to check `delay !== undefined ? delay : obj.propagationDelay`, correctly preserving explicit `delay = 0`.
- **`simulator/spec/eventQueue.spec.js`**:
  - Added unit test suite for `EventQueue` asserting immediate `delay = 0` scheduling, fallback to `propagationDelay` when omitted, and re-scheduling of queued elements.

### Related Issue

- Fixes #7802

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Event scheduling now honors an explicitly specified zero delay.
  * Rescheduling events with zero delay behaves consistently, including for events already in the queue.

* **Tests**
  * Added coverage for zero-delay scheduling, default propagation delays, and rescheduling queued events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->