### PR TITLE
fix: handle Oj::ParseError from invalid escape sequences in sanitize_…

### DIFF
--- a/app/helpers/simulator_helper.rb
+++ b/app/helpers/simulator_helper.rb
@@ -35,9 +35,11 @@ module SimulatorHelper
     data = data.to_json if data.is_a?(ActionController::Parameters)
     return data if project&.assignment_id.blank? || data.blank?
 
-    data = Oj.safe_load(data)
-    saved_restricted_elements = Oj.safe_load(project.assignment.restrictions)
-    scopes = data["scopes"] || []
+    parsed_data = safe_parse_json(data)
+    return data if parsed_data.nil?
+
+    saved_restricted_elements = safe_parse_json(project.assignment.restrictions) || []
+    scopes = parsed_data["scopes"] || []
 
     parsed_scopes = scopes.each_with_object([]) do |scope, new_scopes|
       restricted_elements_used = []
@@ -50,7 +52,33 @@ module SimulatorHelper
       new_scopes.push(scope)
     end
 
-    data["scopes"] = parsed_scopes
-    data.to_json
+    parsed_data["scopes"] = parsed_scopes
+    parsed_data.to_json
   end
+
+  private
+
+    # Attempts to parse a JSON string using Oj first, falling back to the
+    # standard JSON library. Returns nil (and logs a warning) if both fail,
+    # so callers can return the raw data unmodified rather than raising.
+    def safe_parse_json(json_string)
+      sanitized = sanitize_json_string(json_string.to_s)
+      Oj.safe_load(sanitized)
+    rescue Oj::ParseError, Oj::Error
+      begin
+        JSON.parse(sanitized)
+      rescue JSON::ParserError => e
+        Rails.logger.warn("[SimulatorHelper] Could not parse JSON: #{e.message.truncate(200)}")
+        nil
+      end
+    end
+
+    # Replaces invalid JSON escape sequences (backslash not followed by a
+    # recognised escape character) with an escaped backslash so that
+    # downstream JSON parsers do not reject the payload.
+    # Valid single-char escapes: \" \\ \/ \b \f \n \r \t
+    # Valid Unicode escapes:     \uXXXX
+    def sanitize_json_string(str)
+      str.gsub(/\\(?!["\\/bfnrtu]|u[0-9a-fA-F]{4})/, "\\\\\\\\")
+    end
 end

--- a/spec/helpers/simulator_helper_spec.rb
+++ b/spec/helpers/simulator_helper_spec.rb
@@ -91,5 +91,20 @@ describe SimulatorHelper do
       expect(JSON.parse(sanitized_data)["scopes"][0]["restrictedCircuitElementsUsed"])
         .to eq(["Element"])
     end
+
+    it "returns raw data without raising when the JSON contains an invalid escape sequence" do
+      # Simulate a label like "C:\path" which produces \p — an invalid JSON escape.
+      invalid_json = '{"scopes":[{"Element":[{"label":"C:\\path\\to\\nowhere"}]}]}'
+      expect { sanitize_data(@project, invalid_json) }.not_to raise_error
+      result = sanitize_data(@project, invalid_json)
+      # Should return a string (either re-serialised or the raw payload), never nil/exception.
+      expect(result).to be_a(String)
+    end
+
+    it "returns raw data without raising when given completely malformed JSON" do
+      malformed = "not json at all }{{"
+      expect { sanitize_data(@project, malformed) }.not_to raise_error
+      expect(sanitize_data(@project, malformed)).to eq(malformed)
+    end
   end
 end


### PR DESCRIPTION
## PR Title
fix: handle Oj::ParseError from invalid escape sequences in sanitize_data

## PR Description

Fixes # (Add issue number here) 

#### Describe the changes you have made in this PR -
Sentry issue [CIRCUITVERSE-CORE-153](https://circuitverse.sentry.io/issues/143324357/): `Oj.safe_load` raised an `Oj::ParseError` when a circuit JSON payload contained invalid escape sequences (e.g. `\p`, `\a`) inside user-authored text labels such as `scopes[1].Text[0].label`. There was no error handling around the call, causing a 500 error for the user and preventing their circuit from saving.

This PR implements a two-layer fix:
1. `sanitize_json_string`: pre-sanitizes the raw JSON string by replacing backslashes not followed by a recognized JSON escape character with an escaped backslash (`\\`) so the payload is well-formed before parsing.
2. `safe_parse_json`: tries `Oj.safe_load`, falls back to `JSON.parse` on `Oj::ParseError`/`Oj::Error`, and returns `nil` (with a `Rails.logger.warn`) if both fail. This allows `sanitize_data` to return the raw data unmodified rather than raising an unhandled exception, ensuring no circuit data is lost.

Additionally, two new test cases have been added to `simulator_helper_spec.rb` to cover the invalid-escape and completely-malformed-JSON code paths.

### Screenshots of the UI changes (If any) -
<!-- Do not add code diff here -->
*N/A - Backend error handling fix only.*

---

## Code Understanding and AI Usage

**Did you use AI generated code (ChatGPT, Claude, Copilot, etc.) in any part of this PR? **
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
- **What problem does your code solve?** It resolves a 500 error caused by users entering invalid JSON escape sequences (like Windows file paths) into circuit text labels, which strict JSON parsers like `Oj` reject.
- **What alternative approaches did you consider?** We could have simply rescued `Oj::ParseError` and returned the raw string. However, this would mean circuits with simple stray backslashes would bypass the restricted elements check entirely.
- **Why did you choose this specific implementation?** By pre-sanitizing the string with a regex to escape stray backslashes, we salvage the JSON payload so the restricted elements logic can still process it. The fallback to `JSON.parse` acts as an extra safety net, and returning the unmodified string as a final resort ensures we never lose user data just because of a backend parsing issue.
- **What are the key functions/components and what do they do?** 
  - `sanitize_json_string`: A regex-based string replacer that fixes invalid escapes.
  - `safe_parse_json`: A wrapper around `Oj.safe_load` and `JSON.parse` that handles exceptions gracefully.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed or invalid JSON data.
  * Invalid escape sequences are sanitized instead of causing failures.
  * Completely malformed payloads are preserved and returned without raising errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->