### PR TITLE
refactor(organizations): identify organizations by uuid instead of slug

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -157,7 +157,7 @@ class AssignmentsController < ApplicationController
     def set_group
       @group =
         if params[:organization_id].present?
-          Organization.friendly.find(params.expect(:organization_id)).groups.find(params.expect(:group_id))
+          Organization.find_by!(uuid: params.expect(:organization_id)).groups.find(params.expect(:group_id))
         else
           Group.find(params.expect(:group_id))
         end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -110,7 +110,7 @@ class GroupsController < ApplicationController
     def set_group
       @group =
         if params[:organization_id].present?
-          Organization.friendly.find(params.expect(:organization_id)).groups.find(params.expect(:id))
+          Organization.find_by!(uuid: params.expect(:organization_id)).groups.find(params.expect(:id))
         else
           Group.find(params.expect(:id))
         end
@@ -144,7 +144,7 @@ class GroupsController < ApplicationController
     def organization_from_params
       return if params[:organization_id].blank?
 
-      Organization.friendly.find(params.expect(:organization_id))
+      Organization.find_by!(uuid: params.expect(:organization_id))
     end
 
     def join_group_and_organization

--- a/app/controllers/organization_members_controller.rb
+++ b/app/controllers/organization_members_controller.rb
@@ -77,7 +77,7 @@ class OrganizationMembersController < ApplicationController
   private
 
     def set_organization
-      @organization = Organization.friendly.find(params.expect(:organization_id))
+      @organization = Organization.find_by!(uuid: params.expect(:organization_id))
     end
 
     def set_organization_member

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -63,14 +63,6 @@ class OrganizationsController < ApplicationController
     @organization = Organization.new
   end
 
-  # GET /organizations/check_slug
-  def check_slug
-    base_slug = (params[:slug].presence || params[:name]).to_s.strip.parameterize
-    is_taken = base_slug.present? && Organization.exists?(slug: base_slug)
-
-    render json: { slug: base_slug, available: base_slug.present? && !is_taken }
-  end
-
   # POST /organizations
   def create
     @organization = Organization.new(organization_params)
@@ -120,7 +112,7 @@ class OrganizationsController < ApplicationController
   private
 
     def set_organization
-      @organization = Organization.friendly.find(params.expect(:id))
+      @organization = Organization.find_by!(uuid: params.expect(:id))
     end
 
     def visible_groups
@@ -135,7 +127,7 @@ class OrganizationsController < ApplicationController
     end
 
     def organization_params
-      params.expect(organization: [:name, :slug, :description, :location, :logo, :remove_logo, { links: [] }])
+      params.expect(organization: [:name, :description, :location, :logo, :remove_logo, { links: [] }])
     end
 
     def check_organizations_feature_flag

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -2,9 +2,6 @@
 
 class Organization < ApplicationRecord
   MAX_LINKS = 5
-  extend FriendlyId
-
-  friendly_id :name, use: :slugged
 
   has_many :organization_members, dependent: :destroy
   has_many :users, through: :organization_members
@@ -18,7 +15,6 @@ class Organization < ApplicationRecord
   before_validation :sanitize_links
 
   validates :name, presence: true, uniqueness: { case_sensitive: false }, length: { minimum: 2, maximum: 50 }
-  validates :slug, presence: true, uniqueness: { case_sensitive: false }
   validates :location, length: { maximum: 50 }, allow_blank: true
   validates :description, length: { maximum: 350 }, allow_blank: true
   validate :links_count_within_limit
@@ -26,6 +22,10 @@ class Organization < ApplicationRecord
   validate :logo_must_be_valid_image
 
   before_destroy :purge_logo
+
+  def to_param
+    uuid
+  end
 
   private
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,9 +31,6 @@ Rails.application.routes.draw do
       get :members
       get :settings
     end
-    collection do
-      get :check_slug
-    end
     resources :organization_members, only: %i[create update destroy]
     delete :leave, to: "organization_members#leave"
     resources :groups, only: %i[index new create show edit update destroy] do

--- a/db/migrate/20260826095711_add_uuid_to_organizations.rb
+++ b/db/migrate/20260826095711_add_uuid_to_organizations.rb
@@ -1,0 +1,8 @@
+class AddUuidToOrganizations < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_column :organizations, :uuid, :uuid, default: -> { "gen_random_uuid()" }, null: false
+    add_index :organizations, :uuid, unique: true, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20260826101823_remove_slug_from_organizations.rb
+++ b/db/migrate/20260826101823_remove_slug_from_organizations.rb
@@ -1,9 +1,13 @@
 class RemoveSlugFromOrganizations < ActiveRecord::Migration[8.1]
-  def change
+  def up
     safety_assured do
       remove_index :organizations, name: "index_organizations_on_slug"
       remove_check_constraint :organizations, name: "organizations_slug_not_blank"
-      remove_column :organizations, :slug, :string, null: false
+      remove_column :organizations, :slug
     end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, "Slug data cannot be restored once removed"
   end
 end

--- a/db/migrate/20260826101823_remove_slug_from_organizations.rb
+++ b/db/migrate/20260826101823_remove_slug_from_organizations.rb
@@ -1,0 +1,9 @@
+class RemoveSlugFromOrganizations < ActiveRecord::Migration[8.1]
+  def change
+    safety_assured do
+      remove_index :organizations, name: "index_organizations_on_slug"
+      remove_check_constraint :organizations, name: "organizations_slug_not_blank"
+      remove_column :organizations, :slug, :string, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_21_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_26_101823) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -396,7 +396,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_21_000000) do
 
   create_table "organizations", force: :cascade do |t|
     t.string "name", null: false
-    t.string "slug", null: false
+    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.text "description"
     t.string "location"
     t.jsonb "links", default: []
@@ -407,9 +407,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_21_000000) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index "lower((name)::text)", name: "index_organizations_on_lower_name_unique", unique: true
-    t.index ["slug"], name: "index_organizations_on_slug", unique: true
+    t.index ["uuid"], name: "index_organizations_on_uuid", unique: true
     t.check_constraint "char_length(TRIM(BOTH FROM name)) > 0", name: "organizations_name_not_blank"
-    t.check_constraint "char_length(TRIM(BOTH FROM slug)) > 0", name: "organizations_slug_not_blank"
     t.check_constraint "jsonb_array_length(links) <= 5", name: "organizations_links_max_5"
   end
 

--- a/spec/components/previews/organization_card_component_preview.rb
+++ b/spec/components/previews/organization_card_component_preview.rb
@@ -14,7 +14,6 @@ class OrganizationCardComponentPreview < ViewComponent::Preview
     def sample_organization
       org = Organization.new(
         name: "CircuitVerse Community",
-        slug: "circuitverse-community",
         location: "Bengaluru, India",
         description: "A community platform for designing and simulating digital logic circuits."
       )
@@ -24,7 +23,7 @@ class OrganizationCardComponentPreview < ViewComponent::Preview
     end
 
     def minimal_organization
-      org = Organization.new(name: "CircuitVerse Community", slug: "circuitverse-community")
+      org = Organization.new(name: "CircuitVerse Community")
       def org.members_count = 3
       def org.to_param = "circuitverse-community"
       org

--- a/spec/components/previews/organization_dashboard_shell_component_preview.rb
+++ b/spec/components/previews/organization_dashboard_shell_component_preview.rb
@@ -14,7 +14,7 @@ class OrganizationDashboardShellComponentPreview < ViewComponent::Preview
     def render_shell(active_tab:, show_settings_tab:)
       organization = Organization.new(
         name: "CircuitVerse Community",
-        slug: "circuitverse-community"
+        uuid: SecureRandom.uuid
       )
       render(OrganizationDashboardShellComponent.new(
                organization: organization,

--- a/spec/components/previews/organization_form_component_preview.rb
+++ b/spec/components/previews/organization_form_component_preview.rb
@@ -4,7 +4,6 @@ class OrganizationFormComponentPreview < ViewComponent::Preview
   def default
     organization = Organization.new(
       name: "CircuitVerse Community",
-      slug: "circuitverse-community",
       description: "A community platform for designing and simulating digital logic circuits.",
       location: "Bengaluru, India",
       links: [

--- a/spec/controllers/organization_members_controller_spec.rb
+++ b/spec/controllers/organization_members_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe OrganizationMembersController, type: :controller do
     end
 
     it "redirects to root" do
-      get :create, params: { organization_id: organization.id }
+      get :create, params: { organization_id: organization.to_param }
       expect(response).to redirect_to(root_path)
     end
   end
@@ -30,7 +30,7 @@ RSpec.describe OrganizationMembersController, type: :controller do
     end
 
     it "redirects to login" do
-      get :create, params: { organization_id: organization.id }
+      get :create, params: { organization_id: organization.to_param }
       expect(response).to redirect_to(new_user_session_path)
     end
   end
@@ -40,7 +40,7 @@ RSpec.describe OrganizationMembersController, type: :controller do
       it "adds an existing user as a member with the chosen role" do
         expect do
           post :create, params: {
-            organization_id: organization.id,
+            organization_id: organization.to_param,
             organization_member: { role: "mentor", emails: [target_user.email] }
           }
         end.to change(OrganizationMember, :count).by(1)
@@ -50,7 +50,7 @@ RSpec.describe OrganizationMembersController, type: :controller do
       it "creates a pending invitation for an email with no account" do
         expect do
           post :create, params: {
-            organization_id: organization.id,
+            organization_id: organization.to_param,
             organization_member: { role: "member", emails: ["newperson@example.com"] }
           }
         end.to change(PendingInvitation, :count).by(1)
@@ -58,7 +58,7 @@ RSpec.describe OrganizationMembersController, type: :controller do
 
       it "redirects to the members page" do
         post :create, params: {
-          organization_id: organization.id,
+          organization_id: organization.to_param,
           organization_member: { role: "member", emails: [target_user.email] }
         }
         expect(response).to redirect_to(members_organization_path(organization))
@@ -75,7 +75,7 @@ RSpec.describe OrganizationMembersController, type: :controller do
 
       it "returns a forbidden status" do
         post :create,
-             params: { organization_id: organization.id,
+             params: { organization_id: organization.to_param,
                        organization_member: { role: "member", emails: [target_user.email] } }
         expect(response).to have_http_status(:forbidden)
       end
@@ -90,14 +90,14 @@ RSpec.describe OrganizationMembersController, type: :controller do
 
       it "updates the requested member" do
         patch :update,
-              params: { organization_id: organization.id, id: target_member.id, organization_member: new_attributes }
+              params: { organization_id: organization.to_param, id: target_member.id, organization_member: new_attributes }
         target_member.reload
         expect(target_member.role).to eq("mentor")
       end
 
       it "redirects to the organization" do
         patch :update,
-              params: { organization_id: organization.id, id: target_member.id, organization_member: new_attributes }
+              params: { organization_id: organization.to_param, id: target_member.id, organization_member: new_attributes }
         expect(response).to redirect_to(organization)
       end
 
@@ -110,7 +110,7 @@ RSpec.describe OrganizationMembersController, type: :controller do
         sign_in target_user
 
         patch :update,
-              params: { organization_id: organization.id, id: target_member.id,
+              params: { organization_id: organization.to_param, id: target_member.id,
                         organization_member: { role: "member" } }
         expect(response).to have_http_status(:forbidden)
       end
@@ -123,12 +123,12 @@ RSpec.describe OrganizationMembersController, type: :controller do
     context "when user has admin access" do
       it "destroys the requested member" do
         expect do
-          delete :destroy, params: { organization_id: organization.id, id: target_member.id }
+          delete :destroy, params: { organization_id: organization.to_param, id: target_member.id }
         end.to change(OrganizationMember, :count).by(-1)
       end
 
       it "redirects to the organization" do
-        delete :destroy, params: { organization_id: organization.id, id: target_member.id }
+        delete :destroy, params: { organization_id: organization.to_param, id: target_member.id }
         expect(response).to redirect_to(organization)
       end
     end
@@ -141,7 +141,7 @@ RSpec.describe OrganizationMembersController, type: :controller do
       end
 
       it "returns a forbidden status" do
-        delete :destroy, params: { organization_id: organization.id, id: target_member.id }
+        delete :destroy, params: { organization_id: organization.to_param, id: target_member.id }
         expect(response).to have_http_status(:forbidden)
       end
     end
@@ -158,19 +158,19 @@ RSpec.describe OrganizationMembersController, type: :controller do
 
       it "destroys their own membership" do
         expect do
-          delete :leave, params: { organization_id: organization.id }
+          delete :leave, params: { organization_id: organization.to_param }
         end.to change(OrganizationMember, :count).by(-1)
       end
 
       it "redirects to organizations list" do
-        delete :leave, params: { organization_id: organization.id }
+        delete :leave, params: { organization_id: organization.to_param }
         expect(response).to redirect_to(organizations_path)
       end
     end
 
     context "when user is the sole admin" do
       it "returns a forbidden status" do
-        delete :leave, params: { organization_id: organization.id }
+        delete :leave, params: { organization_id: organization.to_param }
         expect(response).to have_http_status(:forbidden)
       end
     end

--- a/spec/controllers/organization_members_controller_spec.rb
+++ b/spec/controllers/organization_members_controller_spec.rb
@@ -90,14 +90,16 @@ RSpec.describe OrganizationMembersController, type: :controller do
 
       it "updates the requested member" do
         patch :update,
-              params: { organization_id: organization.to_param, id: target_member.id, organization_member: new_attributes }
+              params: { organization_id: organization.to_param, id: target_member.id,
+                        organization_member: new_attributes }
         target_member.reload
         expect(target_member.role).to eq("mentor")
       end
 
       it "redirects to the organization" do
         patch :update,
-              params: { organization_id: organization.to_param, id: target_member.id, organization_member: new_attributes }
+              params: { organization_id: organization.to_param, id: target_member.id,
+                        organization_member: new_attributes }
         expect(response).to redirect_to(organization)
       end
 

--- a/spec/controllers/organizations_controller_spec.rb
+++ b/spec/controllers/organizations_controller_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe OrganizationsController, type: :controller do
       end
 
       it "redirects to the overview tab" do
-        get :show, params: { id: organization.id }
+        get :show, params: { id: organization.to_param }
         expect(response).to redirect_to(overview_organization_path(organization))
       end
     end
@@ -61,7 +61,7 @@ RSpec.describe OrganizationsController, type: :controller do
     context "when user does not have show access" do
       it "raises a not found error" do
         expect do
-          get :show, params: { id: organization.id }
+          get :show, params: { id: organization.to_param }
         end.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
@@ -78,7 +78,7 @@ RSpec.describe OrganizationsController, type: :controller do
       end
 
       it "shows all groups in the organization" do
-        get :overview, params: { id: organization.id }
+        get :overview, params: { id: organization.to_param }
         visible = controller.instance_variable_get(:@groups)
         expect(visible).to include(group_user_is_in, other_group)
       end
@@ -91,7 +91,7 @@ RSpec.describe OrganizationsController, type: :controller do
       end
 
       it "shows only the groups the user belongs to" do
-        get :overview, params: { id: organization.id }
+        get :overview, params: { id: organization.to_param }
         visible = controller.instance_variable_get(:@groups)
         expect(visible).to include(group_user_is_in)
         expect(visible).not_to include(other_group)
@@ -106,7 +106,7 @@ RSpec.describe OrganizationsController, type: :controller do
       end
 
       it "shows groups they own but not groups they are not part of" do
-        get :overview, params: { id: organization.id }
+        get :overview, params: { id: organization.to_param }
         visible = controller.instance_variable_get(:@groups)
         expect(visible).to include(owned_group)
         expect(visible).not_to include(other_group)
@@ -128,7 +128,7 @@ RSpec.describe OrganizationsController, type: :controller do
       end
 
       it "returns a success response" do
-        get :settings, params: { id: organization.id }
+        get :settings, params: { id: organization.to_param }
         expect(response).to be_successful
       end
     end
@@ -176,13 +176,13 @@ RSpec.describe OrganizationsController, type: :controller do
         let(:new_attributes) { { name: "Updated Org" } }
 
         it "updates the requested organization" do
-          patch :update, params: { id: organization.id, organization: new_attributes }
+          patch :update, params: { id: organization.to_param, organization: new_attributes }
           organization.reload
           expect(organization.name).to eq("Updated Org")
         end
 
         it "redirects to the organization" do
-          patch :update, params: { id: organization.id, organization: new_attributes }
+          patch :update, params: { id: organization.to_param, organization: new_attributes }
           expect(response).to redirect_to(overview_organization_path(organization))
         end
       end
@@ -198,12 +198,12 @@ RSpec.describe OrganizationsController, type: :controller do
       context "when confirmation matches the organization name" do
         it "destroys the requested organization" do
           expect do
-            delete :destroy, params: { id: organization.id, confirmation: organization.name }
+            delete :destroy, params: { id: organization.to_param, confirmation: organization.name }
           end.to change(Organization, :count).by(-1)
         end
 
         it "redirects to the organizations list" do
-          delete :destroy, params: { id: organization.id, confirmation: organization.name }
+          delete :destroy, params: { id: organization.to_param, confirmation: organization.name }
           expect(response).to redirect_to(organizations_path)
         end
       end
@@ -211,12 +211,12 @@ RSpec.describe OrganizationsController, type: :controller do
       context "when confirmation does not match the organization name" do
         it "does not destroy the organization" do
           expect do
-            delete :destroy, params: { id: organization.id, confirmation: "wrong name" }
+            delete :destroy, params: { id: organization.to_param, confirmation: "wrong name" }
           end.not_to change(Organization, :count)
         end
 
         it "redirects back to the settings page" do
-          delete :destroy, params: { id: organization.id, confirmation: "wrong name" }
+          delete :destroy, params: { id: organization.to_param, confirmation: "wrong name" }
           expect(response).to redirect_to(settings_organization_path(organization))
         end
       end
@@ -224,7 +224,7 @@ RSpec.describe OrganizationsController, type: :controller do
       context "when confirmation is missing" do
         it "does not destroy the organization" do
           expect do
-            delete :destroy, params: { id: organization.id }
+            delete :destroy, params: { id: organization.to_param }
           end.not_to change(Organization, :count)
         end
       end
@@ -232,7 +232,7 @@ RSpec.describe OrganizationsController, type: :controller do
       context "when confirmation does not match (JSON)" do
         it "returns an unprocessable_content error" do
           expect do
-            delete :destroy, params: { id: organization.id, confirmation: "wrong" }, format: :json
+            delete :destroy, params: { id: organization.to_param, confirmation: "wrong" }, format: :json
           end.not_to change(Organization, :count)
 
           expect(response).to have_http_status(:unprocessable_content)

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe Organization, type: :model do
 
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_uniqueness_of(:name).case_insensitive }
-    it { is_expected.to validate_uniqueness_of(:slug).case_insensitive }
 
     describe "links count" do
       it "is valid with 5 or fewer links" do
@@ -58,17 +57,21 @@ RSpec.describe Organization, type: :model do
     end
   end
 
-  describe "slug generation" do
-    it "automatically generates a slug from the name" do
-      org = FactoryBot.create(:organization, name: "My Test Org")
-      expect(org.slug).to be_present
-      expect(org.slug).to eq("my-test-org")
+  describe "uuid" do
+    it "generates a uuid on creation" do
+      org = FactoryBot.create(:organization)
+      expect(org.uuid).to be_present
     end
 
-    it "generates a unique slug when names would collide" do
-      org1 = FactoryBot.create(:organization, name: "Collision Org")
-      org2 = FactoryBot.create(:organization, name: "Collision Org 2")
-      expect(org1.slug).not_to eq(org2.slug)
+    it "generates a distinct uuid per organization" do
+      org1 = FactoryBot.create(:organization)
+      org2 = FactoryBot.create(:organization)
+      expect(org1.uuid).not_to eq(org2.uuid)
+    end
+
+    it "uses the uuid as the route parameter" do
+      org = FactoryBot.create(:organization)
+      expect(org.to_param).to eq(org.uuid)
     end
   end
 


### PR DESCRIPTION
Fixes #7808

#### Describe the changes you have made in this PR -

Organizations are now identified by a UUID in URLs instead of a FriendlyId slug.

- Added a `uuid` column with a `gen_random_uuid()` default and a unique index, so existing rows backfill automatically
- Removed FriendlyId from the `Organization` model and added `to_param` returning the uuid
- Updated the five `Organization.friendly.find` lookups to `find_by!(uuid: ...)`
- Dropped the `slug` column, its index, and its check constraint
- Removed the unused `check_slug` action and route
- Updated specs to pass `to_param` instead of `organization.id`

### Screenshots of the UI changes (If any) -
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI generated code (ChatGPT, Claude, Copilot, etc.) in any part of this PR? **
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Rails calls `to_param` whenever a model is passed to a path helper, so overriding that one method to return the uuid updates every `organization_path` call automatically. That is why there are almost no view changes: only the five controller lookups that resolve an organization from params needed editing.

I planned to split this into two PRs, adding the uuid first and dropping the slug later, but that does not work. The `slug` column is `NOT NULL` with a check constraint, so the moment FriendlyId stops generating slugs, every organization creation fails at the database level. Both changes have to ship together.

`check_slug` was removed rather than ported. Nothing in any view, component, or JS file called it.

The controller specs previously passed `organization.id`, which worked because `friendly.find` accepts a slug or a numeric id. `find_by!(uuid:)` matches neither, so I switched them to `to_param`. I also verified the full flow in the browser: organization pages, nested groups and assignments, invitations, and settings all resolve, and old slug URLs return a clean 404.


---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organizations now use automatically generated, unique UUIDs for URLs and identification.
  * Organization links and routes consistently use UUIDs instead of name-based slugs.

* **Changes**
  * Removed organization slug fields and validation.
  * Removed slug availability checking.
  * Organization lookup now uses UUIDs, while existing links and requests use the updated format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->