### PR TITLE
fix(controller): enforce authentication before group member lookup and authorization (#7816)

### DIFF
--- a/app/controllers/group_members_controller.rb
+++ b/app/controllers/group_members_controller.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class GroupMembersController < ApplicationController
+  before_action :authenticate_user!
   before_action :set_group_member, only: %i[update destroy]
   before_action :check_access, only: %i[update destroy]
-  before_action :authenticate_user!
 
   # GET /group_members
   # GET /group_members.json

--- a/spec/controllers/group_members_controller_spec.rb
+++ b/spec/controllers/group_members_controller_spec.rb
@@ -81,6 +81,13 @@ describe GroupMembersController, type: :request do
         check_not_authorized(response)
       end
     end
+
+    context "when unauthenticated user attempts to update" do
+      it "redirects to sign in page" do
+        patch group_member_path(@group_member), params: { group_member: { mentor: true } }
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
   end
 
   describe "#destroy" do
@@ -111,6 +118,13 @@ describe GroupMembersController, type: :request do
         sign_in_random_user
         delete group_member_path(@group_member)
         check_not_authorized(response)
+      end
+    end
+
+    context "when unauthenticated user attempts to destroy" do
+      it "redirects to sign in page" do
+        delete group_member_path(@group_member)
+        expect(response).to redirect_to(new_user_session_path)
       end
     end
   end


### PR DESCRIPTION
### Summary of Changes

Fixes #7816 where `GroupMembersController` executed `set_group_member` and `check_access` (Pundit authorization check with `current_user = nil`) before `authenticate_user!`, bypassing Devise's redirect-to-login flow for unauthenticated `update` and `destroy` actions.

#### Changes made:
- **`app/controllers/group_members_controller.rb`**: Placed `before_action :authenticate_user!` before `set_group_member` and `check_access` so unauthenticated requests are intercepted and redirected before any database lookups or authorization evaluations occur.
- **`spec/controllers/group_members_controller_spec.rb`**: Added request test contexts asserting that unauthenticated requests to `#update` and `#destroy` redirect to the sign in page.

### Related Issue

- Fixes #7816

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unauthenticated attempts to update or remove group members now redirect to the sign-in page.
  * Authentication is checked before access permissions for improved request handling.

* **Tests**
  * Added coverage for unauthenticated group member update and removal requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->