### PR TITLE
fix(groups): increase member and mentor email input maxlength to 50 (#7819)

### DIFF
--- a/app/javascript/controllers/groups_controller.js
+++ b/app/javascript/controllers/groups_controller.js
@@ -59,7 +59,7 @@ export default class extends Controller {
             multiple: true,
             tokenSeparators: [',', ' '],
         });
-        $('.select2-selection input').attr('maxlength', '30');
+        $('.select2-selection input').attr('maxlength', '50');
         $('.select2-selection input').attr('id', 'group_email_input_mentor');
         this.toggleButtonBasedOnEmails('#group_mentor_emails', '#add-mentor-button');
         $('.select2-selection input').attr('data-action', 'paste->groups#mentorInputPaste');
@@ -74,7 +74,7 @@ export default class extends Controller {
             multiple: true,
             tokenSeparators: [',', ' '],
         });
-        $('.select2-selection input').attr('maxlength', '30');
+        $('.select2-selection input').attr('maxlength', '50');
         $('.select2-selection input').attr('id', 'group_email_input');
         this.toggleButtonBasedOnEmails('#group_member_emails', '#add-members-button');
         $('#group_member_emails').on('select2:select select2:unselect', () => {


### PR DESCRIPTION
### Summary of Changes

Fixes #7819 where the select2 input field for adding group members and mentors truncated user input at 30 characters (`maxlength = 30`), preventing users from entering longer email addresses (such as institutional and university email addresses).

#### Changes made:
- **`app/javascript/controllers/groups_controller.js`**: Increased `maxlength` from `30` to `50` on the select2 input field in both `addMentorToGroup()` and `addMemberToGroup()`.

### Related Issue

- Fixes #7819

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the email search limit in mentor and member selectors, allowing searches with email addresses up to 50 characters long.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->