### PR TITLE
fix(controller): authenticate and authorize before database lookup in view_issue_circuit_data (#7817)

### DIFF
--- a/app/controllers/simulator_controller.rb
+++ b/app/controllers/simulator_controller.rb
@@ -4,7 +4,7 @@ class SimulatorController < ApplicationController
   include SimulatorHelper
   include ActionView::Helpers::SanitizeHelper
 
-  before_action :authenticate_user!, only: %i[create update edit]
+  before_action :authenticate_user!, only: %i[create update edit view_issue_circuit_data]
   before_action :set_project, only: %i[show embed get_data]
   before_action :set_user_project, only: %i[update edit]
   before_action :check_view_access, only: %i[show embed get_data]
@@ -104,11 +104,7 @@ class SimulatorController < ApplicationController
   end
 
   def view_issue_circuit_data
-    unless current_user&.admin?
-      render plain: "Only admins can view issue circuit data", status: :unauthorized
-      return
-    end
-
+    authorize IssueCircuitDatum, :admin?, policy_class: IssueCircuitDatumPolicy
     issue_circuit_data = IssueCircuitDatum.find(params.expect(:id))
     render plain: issue_circuit_data.data
   end

--- a/app/policies/issue_circuit_datum_policy.rb
+++ b/app/policies/issue_circuit_datum_policy.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class IssueCircuitDatumPolicy < ApplicationPolicy
+  attr_reader :user, :issue_circuit_datum
+
+  def initialize(user, issue_circuit_datum)
+    @user = user
+    @issue_circuit_datum = issue_circuit_datum
+  end
+end

--- a/spec/controllers/simulator_controller_spec.rb
+++ b/spec/controllers/simulator_controller_spec.rb
@@ -203,4 +203,40 @@ describe SimulatorController, type: :request do
       end
     end
   end
+
+  describe "#view_issue_circuit_data" do
+    let(:issue_circuit_datum) { IssueCircuitDatum.create!(data: "sample circuit data") }
+
+    context "when user is not signed in" do
+      it "redirects to sign in page" do
+        get "/simulator/issue_circuit_data/#{issue_circuit_datum.id}"
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when signed in user is not admin" do
+      before do
+        sign_in @user
+      end
+
+      it "throws unauthorized error before finding record" do
+        get "/simulator/issue_circuit_data/#{issue_circuit_datum.id}"
+        check_not_authorized(response)
+      end
+    end
+
+    context "when admin user is signed in" do
+      let(:admin_user) { FactoryBot.create(:user, admin: true) }
+
+      before do
+        sign_in admin_user
+      end
+
+      it "renders the issue circuit data" do
+        get "/simulator/issue_circuit_data/#{issue_circuit_datum.id}"
+        expect(response.status).to eq(200)
+        expect(response.body).to eq("sample circuit data")
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Summary of Changes

Fixes #7817 where `SimulatorController#view_issue_circuit_data` performed database lookup (`IssueCircuitDatum.find`) before authentication and Pundit authorization, leaking record existence to unauthenticated and unauthorized callers via distinguishable HTTP response status codes (404 vs 403).

#### Changes made:
- **`app/controllers/simulator_controller.rb`**: Included `view_issue_circuit_data` in `before_action :authenticate_user!` and invoked `authorize IssueCircuitDatum, :admin?, policy_class: IssueCircuitDatumPolicy` before the database lookup.
- **`app/policies/issue_circuit_datum_policy.rb`**: Added `IssueCircuitDatumPolicy` extending `ApplicationPolicy`.
- **`spec/controllers/simulator_controller_spec.rb`**: Added request specs covering unauthenticated redirect, non-admin unauthorized rejection, and admin success.

### Related Issue

- Fixes #7817

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Protected issue circuit data behind sign-in authentication.
  - Restricted access to authorized administrators.
  - Unauthorized access now returns an appropriate error instead of exposing data.

- **Bug Fixes**
  - Improved handling of unauthenticated and unauthorized requests.
  - Authorized administrators can continue viewing stored issue circuit data as expected.

- **Tests**
  - Added coverage for unauthenticated, unauthorized, and authorized access scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->