### PR TITLE
feat: add native Comment and CommentThread models (part 1 of Commontator removal)

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Mirrors Commontator::Comment. Belongs to a thread rather than directly to the
+# commentable, so that thread level state (open/closed, subscriptions) has a
+# home and the existing API shape is preserved.
+class Comment < ApplicationRecord
+  BODY_MAX_LENGTH = 10_000
+
+  belongs_to :comment_thread, inverse_of: :comments
+  belongs_to :user
+  belongs_to :editor, class_name: "User", optional: true
+  belongs_to :parent, class_name: "Comment", optional: true
+
+  has_many :replies, class_name: "Comment",
+                     foreign_key: :parent_id,
+                     inverse_of: :parent,
+                     dependent: :destroy
+
+  validates :body, presence: true, length: { maximum: BODY_MAX_LENGTH }
+  validate :parent_shares_thread
+
+  scope :kept, -> { where(deleted_at: nil) }
+  scope :roots, -> { where(parent_id: nil) }
+  scope :chronological, -> { order(created_at: :asc) }
+
+  def deleted?
+    deleted_at.present?
+  end
+
+  def edited?
+    editor_id.present?
+  end
+
+  def soft_delete!
+    update!(deleted_at: Time.current)
+  end
+
+  def restore!
+    update!(deleted_at: nil)
+  end
+
+  private
+
+    # A reply must live in the same thread as its parent, otherwise a comment
+    # could be threaded onto a discussion it does not belong to.
+    def parent_shares_thread
+      return if parent.nil?
+      return if parent.comment_thread_id == comment_thread_id
+
+      errors.add(:parent, "must belong to the same thread")
+    end
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -18,6 +18,7 @@ class Comment < ApplicationRecord
 
   validates :body, presence: true, length: { maximum: BODY_MAX_LENGTH }
   validate :parent_shares_thread
+  validate :parent_is_not_cyclic
 
   scope :kept, -> { where(deleted_at: nil) }
   scope :roots, -> { where(parent_id: nil) }
@@ -48,5 +49,30 @@ class Comment < ApplicationRecord
       return if parent.comment_thread_id == comment_thread_id
 
       errors.add(:parent, "must belong to the same thread")
+    end
+
+    # Walk up the ancestor chain so a comment cannot be its own parent, nor
+    # part of a reply cycle. Without this, `replies` recurses forever during
+    # dependent: :destroy.
+    def parent_is_not_cyclic
+      return if parent.nil?
+
+      if parent == self
+        errors.add(:parent, "cannot be the comment itself")
+        return
+      end
+
+      # A new record has no id, so nothing can point back at it yet.
+      return if id.nil?
+
+      ancestor = parent
+      while ancestor
+        if ancestor.parent_id == id
+          errors.add(:parent, "cannot create a cycle")
+          return
+        end
+
+        ancestor = ancestor.parent
+      end
     end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -54,6 +54,11 @@ class Comment < ApplicationRecord
     # Walk up the ancestor chain so a comment cannot be its own parent, nor
     # part of a reply cycle. Without this, `replies` recurses forever during
     # dependent: :destroy.
+    #
+    # NOTE: application-level guard only. It does not run for update_column,
+    # insert_all, or raw SQL, and does not protect against concurrent writes.
+    # The invariant must be re-checked wherever rows are written outside the
+    # model, in particular the Commontator data migration.
     def parent_is_not_cyclic
       return if parent.nil?
 

--- a/app/models/comment_thread.rb
+++ b/app/models/comment_thread.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Mirrors Commontator::Thread. One thread per commentable, holding the comments
+# and the open/closed state.
+class CommentThread < ApplicationRecord
+  belongs_to :commentable, polymorphic: true
+  belongs_to :closer, class_name: "User", optional: true
+
+  has_many :comments, dependent: :destroy
+
+  def closed?
+    closed_at.present?
+  end
+
+  def close!(user)
+    update!(closed_at: Time.current, closer: user)
+  end
+
+  def reopen!
+    update!(closed_at: nil, closer: nil)
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -31,7 +31,7 @@ class Project < ApplicationRecord
   has_one :project_datum, dependent: :destroy
   has_many :notifications, as: :notifiable
   has_one :contest_winner, dependent: :destroy
-  has_many :submissions, dependent: :destroy
+  has_one :comment_thread, as: :commentable, dependent: :destroy
 
   scope :public_and_not_forked,
         -> { where(project_access_type: "Public", forked_project_id: nil) }

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -31,6 +31,7 @@ class Project < ApplicationRecord
   has_one :project_datum, dependent: :destroy
   has_many :notifications, as: :notifiable
   has_one :contest_winner, dependent: :destroy
+  has_many :submissions, dependent: :destroy
   has_one :comment_thread, as: :commentable, dependent: :destroy
 
   scope :public_and_not_forked,

--- a/db/migrate/20260901000000_create_comment_tables.rb
+++ b/db/migrate/20260901000000_create_comment_tables.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class CreateCommentTables < ActiveRecord::Migration[8.1]
+  def change
+    create_comment_threads
+    create_comments
+  end
+
+  private
+
+    def create_comment_threads
+      create_table :comment_threads do |t|
+        t.references :commentable, polymorphic: true, null: false, index: false
+        t.datetime :closed_at
+        t.references :closer, null: true, foreign_key: { to_table: :users }
+
+        t.timestamps
+      end
+
+      add_index :comment_threads, %i[commentable_type commentable_id],
+                unique: true,
+                name: "index_comment_threads_on_commentable"
+    end
+
+    def create_comments
+      create_table :comments do |t|
+        t.references :comment_thread, null: false, foreign_key: true, index: false
+        t.references :user, null: false, foreign_key: true
+        t.references :editor, null: true, foreign_key: { to_table: :users }
+        t.references :parent, null: true, foreign_key: { to_table: :comments }
+        t.text :body, null: false
+        t.datetime :deleted_at
+
+        t.timestamps
+      end
+
+      add_index :comments, %i[comment_thread_id created_at]
+      add_index :comments, :deleted_at
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_21_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_01_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -114,6 +114,33 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_21_000000) do
     t.datetime "updated_at", precision: nil, null: false
     t.index ["project_id"], name: "index_collaborations_on_project_id"
     t.index ["user_id"], name: "index_collaborations_on_user_id"
+  end
+
+  create_table "comment_threads", force: :cascade do |t|
+    t.datetime "closed_at"
+    t.bigint "closer_id"
+    t.bigint "commentable_id", null: false
+    t.string "commentable_type", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["closer_id"], name: "index_comment_threads_on_closer_id"
+    t.index ["commentable_type", "commentable_id"], name: "index_comment_threads_on_commentable", unique: true
+  end
+
+  create_table "comments", force: :cascade do |t|
+    t.text "body", null: false
+    t.bigint "comment_thread_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "deleted_at"
+    t.bigint "editor_id"
+    t.bigint "parent_id"
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["comment_thread_id", "created_at"], name: "index_comments_on_comment_thread_id_and_created_at"
+    t.index ["deleted_at"], name: "index_comments_on_deleted_at"
+    t.index ["editor_id"], name: "index_comments_on_editor_id"
+    t.index ["parent_id"], name: "index_comments_on_parent_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "commontator_comments", id: :serial, force: :cascade do |t|
@@ -594,6 +621,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_21_000000) do
   add_foreign_key "assignments", "groups"
   add_foreign_key "collaborations", "projects"
   add_foreign_key "collaborations", "users"
+  add_foreign_key "comment_threads", "users", column: "closer_id"
+  add_foreign_key "comments", "comment_threads"
+  add_foreign_key "comments", "comments", column: "parent_id"
+  add_foreign_key "comments", "users"
+  add_foreign_key "comments", "users", column: "editor_id"
   add_foreign_key "commontator_comments", "commontator_comments", column: "parent_id", on_update: :restrict, on_delete: :cascade
   add_foreign_key "contest_winners", "contests"
   add_foreign_key "contest_winners", "projects"

--- a/spec/factories/comment.rb
+++ b/spec/factories/comment.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :comment_thread do
+    association :commentable, factory: :project
+
+    trait :closed do
+      closed_at { Time.current }
+      association :closer, factory: :user
+    end
+  end
+
+  factory :comment do
+    association :comment_thread
+    association :user
+    body { "A comment body" }
+
+    trait :deleted do
+      deleted_at { Time.current }
+    end
+  end
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -54,6 +54,21 @@ RSpec.describe Comment, type: :model do
       expect(reply).not_to be_valid
       expect(reply.errors[:parent]).to be_present
     end
+
+    it "rejects a comment that is its own parent" do
+      comment = create(:comment, comment_thread: thread, user: author)
+      comment.parent = comment
+
+      expect(comment).not_to be_valid
+    end
+
+    it "rejects a cycle between two comments" do
+      first  = create(:comment, comment_thread: thread, user: author)
+      second = create(:comment, comment_thread: thread, user: author, parent: first)
+      first.parent = second
+
+      expect(first).not_to be_valid
+    end
   end
 
   describe "scopes" do

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Comment, type: :model do
+  let(:author)  { create(:user) }
+  let(:project) { create(:project, author: author) }
+  let(:thread)  { create(:comment_thread, commentable: project) }
+
+  describe "associations" do
+    it "belongs to a thread and a user" do
+      comment = create(:comment, comment_thread: thread, user: author)
+
+      expect(comment.comment_thread).to eq(thread)
+      expect(comment.user).to eq(author)
+    end
+
+    it "exposes replies through the parent association" do
+      parent = create(:comment, comment_thread: thread, user: author)
+      reply  = create(:comment, comment_thread: thread, user: author, parent: parent)
+
+      expect(parent.replies).to contain_exactly(reply)
+      expect(reply.parent).to eq(parent)
+    end
+
+    it "destroys replies when the parent is destroyed" do
+      parent = create(:comment, comment_thread: thread, user: author)
+      create(:comment, comment_thread: thread, user: author, parent: parent)
+
+      expect { parent.destroy }.to change(described_class, :count).by(-2)
+    end
+  end
+
+  describe "validations" do
+    it "requires a body" do
+      comment = build(:comment, comment_thread: thread, user: author, body: nil)
+
+      expect(comment).not_to be_valid
+      expect(comment.errors[:body]).to be_present
+    end
+
+    it "rejects a body longer than the maximum length" do
+      comment = build(:comment, comment_thread: thread, user: author,
+                                body: "a" * (described_class::BODY_MAX_LENGTH + 1))
+
+      expect(comment).not_to be_valid
+    end
+
+    it "rejects a reply whose parent lives in a different thread" do
+      other_thread = create(:comment_thread, commentable: create(:project, author: author))
+      other_parent = create(:comment, comment_thread: other_thread, user: author)
+      reply        = build(:comment, comment_thread: thread, user: author, parent: other_parent)
+
+      expect(reply).not_to be_valid
+      expect(reply.errors[:parent]).to be_present
+    end
+  end
+
+  describe "scopes" do
+    let!(:visible) { create(:comment, comment_thread: thread, user: author) }
+    let!(:removed) { create(:comment, :deleted, comment_thread: thread, user: author) }
+
+    it "excludes soft deleted comments from .kept" do
+      expect(described_class.kept).to contain_exactly(visible)
+    end
+
+    it "returns only top level comments from .roots" do
+      create(:comment, comment_thread: thread, user: author, parent: visible)
+
+      expect(described_class.roots).to contain_exactly(visible, removed)
+    end
+  end
+
+  describe "soft deletion" do
+    let(:comment) { create(:comment, comment_thread: thread, user: author) }
+
+    it "marks the comment as deleted without removing the row" do
+      comment # create it before measuring the count
+
+      expect { comment.soft_delete! }.not_to change(described_class, :count)
+      expect(comment).to be_deleted
+    end
+
+    it "restores a soft deleted comment" do
+      comment.soft_delete!
+      comment.restore!
+
+      expect(comment).not_to be_deleted
+    end
+  end
+
+  describe "#edited?" do
+    it "is false until an editor is recorded" do
+      comment = create(:comment, comment_thread: thread, user: author)
+
+      expect(comment).not_to be_edited
+      comment.update!(body: "changed", editor: author)
+      expect(comment).to be_edited
+    end
+  end
+end

--- a/spec/models/comment_thread_spec.rb
+++ b/spec/models/comment_thread_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CommentThread, type: :model do
+  let(:author)  { create(:user) }
+  let(:project) { create(:project, author: author) }
+
+  describe "associations" do
+    it "belongs to a polymorphic commentable" do
+      thread = create(:comment_thread, commentable: project)
+
+      expect(thread.commentable).to eq(project)
+      expect(project.comment_thread).to eq(thread)
+    end
+
+    it "destroys its comments when destroyed" do
+      thread = create(:comment_thread, commentable: project)
+      create(:comment, comment_thread: thread, user: author)
+
+      expect { thread.destroy }.to change(Comment, :count).by(-1)
+    end
+  end
+
+  describe "open and closed state" do
+    let(:thread) { create(:comment_thread, commentable: project) }
+
+    it "is open by default" do
+      expect(thread).not_to be_closed
+    end
+
+    it "records who closed it" do
+      thread.close!(author)
+
+      expect(thread).to be_closed
+      expect(thread.closer).to eq(author)
+    end
+
+    it "clears the closer when reopened" do
+      thread.close!(author)
+      thread.reopen!
+
+      expect(thread).not_to be_closed
+      expect(thread.closer).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
First step of replacing the Commontator gem with a native comment system.

## What this adds

- `comment_threads` and `comments` tables
- `CommentThread` and `Comment` models
- - Factories and model specs (18 examples)
- Validation rejecting self-parenting and cyclic replies
- `has_one :comment_thread` on `Project`

## What this does not do

Nothing is wired up and nothing is removed. `acts_as_commontable`, the
Commontator engine, the API controllers and the existing views are all
untouched, so there is no behaviour change. The new models are unused
until later PRs.

## Approach

Like-for-like replacement. The schema mirrors Commontator's existing
structure — threads attached polymorphically to a commentable, comments
with nested replies, soft delete, edit tracking, and thread open/closed
state — so that the current API shape can be preserved.

Planned sequence: schema and models (this PR), then policies,
subscriptions and notifications, web UI, API parity, Avo admin, data
migration, and finally removing the gem.

## Notes

`db/schema.rb` was edited by hand to include only the new tables. Running
`db:migrate` locally re-sorts every column in the file alphabetically,
which produced a 400-line diff unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added threaded commenting for projects, including replies and chronological discussions.
  - Added comment editing indicators, soft deletion, and restoration.
  - Added controls to close and reopen comment threads.
  - Added validation for comment content, thread-consistent replies, and circular reply chains.

- **Tests**
  - Added coverage for comment behavior, associations, validations, deletion, restoration, and thread state changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->