### PR TITLE
fix(adapter): sanitize page parameter to prevent ArgumentError (#7830)

### DIFF
--- a/app/lib/adapters/base_adapter.rb
+++ b/app/lib/adapters/base_adapter.rb
@@ -2,5 +2,11 @@
 
 module Adapters
   class BaseAdapter
+    protected
+
+      def sanitize_page(page)
+        page_num = page.to_i
+        page_num.positive? ? page_num : 1
+      end
   end
 end

--- a/app/lib/adapters/pg_adapter.rb
+++ b/app/lib/adapters/pg_adapter.rb
@@ -45,7 +45,7 @@ module Adapters
         results = apply_filters(results, query_params, type)
         results = apply_sorting(results, query_params, type)
 
-        results.paginate(page: query_params[:page], per_page: MAX_RESULTS_PER_PAGE)
+        results.paginate(page: sanitize_page(query_params[:page]), per_page: MAX_RESULTS_PER_PAGE)
       end
 
       def base_project_results(relation, query_params)

--- a/app/lib/adapters/solr_adapter.rb
+++ b/app/lib/adapters/solr_adapter.rb
@@ -6,9 +6,10 @@ module Adapters
 
     def search_project(relation, query_params)
       if query_params[:q].present?
+        page = sanitize_page(query_params[:page])
         relation.search(include: %i[tags author]) do
           fulltext query_params[:q]
-          paginate page: query_params[:page], per_page: MAX_RESULTS_PER_PAGE
+          paginate page: page, per_page: MAX_RESULTS_PER_PAGE
         end.results
       else
         Project.public_and_not_forked
@@ -17,9 +18,10 @@ module Adapters
 
     def search_user(relation, query_params)
       if query_params[:q].present?
+        page = sanitize_page(query_params[:page])
         relation.search do
           fulltext query_params[:q]
-          paginate page: query_params[:page], per_page: MAX_RESULTS_PER_PAGE
+          paginate page: page, per_page: MAX_RESULTS_PER_PAGE
         end.results
       else
         User.all

--- a/spec/lib/adapters/pg_adapter_spec.rb
+++ b/spec/lib/adapters/pg_adapter_spec.rb
@@ -161,4 +161,37 @@ RSpec.describe Adapters::PgAdapter do
       expect(mock_relation).to have_received(:order).with(created_at: :asc)
     end
   end
+
+  describe "pagination sanitization" do
+    let(:mock_relation) { double }
+
+    before do
+      allow(Project).to receive(:public_and_not_forked).and_return(mock_relation)
+      allow(mock_relation).to receive_messages(includes: mock_relation, paginate: double)
+    end
+
+    it "sanitizes invalid non-integer string page parameters to 1" do
+      query_params = { page: "1' AND 1=1 UNION SELECT NULL-- -" }
+
+      adapter.search_project(mock_relation, query_params)
+
+      expect(mock_relation).to have_received(:paginate).with(page: 1, per_page: 9)
+    end
+
+    it "sanitizes non-positive or negative page parameters to 1" do
+      query_params = { page: -5 }
+
+      adapter.search_project(mock_relation, query_params)
+
+      expect(mock_relation).to have_received(:paginate).with(page: 1, per_page: 9)
+    end
+
+    it "sanitizes string numbers correctly" do
+      query_params = { page: "3" }
+
+      adapter.search_project(mock_relation, query_params)
+
+      expect(mock_relation).to have_received(:paginate).with(page: 3, per_page: 9)
+    end
+  end
 end


### PR DESCRIPTION
### Summary of Changes

Fixes #7830 (Sentry `CIRCUITVERSE-CORE-155`) where passing non-integer or malicious SQL-like strings in the `page` query parameter (e.g., `"1' AND 1=1 UNION SELECT NULL-- -"`) caused `will_paginate` to raise `ArgumentError: invalid value for Integer(): ...`.

#### Changes made:
- **`app/lib/adapters/base_adapter.rb`**: Added `sanitize_page(page)` helper method that coerces the input to an integer (`page.to_i`) and defaults non-positive / unparseable values to `1`.
- **`app/lib/adapters/pg_adapter.rb`**: Applied `sanitize_page(query_params[:page])` in `perform_search` before passing to `paginate`.
- **`app/lib/adapters/solr_adapter.rb`**: Applied `sanitize_page(query_params[:page])` in `search_project` and `search_user`.
- **`spec/lib/adapters/pg_adapter_spec.rb`**: Added unit tests for page parameter sanitization.

### Related Issue

- Fixes #7830

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search pagination handling for invalid, negative, zero, and non-numeric page values.
  * Invalid page values now safely return the first page instead of causing unexpected behavior.
  * Valid numeric page values continue to work as expected across project and user searches.

* **Tests**
  * Added coverage for valid and invalid pagination inputs, including malformed values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->