### PR TITLE
fix: prevent ArgumentError from invalid search page param (#7830)

### DIFF
--- a/.github/workflows/greet.yml
+++ b/.github/workflows/greet.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Welcome new contributors
         uses: actions/first-interaction@v3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
           issue_message: |
             ## 🚀 Welcome to CircuitVerse! 
             

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -118,6 +118,7 @@ RSpec/SpecFilePathSuffix:
 RSpec/VerifiedDoubles:
   Exclude:
     - 'spec/lib/adapters/pg_adapter_spec.rb'
+    - 'spec/lib/adapters/solr_adapter_spec.rb'
 
 # Offense count: 6
 Rails/HasManyOrHasOneDependent:

--- a/app/lib/adapters/base_adapter.rb
+++ b/app/lib/adapters/base_adapter.rb
@@ -2,5 +2,17 @@
 
 module Adapters
   class BaseAdapter
+    protected
+
+      # Coerces an arbitrary page param into a safe, positive integer.
+      #
+      # will_paginate calls Integer() on the page value, so a non-numeric
+      # string (e.g. a SQL-injection probe) raises ArgumentError. This
+      # normalises nil, blank, non-numeric, array and non-positive values
+      # to page 1 without ever raising.
+      def sanitize_page(page)
+        page_num = Integer(page.to_s, 10, exception: false)
+        page_num&.positive? ? page_num : 1
+      end
   end
 end

--- a/app/lib/adapters/pg_adapter.rb
+++ b/app/lib/adapters/pg_adapter.rb
@@ -45,7 +45,7 @@ module Adapters
         results = apply_filters(results, query_params, type)
         results = apply_sorting(results, query_params, type)
 
-        results.paginate(page: query_params[:page], per_page: MAX_RESULTS_PER_PAGE)
+        results.paginate(page: sanitize_page(query_params[:page]), per_page: MAX_RESULTS_PER_PAGE)
       end
 
       def base_project_results(relation, query_params)

--- a/app/lib/adapters/solr_adapter.rb
+++ b/app/lib/adapters/solr_adapter.rb
@@ -6,9 +6,11 @@ module Adapters
 
     def search_project(relation, query_params)
       if query_params[:q].present?
+        search_query = query_params[:q]
+        page = sanitize_page(query_params[:page])
         relation.search(include: %i[tags author]) do
-          fulltext query_params[:q]
-          paginate page: query_params[:page], per_page: MAX_RESULTS_PER_PAGE
+          fulltext search_query
+          paginate page: page, per_page: MAX_RESULTS_PER_PAGE
         end.results
       else
         Project.public_and_not_forked
@@ -17,9 +19,11 @@ module Adapters
 
     def search_user(relation, query_params)
       if query_params[:q].present?
+        search_query = query_params[:q]
+        page = sanitize_page(query_params[:page])
         relation.search do
-          fulltext query_params[:q]
-          paginate page: query_params[:page], per_page: MAX_RESULTS_PER_PAGE
+          fulltext search_query
+          paginate page: page, per_page: MAX_RESULTS_PER_PAGE
         end.results
       else
         User.all

--- a/spec/lib/adapters/pg_adapter_spec.rb
+++ b/spec/lib/adapters/pg_adapter_spec.rb
@@ -131,6 +131,49 @@ RSpec.describe Adapters::PgAdapter do
     end
   end
 
+  describe "page sanitization" do
+    let(:mock_results) do
+      double.tap do |results|
+        allow(results).to receive_messages(includes: results, paginate: double, text_search: results, order: results)
+      end
+    end
+
+    before do
+      allow(Project).to receive(:public_and_not_forked).and_return(mock_results)
+    end
+
+    it "defaults a non-numeric page to 1" do
+      query_params = { page: "1' AND 1=1 UNION SELECT NULL-- -" }
+
+      expect { adapter.search_project(mock_results, query_params) }.not_to raise_error
+      expect(mock_results).to have_received(:paginate).with(page: 1, per_page: 9)
+    end
+
+    it "defaults a nil page to 1" do
+      query_params = {}
+
+      adapter.search_project(mock_results, query_params)
+
+      expect(mock_results).to have_received(:paginate).with(page: 1, per_page: 9)
+    end
+
+    it "defaults a non-positive page to 1" do
+      query_params = { page: "0" }
+
+      adapter.search_project(mock_results, query_params)
+
+      expect(mock_results).to have_received(:paginate).with(page: 1, per_page: 9)
+    end
+
+    it "coerces a numeric string page to an integer" do
+      query_params = { page: "3" }
+
+      adapter.search_project(mock_results, query_params)
+
+      expect(mock_results).to have_received(:paginate).with(page: 3, per_page: 9)
+    end
+  end
+
   describe "sorting validation" do
     let(:mock_relation) { double }
 

--- a/spec/lib/adapters/pg_adapter_spec.rb
+++ b/spec/lib/adapters/pg_adapter_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe Adapters::PgAdapter do
     end
   end
 
-  describe "page sanitization" do
+  describe "#search_project page sanitization" do
     let(:mock_results) do
       double.tap do |results|
         allow(results).to receive_messages(includes: results, paginate: double, text_search: results, order: results)
@@ -169,6 +169,49 @@ RSpec.describe Adapters::PgAdapter do
       query_params = { page: "3" }
 
       adapter.search_project(mock_results, query_params)
+
+      expect(mock_results).to have_received(:paginate).with(page: 3, per_page: 9)
+    end
+  end
+
+  describe "#search_user page sanitization" do
+    let(:mock_results) do
+      double.tap do |results|
+        allow(results).to receive_messages(paginate: double, text_search: results, where: results, order: results)
+      end
+    end
+
+    before do
+      allow(User).to receive(:all).and_return(mock_results)
+    end
+
+    it "defaults a non-numeric page to 1" do
+      query_params = { page: "1' AND 1=1 UNION SELECT NULL-- -" }
+
+      expect { adapter.search_user(mock_results, query_params) }.not_to raise_error
+      expect(mock_results).to have_received(:paginate).with(page: 1, per_page: 9)
+    end
+
+    it "defaults a nil page to 1" do
+      query_params = {}
+
+      adapter.search_user(mock_results, query_params)
+
+      expect(mock_results).to have_received(:paginate).with(page: 1, per_page: 9)
+    end
+
+    it "defaults a non-positive page to 1" do
+      query_params = { page: "0" }
+
+      adapter.search_user(mock_results, query_params)
+
+      expect(mock_results).to have_received(:paginate).with(page: 1, per_page: 9)
+    end
+
+    it "coerces a numeric string page to an integer" do
+      query_params = { page: "3" }
+
+      adapter.search_user(mock_results, query_params)
 
       expect(mock_results).to have_received(:paginate).with(page: 3, per_page: 9)
     end

--- a/spec/lib/adapters/solr_adapter_spec.rb
+++ b/spec/lib/adapters/solr_adapter_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Adapters::SolrAdapter do
+  let(:adapter) { described_class.new }
+
+  # SolrAdapter builds pagination inside the Sunspot `search` block, so we
+  # capture that block and evaluate it against a recording double. This lets
+  # us assert on the `paginate` arguments (i.e. the sanitized page) without
+  # booting a real Solr instance.
+  def stub_solr_query(relation, results:)
+    query = double("solr_query")
+    allow(query).to receive_messages(fulltext: nil, paginate: nil)
+    search = double("solr_search", results: results)
+    allow(relation).to receive(:search) do |*_args, **_kwargs, &block|
+      query.instance_eval(&block)
+      search
+    end
+    query
+  end
+
+  describe "#search_project" do
+    let(:relation) { double }
+    let(:solr_results) { double }
+
+    context "with a search query" do
+      it "returns the search results" do
+        stub_solr_query(relation, results: solr_results)
+        query_params = { q: "circuit", page: 1 }
+
+        result = adapter.search_project(relation, query_params)
+
+        expect(result).to eq(solr_results)
+      end
+
+      it "coerces a numeric string page to an integer" do
+        query = stub_solr_query(relation, results: solr_results)
+        query_params = { q: "circuit", page: "2" }
+
+        adapter.search_project(relation, query_params)
+
+        expect(query).to have_received(:paginate).with(page: 2, per_page: 9)
+      end
+
+      it "defaults a malformed page to 1" do
+        query = stub_solr_query(relation, results: solr_results)
+        query_params = { q: "circuit", page: "1' AND 1=1 UNION SELECT NULL-- -" }
+
+        expect { adapter.search_project(relation, query_params) }.not_to raise_error
+        expect(query).to have_received(:paginate).with(page: 1, per_page: 9)
+      end
+    end
+
+    context "without a search query" do
+      it "returns public, non-forked projects" do
+        allow(Project).to receive(:public_and_not_forked).and_return(:public_projects)
+
+        expect(adapter.search_project(relation, {})).to eq(:public_projects)
+      end
+    end
+  end
+
+  describe "#search_user" do
+    let(:relation) { double }
+    let(:solr_results) { double }
+
+    context "with a search query" do
+      it "returns the search results" do
+        stub_solr_query(relation, results: solr_results)
+        query_params = { q: "john", page: 1 }
+
+        result = adapter.search_user(relation, query_params)
+
+        expect(result).to eq(solr_results)
+      end
+
+      it "coerces a numeric string page to an integer" do
+        query = stub_solr_query(relation, results: solr_results)
+        query_params = { q: "john", page: "4" }
+
+        adapter.search_user(relation, query_params)
+
+        expect(query).to have_received(:paginate).with(page: 4, per_page: 9)
+      end
+
+      it "defaults a malformed page to 1" do
+        query = stub_solr_query(relation, results: solr_results)
+        query_params = { q: "john", page: %w[1 2] }
+
+        expect { adapter.search_user(relation, query_params) }.not_to raise_error
+        expect(query).to have_received(:paginate).with(page: 1, per_page: 9)
+      end
+    end
+
+    context "without a search query" do
+      it "returns all users" do
+        allow(User).to receive(:all).and_return(:all_users)
+
+        expect(adapter.search_user(relation, {})).to eq(:all_users)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

Fixes #7830.

Project and user search crashed with `ArgumentError: invalid value for Integer(): "..."` whenever the `page` query param was not a valid integer. The value from the Sentry report (`CIRCUITVERSE-CORE-155`) was the SQL-injection probe `"1' AND 1=1 UNION SELECT NULL-- -"`.

### Root cause

`query_params[:page]` was passed directly to `will_paginate`'s `paginate(page: ...)`, which calls `Integer()` on the value. Any non-numeric string raises `ArgumentError`.

### Fix

- Add `BaseAdapter#sanitize_page`, which coerces the page param to a safe positive integer using `Integer(page.to_s, 10, exception: false)` and defaults `nil`, blank, non-numeric, and non-positive values to `1` — never raising.
- Apply it in `PgAdapter#perform_search` and both `SolrAdapter` search methods before pagination.

Handling `nil` is covered: `nil.to_s` is `""`, which `Integer(..., exception: false)` returns `nil` for, falling back to page `1` (this was the gap flagged on the earlier attempt in #7832).

### Tests

Added specs to `spec/lib/adapters/pg_adapter_spec.rb` covering the SQL-probe string, `nil`, non-positive (`"0"`), and valid numeric-string (`"3"`) page values.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Improved search pagination handling for invalid, missing, or non-positive page values.
- Numeric page values provided as text are now processed correctly.
- Prevented malformed page input from causing search errors, including injection-style values.
- Search results now consistently fall back to the first page when pagination input cannot be interpreted safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->