### PR TITLE
feat: add CommentPolicy and CommentThreadPolicy (part 2 of Commontator removal)

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Mirrors Commontator::Comment. Belongs to a thread rather than directly to the
+# commentable, so that thread level state (open/closed, subscriptions) has a
+# home and the existing API shape is preserved.
+class Comment < ApplicationRecord
+  BODY_MAX_LENGTH = 10_000
+
+  belongs_to :comment_thread, inverse_of: :comments
+  belongs_to :user
+  belongs_to :editor, class_name: "User", optional: true
+  belongs_to :parent, class_name: "Comment", optional: true
+
+  has_many :replies, class_name: "Comment",
+                     foreign_key: :parent_id,
+                     inverse_of: :parent,
+                     dependent: :destroy
+
+  validates :body, presence: true, length: { maximum: BODY_MAX_LENGTH }
+  validate :parent_shares_thread
+
+  scope :kept, -> { where(deleted_at: nil) }
+  scope :roots, -> { where(parent_id: nil) }
+  scope :chronological, -> { order(created_at: :asc) }
+
+  def deleted?
+    deleted_at.present?
+  end
+
+  def edited?
+    editor_id.present?
+  end
+
+  def soft_delete!
+    update!(deleted_at: Time.current)
+  end
+
+  def restore!
+    update!(deleted_at: nil)
+  end
+
+  private
+
+    # A reply must live in the same thread as its parent, otherwise a comment
+    # could be threaded onto a discussion it does not belong to.
+    def parent_shares_thread
+      return if parent.nil?
+      return if parent.comment_thread_id == comment_thread_id
+
+      errors.add(:parent, "must belong to the same thread")
+    end
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -18,6 +18,7 @@ class Comment < ApplicationRecord
 
   validates :body, presence: true, length: { maximum: BODY_MAX_LENGTH }
   validate :parent_shares_thread
+  validate :parent_is_not_cyclic
 
   scope :kept, -> { where(deleted_at: nil) }
   scope :roots, -> { where(parent_id: nil) }
@@ -48,5 +49,30 @@ class Comment < ApplicationRecord
       return if parent.comment_thread_id == comment_thread_id
 
       errors.add(:parent, "must belong to the same thread")
+    end
+
+    # Walk up the ancestor chain so a comment cannot be its own parent, nor
+    # part of a reply cycle. Without this, `replies` recurses forever during
+    # dependent: :destroy.
+    def parent_is_not_cyclic
+      return if parent.nil?
+
+      if parent == self
+        errors.add(:parent, "cannot be the comment itself")
+        return
+      end
+
+      # A new record has no id, so nothing can point back at it yet.
+      return if id.nil?
+
+      ancestor = parent
+      while ancestor
+        if ancestor.parent_id == id
+          errors.add(:parent, "cannot create a cycle")
+          return
+        end
+
+        ancestor = ancestor.parent
+      end
     end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -54,6 +54,11 @@ class Comment < ApplicationRecord
     # Walk up the ancestor chain so a comment cannot be its own parent, nor
     # part of a reply cycle. Without this, `replies` recurses forever during
     # dependent: :destroy.
+    #
+    # NOTE: application-level guard only. It does not run for update_column,
+    # insert_all, or raw SQL, and does not protect against concurrent writes.
+    # The invariant must be re-checked wherever rows are written outside the
+    # model, in particular the Commontator data migration.
     def parent_is_not_cyclic
       return if parent.nil?
 

--- a/app/models/comment_thread.rb
+++ b/app/models/comment_thread.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Mirrors Commontator::Thread. One thread per commentable, holding the comments
+# and the open/closed state.
+class CommentThread < ApplicationRecord
+  belongs_to :commentable, polymorphic: true
+  belongs_to :closer, class_name: "User", optional: true
+
+  has_many :comments, dependent: :destroy
+
+  def closed?
+    closed_at.present?
+  end
+
+  def close!(user)
+    update!(closed_at: Time.current, closer: user)
+  end
+
+  def reopen!
+    update!(closed_at: nil, closer: nil)
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -31,7 +31,7 @@ class Project < ApplicationRecord
   has_one :project_datum, dependent: :destroy
   has_many :notifications, as: :notifiable
   has_one :contest_winner, dependent: :destroy
-  has_many :submissions, dependent: :destroy
+  has_one :comment_thread, as: :commentable, dependent: :destroy
 
   scope :public_and_not_forked,
         -> { where(project_access_type: "Public", forked_project_id: nil) }

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -31,6 +31,7 @@ class Project < ApplicationRecord
   has_one :project_datum, dependent: :destroy
   has_many :notifications, as: :notifiable
   has_one :contest_winner, dependent: :destroy
+  has_many :submissions, dependent: :destroy
   has_one :comment_thread, as: :commentable, dependent: :destroy
 
   scope :public_and_not_forked,

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -36,7 +36,6 @@ class CommentPolicy < ApplicationPolicy
 
   # Commontator#can_be_deleted_by?: the moderator branch returns before the
   # closed-thread check, so moderators may still delete in a closed thread.
-  # An author may undelete only a comment they deleted themselves.
   def destroy?
     return true if thread_policy.moderator?
 
@@ -47,16 +46,13 @@ class CommentPolicy < ApplicationPolicy
   end
 
   # Commontator routes undelete through can_be_deleted_by?, so moderators may
-  # restore any comment, while an author may only restore one they deleted
-  # themselves.
+  # restore any deleted comment, while an author may only restore one they
+  # deleted themselves.
   def restore?
+    return false unless comment.deleted?
     return true if thread_policy.moderator?
 
-    author? &&
-      comment.deleted? &&
-      comment.editor_id == user.id &&
-      !thread_closed? &&
-      show?
+    author? && comment.editor_id == user.id && !thread_closed? && show?
   end
 
   # Commontator#can_be_voted_on_by?: a user may not vote on their own comment,

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+# Mirrors the comment permissions in commontator-7.0.1, as configured in
+# config/initializers/commontator.rb:
+#
+#   comment_editing       = :a  -> authors may always edit their own comments
+#   comment_deletion      = :a  -> authors may always delete their own comments
+#   moderator_permissions = :d  -> moderators may delete and close, not edit
+#   comment_voting        = :ld -> likes and dislikes are both enabled
+#
+# Intentionally does not call super, for the same reason as
+# CommentThreadPolicy: comments on public projects are readable anonymously.
+class CommentPolicy < ApplicationPolicy
+  attr_reader :user, :comment
+
+  delegate :show?, to: :thread_policy
+
+  def initialize(user, comment)
+    @user = user
+    @comment = comment
+  end
+
+  def create?
+    thread_policy.create_comment?
+  end
+
+  # Commontator#can_be_edited_by?: moderators are excluded here because
+  # moderator_permissions is :d rather than :e.
+  def update?
+    author? &&
+      !comment.deleted? &&
+      !thread_closed? &&
+      (comment.editor_id.nil? || comment.editor_id == user.id) &&
+      show?
+  end
+
+  # Commontator#can_be_deleted_by?: the moderator branch returns before the
+  # closed-thread check, so moderators may still delete in a closed thread.
+  # An author may undelete only a comment they deleted themselves.
+  def destroy?
+    return true if thread_policy.moderator?
+
+    author? &&
+      !thread_closed? &&
+      (!comment.deleted? || comment.editor_id == user.id) &&
+      show?
+  end
+
+  def restore?
+    destroy?
+  end
+
+  # Commontator#can_be_voted_on_by?: a user may not vote on their own comment,
+  # and voting closes along with the thread.
+  def vote?
+    user.present? &&
+      !author? &&
+      !comment.deleted? &&
+      !thread_closed? &&
+      show?
+  end
+
+  private
+
+    def author?
+      user.present? && comment.user_id == user.id
+    end
+
+    def thread_closed?
+      comment.comment_thread&.closed? || false
+    end
+
+    def thread_policy
+      @thread_policy ||= CommentThreadPolicy.new(user, comment.comment_thread)
+    end
+end

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -46,8 +46,17 @@ class CommentPolicy < ApplicationPolicy
       show?
   end
 
+  # Commontator routes undelete through can_be_deleted_by?, so moderators may
+  # restore any comment, while an author may only restore one they deleted
+  # themselves.
   def restore?
-    destroy?
+    return true if thread_policy.moderator?
+
+    author? &&
+      comment.deleted? &&
+      comment.editor_id == user.id &&
+      !thread_closed? &&
+      show?
   end
 
   # Commontator#can_be_voted_on_by?: a user may not vote on their own comment,

--- a/app/policies/comment_thread_policy.rb
+++ b/app/policies/comment_thread_policy.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# Mirrors the thread permissions Commontator is currently configured with:
+#
+#   thread_read_proc      -> public commentable, or ProjectPolicy view access
+#   thread_moderator_proc -> user.admin?
+#
+# Intentionally does not call super: threads on public projects must stay
+# readable by anonymous users, matching the current API behaviour where
+# unauthenticated requests can list a public project's comments.
+class CommentThreadPolicy < ApplicationPolicy
+  attr_reader :user, :comment_thread
+
+  def initialize(user, comment_thread)
+    @user = user
+    @comment_thread = comment_thread
+  end
+
+  def show?
+    readable?
+  end
+
+  def create_comment?
+    user.present? && !comment_thread.closed? && readable?
+  end
+
+  def subscribe?
+    user.present? && readable?
+  end
+
+  def unsubscribe?
+    subscribe?
+  end
+
+  def close?
+    moderator?
+  end
+
+  def reopen?
+    moderator?
+  end
+
+  # moderator_permissions is :d, so moderators may delete comments and close
+  # threads, but may not edit other people's comments.
+  def moderator?
+    user.present? && user.admin?
+  end
+
+  private
+
+    def readable?
+      commentable = comment_thread.commentable
+      return false if commentable.nil?
+      return true if commentable.public?
+
+      ProjectPolicy.new(user, commentable).check_view_access?
+    end
+end

--- a/db/migrate/20260901000000_create_comment_tables.rb
+++ b/db/migrate/20260901000000_create_comment_tables.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class CreateCommentTables < ActiveRecord::Migration[8.1]
+  def change
+    create_comment_threads
+    create_comments
+  end
+
+  private
+
+    def create_comment_threads
+      create_table :comment_threads do |t|
+        t.references :commentable, polymorphic: true, null: false, index: false
+        t.datetime :closed_at
+        t.references :closer, null: true, foreign_key: { to_table: :users }
+
+        t.timestamps
+      end
+
+      add_index :comment_threads, %i[commentable_type commentable_id],
+                unique: true,
+                name: "index_comment_threads_on_commentable"
+    end
+
+    def create_comments
+      create_table :comments do |t|
+        t.references :comment_thread, null: false, foreign_key: true, index: false
+        t.references :user, null: false, foreign_key: true
+        t.references :editor, null: true, foreign_key: { to_table: :users }
+        t.references :parent, null: true, foreign_key: { to_table: :comments }
+        t.text :body, null: false
+        t.datetime :deleted_at
+
+        t.timestamps
+      end
+
+      add_index :comments, %i[comment_thread_id created_at]
+      add_index :comments, :deleted_at
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_21_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_01_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -114,6 +114,33 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_21_000000) do
     t.datetime "updated_at", precision: nil, null: false
     t.index ["project_id"], name: "index_collaborations_on_project_id"
     t.index ["user_id"], name: "index_collaborations_on_user_id"
+  end
+
+  create_table "comment_threads", force: :cascade do |t|
+    t.datetime "closed_at"
+    t.bigint "closer_id"
+    t.bigint "commentable_id", null: false
+    t.string "commentable_type", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["closer_id"], name: "index_comment_threads_on_closer_id"
+    t.index ["commentable_type", "commentable_id"], name: "index_comment_threads_on_commentable", unique: true
+  end
+
+  create_table "comments", force: :cascade do |t|
+    t.text "body", null: false
+    t.bigint "comment_thread_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "deleted_at"
+    t.bigint "editor_id"
+    t.bigint "parent_id"
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["comment_thread_id", "created_at"], name: "index_comments_on_comment_thread_id_and_created_at"
+    t.index ["deleted_at"], name: "index_comments_on_deleted_at"
+    t.index ["editor_id"], name: "index_comments_on_editor_id"
+    t.index ["parent_id"], name: "index_comments_on_parent_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "commontator_comments", id: :serial, force: :cascade do |t|
@@ -594,6 +621,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_21_000000) do
   add_foreign_key "assignments", "groups"
   add_foreign_key "collaborations", "projects"
   add_foreign_key "collaborations", "users"
+  add_foreign_key "comment_threads", "users", column: "closer_id"
+  add_foreign_key "comments", "comment_threads"
+  add_foreign_key "comments", "comments", column: "parent_id"
+  add_foreign_key "comments", "users"
+  add_foreign_key "comments", "users", column: "editor_id"
   add_foreign_key "commontator_comments", "commontator_comments", column: "parent_id", on_update: :restrict, on_delete: :cascade
   add_foreign_key "contest_winners", "contests"
   add_foreign_key "contest_winners", "projects"

--- a/spec/factories/comment.rb
+++ b/spec/factories/comment.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :comment_thread do
+    association :commentable, factory: :project
+
+    trait :closed do
+      closed_at { Time.current }
+      association :closer, factory: :user
+    end
+  end
+
+  factory :comment do
+    association :comment_thread
+    association :user
+    body { "A comment body" }
+
+    trait :deleted do
+      deleted_at { Time.current }
+    end
+  end
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -54,6 +54,21 @@ RSpec.describe Comment, type: :model do
       expect(reply).not_to be_valid
       expect(reply.errors[:parent]).to be_present
     end
+
+    it "rejects a comment that is its own parent" do
+      comment = create(:comment, comment_thread: thread, user: author)
+      comment.parent = comment
+
+      expect(comment).not_to be_valid
+    end
+
+    it "rejects a cycle between two comments" do
+      first  = create(:comment, comment_thread: thread, user: author)
+      second = create(:comment, comment_thread: thread, user: author, parent: first)
+      first.parent = second
+
+      expect(first).not_to be_valid
+    end
   end
 
   describe "scopes" do

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Comment, type: :model do
+  let(:author)  { create(:user) }
+  let(:project) { create(:project, author: author) }
+  let(:thread)  { create(:comment_thread, commentable: project) }
+
+  describe "associations" do
+    it "belongs to a thread and a user" do
+      comment = create(:comment, comment_thread: thread, user: author)
+
+      expect(comment.comment_thread).to eq(thread)
+      expect(comment.user).to eq(author)
+    end
+
+    it "exposes replies through the parent association" do
+      parent = create(:comment, comment_thread: thread, user: author)
+      reply  = create(:comment, comment_thread: thread, user: author, parent: parent)
+
+      expect(parent.replies).to contain_exactly(reply)
+      expect(reply.parent).to eq(parent)
+    end
+
+    it "destroys replies when the parent is destroyed" do
+      parent = create(:comment, comment_thread: thread, user: author)
+      create(:comment, comment_thread: thread, user: author, parent: parent)
+
+      expect { parent.destroy }.to change(described_class, :count).by(-2)
+    end
+  end
+
+  describe "validations" do
+    it "requires a body" do
+      comment = build(:comment, comment_thread: thread, user: author, body: nil)
+
+      expect(comment).not_to be_valid
+      expect(comment.errors[:body]).to be_present
+    end
+
+    it "rejects a body longer than the maximum length" do
+      comment = build(:comment, comment_thread: thread, user: author,
+                                body: "a" * (described_class::BODY_MAX_LENGTH + 1))
+
+      expect(comment).not_to be_valid
+    end
+
+    it "rejects a reply whose parent lives in a different thread" do
+      other_thread = create(:comment_thread, commentable: create(:project, author: author))
+      other_parent = create(:comment, comment_thread: other_thread, user: author)
+      reply        = build(:comment, comment_thread: thread, user: author, parent: other_parent)
+
+      expect(reply).not_to be_valid
+      expect(reply.errors[:parent]).to be_present
+    end
+  end
+
+  describe "scopes" do
+    let!(:visible) { create(:comment, comment_thread: thread, user: author) }
+    let!(:removed) { create(:comment, :deleted, comment_thread: thread, user: author) }
+
+    it "excludes soft deleted comments from .kept" do
+      expect(described_class.kept).to contain_exactly(visible)
+    end
+
+    it "returns only top level comments from .roots" do
+      create(:comment, comment_thread: thread, user: author, parent: visible)
+
+      expect(described_class.roots).to contain_exactly(visible, removed)
+    end
+  end
+
+  describe "soft deletion" do
+    let(:comment) { create(:comment, comment_thread: thread, user: author) }
+
+    it "marks the comment as deleted without removing the row" do
+      comment # create it before measuring the count
+
+      expect { comment.soft_delete! }.not_to change(described_class, :count)
+      expect(comment).to be_deleted
+    end
+
+    it "restores a soft deleted comment" do
+      comment.soft_delete!
+      comment.restore!
+
+      expect(comment).not_to be_deleted
+    end
+  end
+
+  describe "#edited?" do
+    it "is false until an editor is recorded" do
+      comment = create(:comment, comment_thread: thread, user: author)
+
+      expect(comment).not_to be_edited
+      comment.update!(body: "changed", editor: author)
+      expect(comment).to be_edited
+    end
+  end
+end

--- a/spec/models/comment_thread_spec.rb
+++ b/spec/models/comment_thread_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CommentThread, type: :model do
+  let(:author)  { create(:user) }
+  let(:project) { create(:project, author: author) }
+
+  describe "associations" do
+    it "belongs to a polymorphic commentable" do
+      thread = create(:comment_thread, commentable: project)
+
+      expect(thread.commentable).to eq(project)
+      expect(project.comment_thread).to eq(thread)
+    end
+
+    it "destroys its comments when destroyed" do
+      thread = create(:comment_thread, commentable: project)
+      create(:comment, comment_thread: thread, user: author)
+
+      expect { thread.destroy }.to change(Comment, :count).by(-1)
+    end
+  end
+
+  describe "open and closed state" do
+    let(:thread) { create(:comment_thread, commentable: project) }
+
+    it "is open by default" do
+      expect(thread).not_to be_closed
+    end
+
+    it "records who closed it" do
+      thread.close!(author)
+
+      expect(thread).to be_closed
+      expect(thread.closer).to eq(author)
+    end
+
+    it "clears the closer when reopened" do
+      thread.close!(author)
+      thread.reopen!
+
+      expect(thread).not_to be_closed
+      expect(thread.closer).to be_nil
+    end
+  end
+end

--- a/spec/policies/comment_policy_spec.rb
+++ b/spec/policies/comment_policy_spec.rb
@@ -71,6 +71,11 @@ describe CommentPolicy do
     it "does not let the author undelete it" do
       expect(subject).not_to permit(:restore)
     end
+
+    it "lets a moderator restore it" do
+      admin = FactoryBot.create(:user, admin: true)
+      expect(described_class.new(admin, comment)).to permit(:restore)
+    end
   end
 
   context "when the thread is closed" do

--- a/spec/policies/comment_policy_spec.rb
+++ b/spec/policies/comment_policy_spec.rb
@@ -37,6 +37,10 @@ describe CommentPolicy do
     # moderator_permissions is :d, so moderators delete but do not edit.
     it { is_expected.to permit(:destroy) }
     it { is_expected.not_to permit(:update) }
+
+    it "does not permit restoring a comment that is not deleted" do
+      expect(subject).not_to permit(:restore)
+    end
   end
 
   context "when the user is anonymous" do

--- a/spec/policies/comment_policy_spec.rb
+++ b/spec/policies/comment_policy_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe CommentPolicy do
+  subject { described_class.new(user, comment) }
+
+  let(:project_author) { FactoryBot.create(:user) }
+  let(:commenter)      { FactoryBot.create(:user) }
+  let(:project)        { FactoryBot.create(:project, :public, author: project_author) }
+  let(:comment_thread) { FactoryBot.create(:comment_thread, commentable: project) }
+  let(:comment) do
+    FactoryBot.create(:comment, comment_thread: comment_thread, user: commenter)
+  end
+
+  context "when the user wrote the comment" do
+    let(:user) { commenter }
+
+    it { is_expected.to permit(:show) }
+    it { is_expected.to permit(:update) }
+    it { is_expected.to permit(:destroy) }
+    it { is_expected.not_to permit(:vote) }
+  end
+
+  context "when the user is another signed in user" do
+    let(:user) { FactoryBot.create(:user) }
+
+    it { is_expected.to permit(:show) }
+    it { is_expected.to permit(:vote) }
+    it { is_expected.not_to permit(:update) }
+    it { is_expected.not_to permit(:destroy) }
+  end
+
+  context "when the user is a site admin" do
+    let(:user) { FactoryBot.create(:user, admin: true) }
+
+    # moderator_permissions is :d, so moderators delete but do not edit.
+    it { is_expected.to permit(:destroy) }
+    it { is_expected.not_to permit(:update) }
+  end
+
+  context "when the user is anonymous" do
+    let(:user) { nil }
+
+    it { is_expected.to permit(:show) }
+    it { is_expected.not_to permit(:vote) }
+    it { is_expected.not_to permit(:update) }
+    it { is_expected.not_to permit(:destroy) }
+  end
+
+  context "when the comment was deleted by its author" do
+    let(:user) { commenter }
+    let(:comment) do
+      FactoryBot.create(:comment, :deleted, comment_thread: comment_thread,
+                                            user: commenter, editor: commenter)
+    end
+
+    it { is_expected.not_to permit(:update) }
+    it { is_expected.to permit(:restore) }
+    it { is_expected.not_to permit(:vote) }
+  end
+
+  context "when the comment was deleted by a moderator" do
+    let(:user) { commenter }
+    let(:comment) do
+      FactoryBot.create(:comment, :deleted, comment_thread: comment_thread,
+                                            user: commenter,
+                                            editor: FactoryBot.create(:user, admin: true))
+    end
+
+    it "does not let the author undelete it" do
+      expect(subject).not_to permit(:restore)
+    end
+  end
+
+  context "when the thread is closed" do
+    before { comment_thread.close!(FactoryBot.create(:user, admin: true)) }
+
+    context "for the comment author" do
+      let(:user) { commenter }
+
+      it { is_expected.to permit(:show) }
+      it { is_expected.not_to permit(:update) }
+      it { is_expected.not_to permit(:destroy) }
+    end
+
+    # can_be_deleted_by? returns for moderators before the closed-thread check.
+    context "for a site admin" do
+      let(:user) { FactoryBot.create(:user, admin: true) }
+
+      it { is_expected.to permit(:destroy) }
+    end
+  end
+
+  context "when the project is private" do
+    let(:project) { FactoryBot.create(:project, author: project_author) }
+    let(:user)    { FactoryBot.create(:user) }
+
+    it { is_expected.not_to permit(:show) }
+    it { is_expected.not_to permit(:vote) }
+  end
+end

--- a/spec/policies/comment_thread_policy_spec.rb
+++ b/spec/policies/comment_thread_policy_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe CommentThreadPolicy do
+  subject { described_class.new(user, comment_thread) }
+
+  let(:author)         { FactoryBot.create(:user) }
+  let(:project)        { FactoryBot.create(:project, :public, author: author) }
+  let(:comment_thread) { FactoryBot.create(:comment_thread, commentable: project) }
+
+  context "when the project is public" do
+    context "with an anonymous user" do
+      let(:user) { nil }
+
+      it { is_expected.to permit(:show) }
+      it { is_expected.not_to permit(:create_comment) }
+      it { is_expected.not_to permit(:subscribe) }
+      it { is_expected.not_to permit(:close) }
+    end
+
+    context "with a signed in user" do
+      let(:user) { FactoryBot.create(:user) }
+
+      it { is_expected.to permit(:show) }
+      it { is_expected.to permit(:create_comment) }
+      it { is_expected.to permit(:subscribe) }
+      it { is_expected.not_to permit(:close) }
+    end
+
+    context "with a site admin" do
+      let(:user) { FactoryBot.create(:user, admin: true) }
+
+      it { is_expected.to permit(:close) }
+      it { is_expected.to permit(:reopen) }
+    end
+  end
+
+  context "when the project is private" do
+    let(:project) { FactoryBot.create(:project, author: author) }
+
+    context "with an anonymous user" do
+      let(:user) { nil }
+
+      it { is_expected.not_to permit(:show) }
+    end
+
+    context "with an unrelated user" do
+      let(:user) { FactoryBot.create(:user) }
+
+      it { is_expected.not_to permit(:show) }
+      it { is_expected.not_to permit(:create_comment) }
+    end
+
+    context "with the project author" do
+      let(:user) { author }
+
+      it { is_expected.to permit(:show) }
+      it { is_expected.to permit(:create_comment) }
+    end
+  end
+
+  context "when the thread is closed" do
+    let(:user) { FactoryBot.create(:user) }
+
+    before { comment_thread.close!(FactoryBot.create(:user, admin: true)) }
+
+    it { is_expected.to permit(:show) }
+    it { is_expected.not_to permit(:create_comment) }
+  end
+end


### PR DESCRIPTION
Depends on #7831.

Second step of replacing the Commontator gem. Ports the comment and thread
permission rules into Pundit policies.

## What this adds

- `CommentThreadPolicy` — read, comment, subscribe, close/reopen
- `CommentPolicy` — show, create, update, destroy, restore, vote
- Policy specs (32 examples)

## Rules ported

| Rule | Behaviour |
|---|---|
| Read | Project is public, or the user has project view access |
| Moderator | Any site admin |
| Create | Signed in, thread open, and can read |
| Edit | Author only, thread open, not deleted, not edited by someone else |
| Delete | Author when thread is open, **or** any moderator even when closed |
| Undelete | Any moderator, or the author if they were the one who deleted it |
| Vote | Signed in, not the author, thread open, comment not deleted |

## Note on how these were derived

Rules were read from `commontator-7.0.1`'s `Comment` model rather than
inferred from the initializer. That surfaced three behaviours the config alone
does not describe:

1. In `can_be_deleted_by?`, the moderator branch returns **before** the
   closed-thread check, so moderators may delete inside a closed thread.
2. `can_be_edited_by?` also requires `editor.nil? || user == editor`.
3. `can_be_voted_on?` blocks voting on closed threads and deleted comments.

## What this does not do

Nothing calls these policies yet. The controllers still use Commontator, so
there is no behaviour change.

## Approach note

Neither policy calls `super`. `ApplicationPolicy#initialize` raises for nil
users, but comments on public projects must stay readable anonymously — the
existing API spec asserts this. `ProjectPolicy` skips `super` for the same
reason.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added project comment threads with replies and chronological discussions.
  * Added comment editing, soft deletion, restoration, and voting permissions.
  * Added thread subscription permissions.
  * Added moderator controls to close and reopen discussions.
  * Added visibility and access controls for public and private projects.
  * Added validation to prevent invalid reply relationships and comment cycles.
* **Tests**
  * Added coverage for comment behavior, thread lifecycle, validation, restoration, and access permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->