### PR TITLE
fix(groups): promote existing group members when adding mentors (#7822)

### DIFF
--- a/app/controllers/group_members_controller.rb
+++ b/app/controllers/group_members_controller.rb
@@ -37,20 +37,31 @@ class GroupMembersController < ApplicationController
     is_mentor = group_member_params[:mentor] == "true" if group_member_params[:mentor]
     group_member_emails = group_member_params[:emails].grep(Devise.email_regexp)
 
-    present_members = User.where(id: @group.group_members.pluck(:user_id)).pluck(:email)
-    newly_added = group_member_emails - present_members - [current_user&.email]
-    newly_added.each do |email|
-      email = email.strip
-      user = User.find_by(email: email)
-      if user.nil?
-        PendingInvitation.where(group_id: @group.id, email: email).first_or_create
-        # @group.pending_invitations.create(email:email)
-      else
-        GroupMember.where(group_id: @group.id, user_id: user.id, mentor: is_mentor).first_or_create
-
-        # group_member = @group.group_members.new
-        # group_member.user_id = user.id
-        # group_member.save
+    if is_mentor
+      already_mentors = User.where(id: @group.group_members.mentor.pluck(:user_id)).pluck(:email)
+      newly_added = group_member_emails - already_mentors - [@group.primary_mentor.email] - [current_user&.email]
+      newly_added.each do |email|
+        email = email.strip
+        user = User.find_by(email: email)
+        if user.nil?
+          PendingInvitation.where(group_id: @group.id, email: email).first_or_create
+        else
+          group_member = GroupMember.find_or_initialize_by(group_id: @group.id, user_id: user.id)
+          group_member.mentor = true
+          group_member.save
+        end
+      end
+    else
+      present_members = User.where(id: @group.group_members.pluck(:user_id)).pluck(:email)
+      newly_added = group_member_emails - present_members - [current_user&.email]
+      newly_added.each do |email|
+        email = email.strip
+        user = User.find_by(email: email)
+        if user.nil?
+          PendingInvitation.where(group_id: @group.id, email: email).first_or_create
+        else
+          GroupMember.where(group_id: @group.id, user_id: user.id, mentor: is_mentor).first_or_create
+        end
       end
     end
 

--- a/spec/controllers/group_members_controller_spec.rb
+++ b/spec/controllers/group_members_controller_spec.rb
@@ -32,6 +32,31 @@ describe GroupMembersController, type: :request do
                                           .and change(PendingInvitation, :count).by(1)
         expect(GroupMember.last.user).not_to eq(@primary_mentor)
       end
+
+      context "when adding mentors" do
+        let(:existing_member_user) { FactoryBot.create(:user) }
+        let!(:existing_member) do
+          FactoryBot.create(:group_member, user: existing_member_user, group: @group, mentor: false)
+        end
+        let(:mentor_params) do
+          {
+            group_member: {
+              group_id: @group.id,
+              mentor: "true",
+              emails: [existing_member_user.email, Faker::Internet.email]
+            }
+          }
+        end
+
+        it "promotes existing group member to mentor and creates pending invitations for new emails" do
+          expect do
+            post group_members_path, params: mentor_params
+          end.to change(PendingInvitation, :count).by(1)
+             .and not_change(GroupMember, :count)
+
+          expect(existing_member.reload.mentor).to be true
+        end
+      end
     end
 
     context "when a mentor is logged in" do


### PR DESCRIPTION
### Summary of Changes

Fixes #7822 where adding an existing group member as a mentor via "+ Add Mentors" was silently dropped because `present_members` included all group members and filtered them out of `newly_added`.

#### Changes made:
- **`app/controllers/group_members_controller.rb`**:
  - When `is_mentor` is `true`, only filter out users who are already mentors (`already_mentors`) and primary mentor.
  - For existing group members who are submitted via "+ Add Mentors", use `GroupMember.find_or_initialize_by(group_id: @group.id, user_id: user.id)` to promote them to `mentor: true` rather than attempting a duplicate create or ignoring them.
- **`spec/controllers/group_members_controller_spec.rb`**:
  - Added test case verifying promoting an existing group member to mentor via `create` with `mentor: "true"`.

### Related Issue

- Fixes #7822

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Group administrators can now add existing members as mentors.
  * Mentor invitations are sent only to eligible users who are not already mentors, the primary mentor, or the current user.
  * New mentor invitees receive pending invitations.

* **Bug Fixes**
  * Prevented duplicate memberships when promoting an existing group member to mentor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->