### PR TITLE
fix(organizations): Standardize email input lengths to 254 characters for groups and projects

### DIFF
--- a/app/javascript/controllers/groups_controller.js
+++ b/app/javascript/controllers/groups_controller.js
@@ -59,7 +59,7 @@ export default class extends Controller {
             multiple: true,
             tokenSeparators: [',', ' '],
         });
-        $('.select2-selection input').attr('maxlength', '30');
+        $('.select2-selection input').attr('maxlength', '254');
         $('.select2-selection input').attr('id', 'group_email_input_mentor');
         this.toggleButtonBasedOnEmails('#group_mentor_emails', '#add-mentor-button');
         $('.select2-selection input').attr('data-action', 'paste->groups#mentorInputPaste');
@@ -74,7 +74,7 @@ export default class extends Controller {
             multiple: true,
             tokenSeparators: [',', ' '],
         });
-        $('.select2-selection input').attr('maxlength', '30');
+        $('.select2-selection input').attr('maxlength', '254');
         $('.select2-selection input').attr('id', 'group_email_input');
         this.toggleButtonBasedOnEmails('#group_member_emails', '#add-members-button');
         $('#group_member_emails').on('select2:select select2:unselect', () => {

--- a/app/views/projects/_add_collaborator_modal.html.erb
+++ b/app/views/projects/_add_collaborator_modal.html.erb
@@ -42,7 +42,7 @@ $(document).ready(() => {
     tokenSeparators: [',', ' '],
   });
 
-  $('.select2-selection input').attr('maxlength', '30'); // to limit the no. of chars entered in input box to avoid the overflow
+  $('.select2-selection input').attr('maxlength', '254');
   $('.select2-selection input').attr('id', 'project_email_input_collaborator');
   $('.add-collaborators-button').attr('disabled', true); // setting submit button to disabled initially
 

--- a/spec/system/group_spec.rb
+++ b/spec/system/group_spec.rb
@@ -103,6 +103,22 @@ describe "Group management", type: :system do
     )
   end
 
+  it "allows typing up to 254 characters for a mentor email" do
+    visit "/groups/#{group.id}"
+    click_button "+ Add Mentors"
+    local_part = "a" * 64
+    domain = "#{"b" * 185}.com"
+    long_email = "#{local_part}@#{domain}"
+    expect(find("#group_email_input_mentor")[:maxlength]).to eq("254")
+    fill_in_input "#group_email_input_mentor", with: long_email
+    fill_in_input "#group_email_input_mentor", with: :enter
+    click_button "Add mentors"
+
+    expect(page).to have_text(
+      "Out of 1 Email(s), 1 was valid and 0 were invalid. 1 user(s) will be invited."
+    )
+  end
+
   it "removes mentor" do
     add_user_to_group_as_mentor
     visit "/groups/#{group.id}"

--- a/spec/system/group_spec.rb
+++ b/spec/system/group_spec.rb
@@ -46,6 +46,21 @@ describe "Group management", type: :system do
     )
   end
 
+  it "allows typing up to 254 characters for a member email" do
+    visit "/groups/#{group.id}"
+    click_button "+ Add Members"
+    domain = "@gmail.com"
+    long_email = "#{"a" * (254 - domain.length)}#{domain}"
+    expect(find("#group_email_input")[:maxlength]).to eq("254")
+    fill_in_input "#group_email_input", with: long_email
+    fill_in_input "#group_email_input", with: :enter
+    click_button "Add members"
+
+    expect(page).to have_text(
+      "Out of 1 Email(s), 1 was valid and 0 were invalid. 1 user(s) will be invited."
+    )
+  end
+
   it "removes a member from the group" do
     group.users.append(user)
     visit "/groups/#{group.id}"

--- a/spec/system/group_spec.rb
+++ b/spec/system/group_spec.rb
@@ -49,8 +49,9 @@ describe "Group management", type: :system do
   it "allows typing up to 254 characters for a member email" do
     visit "/groups/#{group.id}"
     click_button "+ Add Members"
-    domain = "@gmail.com"
-    long_email = "#{"a" * (254 - domain.length)}#{domain}"
+    local_part = "a" * 64
+    domain = "#{"b" * 185}.com"
+    long_email = "#{local_part}@#{domain}"
     expect(find("#group_email_input")[:maxlength]).to eq("254")
     fill_in_input "#group_email_input", with: long_email
     fill_in_input "#group_email_input", with: :enter

--- a/spec/system/project_spec.rb
+++ b/spec/system/project_spec.rb
@@ -151,6 +151,19 @@ describe "Project", type: :system do
       click_on "Add Collaborators"
       expect(page).to have_text("1 user(s) will be invited")
     end
+
+    it "allows 254-character email for collaborator input" do
+      domain = "@example.com"
+      long_email = "#{"a" * (254 - domain.length)}#{domain}"
+      visit user_project_path(private_project.author, private_project)
+      click_on "+ Add a Collaborator"
+      project_input_field_id = "#project_email_input_collaborator"
+      expect(find(project_input_field_id)[:maxlength]).to eq("254")
+      fill_in_input project_input_field_id, with: long_email
+      fill_in_input project_input_field_id, with: :enter
+      click_on "Add Collaborators"
+      expect(page).to have_text("1 user(s) will be invited")
+    end
   end
 
   def fill_in_input(editor, with:)

--- a/spec/system/project_spec.rb
+++ b/spec/system/project_spec.rb
@@ -153,8 +153,9 @@ describe "Project", type: :system do
     end
 
     it "allows 254-character email for collaborator input" do
-      domain = "@example.com"
-      long_email = "#{"a" * (254 - domain.length)}#{domain}"
+      local_part = "a" * 64
+      domain = "#{"b" * 185}.com"
+      long_email = "#{local_part}@#{domain}"
       visit user_project_path(private_project.author, private_project)
       click_on "+ Add a Collaborator"
       project_input_field_id = "#project_email_input_collaborator"


### PR DESCRIPTION
Fixes #7819


#### Describe the changes you have made in this PR -
Increased the character limit for the email input field from 30 to 254 characters when inviting mentors and members to a group. The previous limit of 30 was too restrictive for some university emails. 254 characters was chosen as it is the  maximum complete email address length under SMTP limits


## Code Understanding and AI Usage

**Did you use AI generated code (ChatGPT, Claude, Copilot, etc.) in any part of this PR?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**Explain your implementation approach:**
Increased hardcoded limit of email ID length from 30 to 254 to account for long email addresses. 

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the maximum permitted email address length in mentor and member group forms from 30 to 254 characters.
  * Increased the maximum permitted email address length when adding project collaborators to 254 characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->