### PR TITLE
fix(i18n): fix missing footer API link translation key (#7843)

### DIFF
--- a/app/component/footer_links_component.rb
+++ b/app/component/footer_links_component.rb
@@ -26,7 +26,7 @@ class FooterLinksComponent < ViewComponent::Base
       { url: "/contribute", text: "layout.footer.link_to_contribute" },
       { url: "/teachers", text: "layout.link_to_teachers" },
       { url: "/about", text: "layout.link_to_about" },
-      { url: "https://api.circuitverse.org", text: "API", target: "_blank" },
+      { url: "https://api.circuitverse.org", text: "layout.link_to_api", target: "_blank" },
       { url: "https://docs.circuitverse.org/chapter8/chapter8-cvfaq", text: "layout.link_to_faq" }
     ]
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,6 +37,7 @@ en:
   facebook: "Facebook"
   github: "Github"
   gitlab: "Gitlab"
+  API: "API"
   components:
     search_bar:
       placeholders:

--- a/config/locales/views/layouts/de.yml
+++ b/config/locales/views/layouts/de.yml
@@ -11,6 +11,7 @@ de:
     link_to_faq: "FAQ"
     link_to_contests: "Wettbewerbe"
     link_to_explore: "Erforschen"
+    link_to_api: "API"
     footer:
       social_icon_text: "Folgen Sie uns auf:"
       link_to_examples: "Beispiele"

--- a/config/locales/views/layouts/en.yml
+++ b/config/locales/views/layouts/en.yml
@@ -11,6 +11,7 @@ en:
     link_to_faq: "FAQ"
     link_to_contests: "Contests"
     link_to_explore: "Explore"
+    link_to_api: "API"
     footer:
       social_icon_text: "Follow us on:"
       link_to_examples: "Examples"

--- a/spec/components/footer_links_component_spec.rb
+++ b/spec/components/footer_links_component_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe FooterLinksComponent, type: :component do
 
     expect(page).to have_link(I18n.t("layout.link_to_simulator"), href: "/simulator")
     expect(page).to have_link(I18n.t("layout.link_to_learn_more"), href: "/learn")
+    expect(page).to have_link(I18n.t("layout.link_to_api"), href: "https://api.circuitverse.org")
     expect(page).to have_link(I18n.t("login"), href: "/users/sign_in")
     expect(page).not_to have_link(I18n.t("layout.footer.my_circuits"))
   end


### PR DESCRIPTION
Fixes #7843

#### Describe the changes you have made in this PR -
- Standardized the API footer link translation key in `FooterLinksComponent` (`app/component/footer_links_component.rb`) to `"layout.link_to_api"` to match the existing `layout.link_to_*` pattern used by other links (`link_to_docs`, `link_to_about`, etc.).
- Added `link_to_api: "API"` entry to `config/locales/views/layouts/en.yml` under `en.layout`.
- Added `API: "API"` entry to `config/locales/en.yml` as a fallback.
- Added RSpec unit test in `spec/components/footer_links_component_spec.rb` verifying the rendering of the API link.

### Screenshots of the UI changes (If any) -
*N/A (Fixes HTML source output where `<span class="translation_missing" title="translation missing: en.API">Api</span>` was being rendered).*

---

## Code Understanding and AI Usage

**Did you use AI generated code (ChatGPT, Claude, Copilot, etc.) in any part of this PR? **
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
- **Problem solved:** The API link in the footer rendered a `translation_missing` wrapper span because `FooterLinksComponent` passed raw string `"API"` to `t()`, but the key did not exist in locale files.
- **Alternative approaches considered:** Adding `API: "API"` to `config/locales/en.yml` alone. However, all other links in `FooterLinksComponent` (`link_to_docs`, `link_to_simulator`, `link_to_about`) use the `layout.link_to_*` prefix in `config/locales/views/layouts/en.yml`.
- **Why this implementation was chosen:** Standardizing to `layout.link_to_api` maintains consistency with the codebase's existing layout locale hierarchy, while adding top-level `API` key ensures safety.
- **Key components updated:**
  - `app/component/footer_links_component.rb`: Uses `layout.link_to_api` key.
  - `config/locales/views/layouts/en.yml`: Contains the `link_to_api: "API"` translation string.
  - `spec/components/footer_links_component_spec.rb`: Tests link rendering.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Internationalization**
  - The footer’s API link label now uses localized text.
  - Added English and German translations for the API link, preserving the displayed label as “API”.

- **Bug Fixes**
  - Updated footer link coverage to verify the API link label and destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->